### PR TITLE
fix(bootstrap): guarantee + verify better-sqlite3 native binding (no more silent empty vault)

### DIFF
--- a/bin/sb-bootstrap.ts
+++ b/bin/sb-bootstrap.ts
@@ -13,10 +13,21 @@ function main() {
       markBootstrapDone();
     } else {
       execFileSync("npm", ["ci", "--omit=dev"], { cwd: root, stdio: "ignore" });
+      // `npm ci` does NOT guarantee better-sqlite3's native addon: on a Node
+      // ABI with no published prebuild it leaves the package source-only.
+      // Force a source rebuild, then verify the binding actually loads under
+      // this Node runtime. Only mark done if it genuinely works — otherwise
+      // the sentinel fires and SessionStart retries next session.
+      execFileSync("npm", ["rebuild", "better-sqlite3"], { cwd: root, stdio: "ignore" });
+      execFileSync(
+        process.execPath,
+        ["-e", "require(require('node:path').join(process.cwd(),'node_modules','better-sqlite3'))"],
+        { cwd: root, stdio: "ignore" },
+      );
       markBootstrapDone();
     }
   } catch (e: any) {
-    writeFailure(`bootstrap (npm ci) failed: ${e?.message || e}`);
+    writeFailure(`bootstrap failed (npm ci / better-sqlite3 native build): ${e?.message || e}`);
   } finally {
     releaseLock("bootstrap");
   }

--- a/dist/bin/sb-bootstrap.js
+++ b/dist/bin/sb-bootstrap.js
@@ -18,11 +18,18 @@ function main() {
         }
         else {
             execFileSync("npm", ["ci", "--omit=dev"], { cwd: root, stdio: "ignore" });
+            // `npm ci` does NOT guarantee better-sqlite3's native addon: on a Node
+            // ABI with no published prebuild it leaves the package source-only.
+            // Force a source rebuild, then verify the binding actually loads under
+            // this Node runtime. Only mark done if it genuinely works — otherwise
+            // the sentinel fires and SessionStart retries next session.
+            execFileSync("npm", ["rebuild", "better-sqlite3"], { cwd: root, stdio: "ignore" });
+            execFileSync(process.execPath, ["-e", "require(require('node:path').join(process.cwd(),'node_modules','better-sqlite3'))"], { cwd: root, stdio: "ignore" });
             markBootstrapDone();
         }
     }
     catch (e) {
-        writeFailure(`bootstrap (npm ci) failed: ${e?.message || e}`);
+        writeFailure(`bootstrap failed (npm ci / better-sqlite3 native build): ${e?.message || e}`);
     }
     finally {
         releaseLock("bootstrap");

--- a/dist/src/bootstrap.js
+++ b/dist/src/bootstrap.js
@@ -3,9 +3,41 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dataDir } from "./paths.js";
+// Bounded search for a compiled native addon (*.node) within a directory.
+function hasDotNode(dir) {
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    }
+    catch {
+        return false;
+    }
+    for (const e of entries) {
+        const p = path.join(dir, e.name);
+        if (e.isDirectory()) {
+            if (hasDotNode(p))
+                return true;
+        }
+        else if (e.name.endsWith(".node"))
+            return true;
+    }
+    return false;
+}
+// Deps are "present" only when better-sqlite3's NATIVE BINDING actually exists
+// — not merely when the package directory does. A source-only install (no
+// build/Release/*.node, no prebuilds/) means the addon was never compiled
+// (e.g. a Node ABI with no published prebuild + a bootstrap that didn't
+// rebuild). Treating that as ready causes silent require() crashes downstream
+// and never surfaces to the sentinel. Stays builtin-only (no require of the
+// native module) so import-safe entrypoints can call it cheaply.
 export function depsPresent(pluginRoot) {
     try {
-        return fs.existsSync(path.join(pluginRoot, "node_modules", "better-sqlite3"));
+        const bs = path.join(pluginRoot, "node_modules", "better-sqlite3");
+        if (!fs.existsSync(bs))
+            return false;
+        return hasDotNode(path.join(bs, "build")) ||
+            hasDotNode(path.join(bs, "prebuilds")) ||
+            hasDotNode(path.join(bs, "lib", "binding"));
     }
     catch {
         return false;

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -4,9 +4,34 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dataDir } from "./paths.js";
 
-export function depsPresent(pluginRoot: string): boolean {
-  try { return fs.existsSync(path.join(pluginRoot, "node_modules", "better-sqlite3")); }
+// Bounded search for a compiled native addon (*.node) within a directory.
+function hasDotNode(dir: string): boolean {
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
   catch { return false; }
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) { if (hasDotNode(p)) return true; }
+    else if (e.name.endsWith(".node")) return true;
+  }
+  return false;
+}
+
+// Deps are "present" only when better-sqlite3's NATIVE BINDING actually exists
+// — not merely when the package directory does. A source-only install (no
+// build/Release/*.node, no prebuilds/) means the addon was never compiled
+// (e.g. a Node ABI with no published prebuild + a bootstrap that didn't
+// rebuild). Treating that as ready causes silent require() crashes downstream
+// and never surfaces to the sentinel. Stays builtin-only (no require of the
+// native module) so import-safe entrypoints can call it cheaply.
+export function depsPresent(pluginRoot: string): boolean {
+  try {
+    const bs = path.join(pluginRoot, "node_modules", "better-sqlite3");
+    if (!fs.existsSync(bs)) return false;
+    return hasDotNode(path.join(bs, "build")) ||
+           hasDotNode(path.join(bs, "prebuilds")) ||
+           hasDotNode(path.join(bs, "lib", "binding"));
+  } catch { return false; }
 }
 
 function doneFile(): string { return path.join(dataDir(), "bootstrap-done"); }

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -9,10 +9,16 @@ beforeEach(() => {
   process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-bs-data";
 });
 
-it("depsPresent is false without node_modules/better-sqlite3, true with it", () => {
+it("depsPresent is false without the better-sqlite3 native binding, true with it", () => {
   fs.mkdirSync("/tmp/sb-bs", { recursive: true });
   expect(depsPresent("/tmp/sb-bs")).toBe(false);
+  // package directory alone is NOT enough — a source-only install (no compiled
+  // .node) must read as not-ready, or entrypoints crash silently on require().
   fs.mkdirSync("/tmp/sb-bs/node_modules/better-sqlite3", { recursive: true });
+  expect(depsPresent("/tmp/sb-bs")).toBe(false);
+  // with the compiled native binding present → ready
+  fs.mkdirSync("/tmp/sb-bs/node_modules/better-sqlite3/build/Release", { recursive: true });
+  fs.writeFileSync("/tmp/sb-bs/node_modules/better-sqlite3/build/Release/better_sqlite3.node", "");
   expect(depsPresent("/tmp/sb-bs")).toBe(true);
 });
 

--- a/tests/depsBinding.test.ts
+++ b/tests/depsBinding.test.ts
@@ -1,0 +1,43 @@
+import { it, expect, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { depsPresent } from "../src/bootstrap.js";
+
+// Regression: depsPresent() must report deps ready ONLY when better-sqlite3's
+// native binding actually exists — not merely when the package directory exists.
+// A source-only install (no build/Release/*.node, no prebuilds/) means the
+// binding was never compiled (e.g. Node ABI with no prebuild + bootstrap that
+// didn't rebuild). Treating that as "ready" causes silent require() crashes.
+
+const ROOT = "/tmp/sb-deps-binding";
+const BS = path.join(ROOT, "node_modules", "better-sqlite3");
+
+beforeEach(() => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+});
+
+it("false when better-sqlite3 is absent entirely", () => {
+  fs.mkdirSync(ROOT, { recursive: true });
+  expect(depsPresent(ROOT)).toBe(false);
+});
+
+it("false when better-sqlite3 is present but the native binding was never built (source-only)", () => {
+  fs.mkdirSync(BS, { recursive: true });
+  fs.writeFileSync(path.join(BS, "package.json"), '{"name":"better-sqlite3"}');
+  // no build/Release/*.node, no prebuilds/ — this is the broken-install bug
+  expect(depsPresent(ROOT)).toBe(false);
+});
+
+it("true when the compiled binding exists at build/Release/better_sqlite3.node", () => {
+  const rel = path.join(BS, "build", "Release");
+  fs.mkdirSync(rel, { recursive: true });
+  fs.writeFileSync(path.join(rel, "better_sqlite3.node"), "");
+  expect(depsPresent(ROOT)).toBe(true);
+});
+
+it("true when a prebuilt binding is shipped under prebuilds/ (must not false-negative prebuild installs)", () => {
+  const pre = path.join(BS, "prebuilds", "darwin-arm64");
+  fs.mkdirSync(pre, { recursive: true });
+  fs.writeFileSync(path.join(pre, "better-sqlite3.node"), "");
+  expect(depsPresent(ROOT)).toBe(true);
+});


### PR DESCRIPTION
Fixes the runtime defect found while debugging "vault empty after install": the distiller/search/recall would crash on `require('better-sqlite3')` because its native binding was never built.

## Root cause

`npm ci --omit=dev` does **not** guarantee `better-sqlite3`'s native addon. On a Node ABI with no published prebuild (e.g. **Node 25 / ABI 141**) it leaves the package **source-only** (no `build/`, no `prebuilds/`). Then:

- `depsPresent()` only checked the package **directory** existed → returned a **false "ready"**.
- Import-safe entrypoints proceeded and crashed on `require('better-sqlite3')`.
- Nothing reached the sentinel → **silent** failure (capture log written, but vault never populated).

Verified empirically: a plain `npm rebuild better-sqlite3` builds & loads cleanly on Node v25.2.1; the toolchain was present — the bootstrap just never compiled it.

## Fix

- **`bin/sb-bootstrap.ts`**: after `npm ci --omit=dev`, run `npm rebuild better-sqlite3` (force source build), then **verify the binding actually `require()`s** under this Node runtime. `markBootstrapDone()` only on success; any failure → `writeFailure()` sentinel + retried next `SessionStart` (visible, not silent).
- **`src/bootstrap.ts depsPresent()`**: now requires a real compiled `.node` (under `build/`, `prebuilds/`, or `lib/binding/`), not just the package dir — **without** false-negativing prebuilt installs. Stays builtin-only (no native require) so import-safe entrypoints keep calling it cheaply.

## Tests (TDD)

- New `tests/depsBinding.test.ts`: absent → false; **source-only → false** (the bug); `build/Release/*.node` → true; `prebuilds/*.node` → true.
- Corrected `tests/bootstrap.test.ts` — it had codified the weak dir-only contract.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm test` — **61 files / 141 tests** green
- `src`/`bin` changed → `dist/` rebuilt & committed (delta = only `sb-bootstrap.js` + `bootstrap.js`)

This is the Phase-5 install-robustness gap surfacing through a real install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
