### PR TITLE
ci: never cancel push-to-main runs (fixes false-red badge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel superseded PR runs; never cancel a push-to-main run, or the
+  # status badge would render the cancellation as a (false) failure.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes the CI status badge showing red while CI is actually passing.

**Cause:** `concurrency.cancel-in-progress: true` was keyed only on `github.ref`. Back-to-back pushes to `main` (e.g. several merges or a force-push in quick succession) cancelled each other's in-progress `main` runs. A **cancelled** run renders the workflow status badge red — the same as a failure — even though nothing failed.

**Fix:** scope cancellation to `pull_request` events only:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Superseded PR runs are still cancelled (desirable); every push-to-`main` run now always completes, so the badge always reflects a real pass/fail.

CI-config only; no source or `dist/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
