### PR TITLE
fix(packaging): plugin.json author must be an object (fixes /plugin install)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,9 @@
   "name": "superbrain",
   "version": "0.1.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
-  "author": "Alex",
+  "author": {
+    "name": "m3talux"
+  },
   "license": "MIT",
   "hooks": "./hooks/hooks.json",
   "skills": ["./skills/superbrain-distill", "./skills/superbrain-recall"],

--- a/tests/manifestP4.test.ts
+++ b/tests/manifestP4.test.ts
@@ -8,6 +8,15 @@ it("plugin.json version matches package.json and references commands", () => {
   expect(plg.commands).toBe("./commands");
 });
 
+it("plugin.json author is an object with a name (Claude Code schema requires object, not string)", () => {
+  const plg = JSON.parse(fs.readFileSync(".claude-plugin/plugin.json", "utf8"));
+  expect(typeof plg.author).toBe("object");
+  expect(plg.author).not.toBeNull();
+  expect(Array.isArray(plg.author)).toBe(false);
+  expect(typeof plg.author.name).toBe("string");
+  expect(plg.author.name.length).toBeGreaterThan(0);
+});
+
 it("slash-command files invoke the sb.js CLI", () => {
   const adopt = fs.readFileSync("commands/adopt.md", "utf8");
   const migrate = fs.readFileSync("commands/migrate.md", "utf8");


### PR DESCRIPTION
Fixes `/plugin install superbrain` failing with:

> Validation errors: author: Invalid input: expected object, received string

## Root cause

`.claude-plugin/plugin.json` had `"author": "Alex"` (a string). Claude Code's plugin manifest schema requires `author` to be an **object** (`{ "name": "..." }`), as in every known-good plugin (claude-mem, ui-ux-pro-max, …).

## Fix

- `"author": { "name": "m3talux" }` — matches the proven schema exactly (minimal `{name}` form; no unverified extra keys).
- Regression test in `tests/manifestP4.test.ts` asserting `author` is a non-null, non-array object with a string `name` — so CI catches this schema class.

The validator reported *only* `author`; the other declared fields (`hooks`, `skills`, `mcpServers`, `commands`) are schema-valid.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm test` — 60 files / 137 tests green (+1)
- No `src`/`bin` change → `dist/` untouched

After merge: refresh the marketplace (`/plugin marketplace update m3talux`) then `/plugin install superbrain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
