### PR TITLE
fix(packaging): stop redeclaring auto-discovered paths in plugin.json (fixes duplicate-hooks)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,11 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
   "version": "0.1.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"
   },
-  "license": "MIT",
-  "hooks": "./hooks/hooks.json",
-  "skills": ["./skills/superbrain-distill", "./skills/superbrain-recall"],
-  "mcpServers": "./.mcp.json",
-  "commands": "./commands"
+  "repository": "https://github.com/m3talux/superbrain",
+  "license": "MIT"
 }

--- a/tests/manifestP4.test.ts
+++ b/tests/manifestP4.test.ts
@@ -1,11 +1,16 @@
 import { it, expect } from "vitest";
 import fs from "node:fs";
 
-it("plugin.json version matches package.json and references commands", () => {
+it("plugin.json version is in lockstep and does NOT redeclare auto-discovered paths", () => {
   const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
   const plg = JSON.parse(fs.readFileSync(".claude-plugin/plugin.json", "utf8"));
   expect(plg.version).toBe(pkg.version);
-  expect(plg.commands).toBe("./commands");
+  // Claude Code auto-discovers hooks/hooks.json, commands/, skills/ and .mcp.json
+  // by convention. Declaring them in plugin.json double-loads them — the hooks
+  // one is a fatal "Duplicate hooks file detected" at install. They must be absent.
+  for (const k of ["hooks", "commands", "skills", "mcpServers"]) {
+    expect(plg[k], `plugin.json must not declare "${k}" (auto-discovered by Claude Code)`).toBeUndefined();
+  }
 });
 
 it("plugin.json author is an object with a name (Claude Code schema requires object, not string)", () => {

--- a/tests/phase2Manifest.test.ts
+++ b/tests/phase2Manifest.test.ts
@@ -1,10 +1,12 @@
 import { it, expect } from "vitest";
 import fs from "node:fs";
 
-it("plugin manifest registers the recall skill + mcp; .mcp.json is valid; skill name matches dir", () => {
-  const p = JSON.parse(fs.readFileSync(".claude-plugin/plugin.json", "utf8"));
-  expect(p.skills).toContain("./skills/superbrain-recall");
-  expect(p.mcpServers || p.mcp).toBeTruthy();
+it("recall skill + mcp are packaged at conventional auto-discovered paths; .mcp.json is valid; skill name matches dir", () => {
+  // Claude Code auto-discovers skills/ and .mcp.json by convention — they must
+  // exist at the conventional paths and must NOT be redeclared in plugin.json
+  // (declaring auto-discovered paths double-loads them).
+  expect(fs.existsSync("skills/superbrain-recall/SKILL.md")).toBe(true);
+  expect(fs.existsSync(".mcp.json")).toBe(true);
   const m = JSON.parse(fs.readFileSync(".mcp.json", "utf8"));
   const srv = m.mcpServers.superbrain;
   expect(srv.command).toBe("node");


### PR DESCRIPTION
Fixes the post-install runtime error:

> Hook load failed: Duplicate hooks file detected: ./hooks/hooks.json … The standard hooks/hooks.json is loaded automatically, so manifest.hooks should only reference additional hook files.

## Root cause (the whole whack-a-mole)

`plugin.json` was **over-declaring auto-discovered paths**. Per the authoritative Claude Code plugin reference, `hooks/hooks.json`, `commands/`, `skills/`, and `.mcp.json` are **auto-discovered by convention**. Declaring them in `plugin.json` double-loads them — and the `hooks` duplicate is fatal at install. (claude-mem's working manifest declares none of these.)

## Fix

`plugin.json` stripped to the minimal valid manifest:

```json
{
  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
  "name": "superbrain",
  "version": "0.1.0",
  "description": "...",
  "author": { "name": "m3talux" },
  "repository": "https://github.com/m3talux/superbrain",
  "license": "MIT"
}
```

Removed `hooks`, `commands`, `skills`, `mcpServers` — all auto-discovered (the artifacts still exist at conventional paths, so functionality is unchanged; Claude Code loads them once).

## Test corrections (they had codified the bug)

- `tests/manifestP4.test.ts`: was asserting `plg.commands === "./commands"` — replaced with a guard that **fails if any of `hooks`/`commands`/`skills`/`mcpServers` is declared** (regression lock for this entire class) + version lockstep.
- `tests/phase2Manifest.test.ts`: was asserting `plg.skills`/`plg.mcpServers` — now asserts the real artifacts exist at the auto-discovered paths (`skills/superbrain-recall/SKILL.md`, valid `.mcp.json` → `sb-mcp.js`).

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm test` — 60 files / 137 tests green
- No `src`/`bin` change → `dist/` untouched

After merge: `/plugin marketplace update m3talux` → reinstall → `/reload-plugins`. This was the 4th and root packaging defect; the new test makes the whole class CI-caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
