### PR TITLE
docs: use personal contact email in governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,7 +46,7 @@ an individual is officially representing the community in public spaces.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project maintainer at **alex@weaviate.io**. All complaints will
+reported to the project maintainer at **alex.khoury.perso@gmail.com**. All complaints will
 be reviewed and investigated promptly and fairly. The maintainer is obligated to
 respect the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ SuperBrain is in active development. Security fixes are applied to the latest
 **Please do not open a public issue for security vulnerabilities.**
 
 Report privately via GitHub's [security advisories][advisories] ("Report a
-vulnerability") or by email to **alex@weaviate.io**. Include:
+vulnerability") or by email to **alex.khoury.perso@gmail.com**. Include:
 
 - a description of the issue and its impact,
 - steps to reproduce (or a proof of concept),


### PR DESCRIPTION
Use the maintainer's personal contact email in the public governance docs.

Replaces `alex@weaviate.io` → `alex.khoury.perso@gmail.com` in:

- `SECURITY.md` (vulnerability report address)
- `CODE_OF_CONDUCT.md` (conduct report address)

No other markdown files referenced the old address. Docs-only; no code or `dist/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
