### PR TITLE
fix(packaging): add .claude-plugin/marketplace.json (fixes /plugin marketplace add)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "m3talux",
+  "description": "SuperBrain — automatic Claude Code to Obsidian second brain.",
+  "owner": {
+    "name": "m3talux"
+  },
+  "plugins": [
+    {
+      "name": "superbrain",
+      "version": "0.1.0",
+      "source": "./",
+      "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
+      "homepage": "https://github.com/m3talux/superbrain"
+    }
+  ]
+}

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,7 +1,0 @@
-{
-  "name": "superbrain",
-  "owner": "alex",
-  "plugins": [
-    { "name": "superbrain", "source": "./", "description": "Automatic Claude Code -> Obsidian second brain (capture spine)." }
-  ]
-}

--- a/tests/marketplaceManifest.test.ts
+++ b/tests/marketplaceManifest.test.ts
@@ -1,0 +1,31 @@
+import { it, expect } from "vitest";
+import fs from "node:fs";
+
+// Claude Code's `/plugin marketplace add <repo>` requires the marketplace
+// manifest at `.claude-plugin/marketplace.json` (NOT repo root). These tests
+// lock in the packaging contract so the install path can't silently break.
+
+it("marketplace.json exists at .claude-plugin/ and is valid JSON", () => {
+  expect(fs.existsSync(".claude-plugin/marketplace.json")).toBe(true);
+  const mk = JSON.parse(fs.readFileSync(".claude-plugin/marketplace.json", "utf8"));
+  expect(typeof mk.name).toBe("string");
+  expect(mk.name.length).toBeGreaterThan(0);
+  expect(typeof mk.owner?.name).toBe("string");
+  expect(Array.isArray(mk.plugins)).toBe(true);
+  expect(mk.plugins.length).toBeGreaterThan(0);
+});
+
+it("the superbrain plugin entry points at the repo root and tracks the version", () => {
+  const mk = JSON.parse(fs.readFileSync(".claude-plugin/marketplace.json", "utf8"));
+  const plg = JSON.parse(fs.readFileSync(".claude-plugin/plugin.json", "utf8"));
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const entry = mk.plugins.find((p: { name: string }) => p.name === "superbrain");
+  expect(entry).toBeDefined();
+  expect(entry.source).toBe("./"); // plugin manifest is at repo-root .claude-plugin/plugin.json
+  expect(entry.version).toBe(plg.version);
+  expect(entry.version).toBe(pkg.version);
+});
+
+it("no stale marketplace.json at the repo root (wrong location)", () => {
+  expect(fs.existsSync("marketplace.json")).toBe(false);
+});


### PR DESCRIPTION
Fixes `/plugin marketplace add m3talux/superbrain` failing with **"Marketplace file not found at …/.claude-plugin/marketplace.json"**.

## Root cause

Claude Code requires the marketplace manifest at **`.claude-plugin/marketplace.json`**. The repo only had an **untracked** `marketplace.json` at the **repo root** (wrong location, never committed — so the public repo had no marketplace manifest at all). A real Phase-4 packaging miss.

## Fix

- Add `.claude-plugin/marketplace.json` with the correct schema (mirrors the official `claude-plugins-official` / claude-mem examples): string `source: "./"` (repo root is the plugin, `.claude-plugin/plugin.json`), `version` tracks `plugin.json`/`package.json` at `0.1.0`, de-phased description.
- Remove the stale untracked root `marketplace.json`.
- Add `tests/marketplaceManifest.test.ts` (3 tests): manifest exists at the right path & is valid; plugin entry points at root and version is in lockstep; **no** stale root `marketplace.json` — locks in the contract so CI catches this class of regression.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm test` — 60 files / 136 tests green (+3 new)
- No `src`/`bin` change → `dist/` untouched

After merge: `/plugin marketplace add m3talux/superbrain` → `/plugin install superbrain` should work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
