### PR TITLE
fix(cost): pin distill/rollup claude -p model (default Sonnet 4.6); SUPERBRAIN_MODEL override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ behavior may change without notice.
 
 ### Changed
 
+- The detached `claude -p` distill and rollup spawns now **pin the model**
+  (default `claude-sonnet-4-6`) instead of inheriting the user's session
+  model. Prevents the legacy-scribe failure mode where a user on Opus burned
+  the daily quota in hours. Override via the new `SUPERBRAIN_MODEL`
+  environment variable (e.g. `claude-haiku-4-5-20251001` for cheaper, or
+  `claude-opus-4-7` with `ANTHROPIC_API_KEY` for higher quality on the API
+  path).
 - `/superbrain:migrate` redesigned. The previous implementation archived a
   maintainer-specific legacy "scribe" setup — that was wrong for a public plugin
   (it only made sense on one machine). The new command is a **non-destructive

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ All optional — sensible defaults mean a clean install needs none.
 |---|---|---|
 | `SUPERBRAIN_VAULT` | `~/.superbrain/vault` | Where notes are written |
 | `CLAUDE_PLUGIN_DATA` | `~/.superbrain` | Runtime state (cursors, queue, rollup state) |
+| `SUPERBRAIN_MODEL` | `claude-sonnet-4-6` | Model used by the detached `claude -p` distill/rollup spawns. Pinned by default so the distiller never inherits your session's Opus and burns the daily quota; override to `claude-haiku-4-5-20251001` for cheaper-but-lower-quality, or `claude-opus-4-7` (best with `ANTHROPIC_API_KEY`) for higher quality. |
 | `ANTHROPIC_API_KEY` | *(unset)* | Optional escape hatch — distillation uses the API path instead of your subscription |
 
 > **Heads-up (2026-06-15):** background `claude -p` / Agent-SDK usage on subscription plans draws from a separate capped monthly credit after this date. If captures stop, SuperBrain surfaces a one-time notice on session start — set `ANTHROPIC_API_KEY` to switch to the API path.

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -124,3 +124,12 @@ When done, print:
 
 Be concise. Don't dump full note contents to the user. Ask questions only when the locate step
 genuinely requires user input. Default to action once the plan is confirmed.
+
+# Tip: model for large vaults
+
+This slash command runs **in your active session**, at whatever Claude model you've selected —
+not on a pinned model. For a vault with hundreds of notes, categorization quality matters but
+Opus is expensive. Before invoking on a big vault, consider switching your session to Sonnet
+(`/model claude-sonnet-4-6`) — similar judgment quality at ~1/5 the cost. Switch back after.
+(The plugin's own detached distill/rollup spawns are already pinned to Sonnet by default; see
+`SUPERBRAIN_MODEL` in the README.)

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -1,6 +1,21 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+// Pin the model on every detached `claude -p` distill/rollup spawn so it never
+// inherits the user's session model (which is often Opus, and burns daily
+// quota in hours — exactly the legacy-scribe bug we replaced). Default Sonnet
+// 4.6 balances quality (the distiller IS the product — the vault is only as
+// good as the routed notes it writes) against cost (~1/5 of Opus). Override
+// via SUPERBRAIN_MODEL for power users (e.g. claude-haiku-4-5-20251001 for
+// cheaper-but-lower-quality, or claude-opus-4-7 with ANTHROPIC_API_KEY set to
+// bypass subscription limits).
+export function distillModel() {
+    const v = process.env.SUPERBRAIN_MODEL;
+    return (v && v.trim()) ? v.trim() : "claude-sonnet-4-6";
+}
+function callClaude(prompt) {
+    return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
+}
 import { readDelta } from "./ndjson.js";
 import { readCursor, writeCursor } from "./cursor.js";
 import { route } from "./router.js";
@@ -50,7 +65,7 @@ function getEnvelope(deltaJson) {
     }
     catch { /* none yet */ }
     const fullPrompt = prompt + "\n\nCurrent preferences (reconcile, do not lose existing rules):\n" + (curPrefs || "(none)");
-    const out = execFileSync("claude", ["-p", fullPrompt], { encoding: "utf8" });
+    const out = callClaude(fullPrompt);
     return parseEnvelope(out);
 }
 function appendLog(title, rel) {
@@ -66,7 +81,7 @@ function getRollupItems(logContent, key) {
     const prompt = `You are SuperBrain's daily rollup synthesizer. Given this activity log for ${key}, ` +
         'output ONLY a JSON object {"items":[{"kind":"capture","title":"Daily ' + key + '",' +
         `"body":"<synthesis>","date":"${key}","links":[]}]}. Activity log:\n` + logContent;
-    const out = execFileSync("claude", ["-p", prompt], { encoding: "utf8" });
+    const out = callClaude(prompt);
     return parseEnvelope(out).items;
 }
 export async function runRollup(rollupEnv) {

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -1,6 +1,23 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+
+// Pin the model on every detached `claude -p` distill/rollup spawn so it never
+// inherits the user's session model (which is often Opus, and burns daily
+// quota in hours — exactly the legacy-scribe bug we replaced). Default Sonnet
+// 4.6 balances quality (the distiller IS the product — the vault is only as
+// good as the routed notes it writes) against cost (~1/5 of Opus). Override
+// via SUPERBRAIN_MODEL for power users (e.g. claude-haiku-4-5-20251001 for
+// cheaper-but-lower-quality, or claude-opus-4-7 with ANTHROPIC_API_KEY set to
+// bypass subscription limits).
+export function distillModel(): string {
+  const v = process.env.SUPERBRAIN_MODEL;
+  return (v && v.trim()) ? v.trim() : "claude-sonnet-4-6";
+}
+function callClaude(prompt: string): string {
+  return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
+}
+
 import { readDelta } from "./ndjson.js";
 import { readCursor, writeCursor } from "./cursor.js";
 import { route, type DistilledItem } from "./router.js";
@@ -52,7 +69,7 @@ function getEnvelope(deltaJson: string): DistilledEnvelope {
   let curPrefs = "";
   try { curPrefs = fs.readFileSync(preferencesPath(), "utf8"); } catch { /* none yet */ }
   const fullPrompt = prompt + "\n\nCurrent preferences (reconcile, do not lose existing rules):\n" + (curPrefs || "(none)");
-  const out = execFileSync("claude", ["-p", fullPrompt], { encoding: "utf8" });
+  const out = callClaude(fullPrompt);
   return parseEnvelope(out);
 }
 
@@ -70,7 +87,7 @@ function getRollupItems(logContent: string, key: string): DistilledItem[] {
     `You are SuperBrain's daily rollup synthesizer. Given this activity log for ${key}, ` +
     'output ONLY a JSON object {"items":[{"kind":"capture","title":"Daily ' + key + '",' +
     `"body":"<synthesis>","date":"${key}","links":[]}]}. Activity log:\n` + logContent;
-  const out = execFileSync("claude", ["-p", prompt], { encoding: "utf8" });
+  const out = callClaude(prompt);
   return parseEnvelope(out).items;
 }
 

--- a/tests/distillModel.test.ts
+++ b/tests/distillModel.test.ts
@@ -1,0 +1,38 @@
+import { it, expect } from "vitest";
+import fs from "node:fs";
+import { distillModel } from "../src/distillRun.js";
+
+// Cost-control invariant: the detached distill/rollup `claude -p` spawns must
+// NEVER inherit the user's session model (often Opus, which burned the legacy
+// scribe's daily quota in hours). The model is pinned via `--model` on every
+// call site, honoring SUPERBRAIN_MODEL with a Sonnet default.
+
+it("defaults to claude-sonnet-4-6 and honors SUPERBRAIN_MODEL override (trims, ignores empty)", () => {
+  const prev = process.env.SUPERBRAIN_MODEL;
+  try {
+    delete process.env.SUPERBRAIN_MODEL;
+    expect(distillModel()).toBe("claude-sonnet-4-6");
+    process.env.SUPERBRAIN_MODEL = "claude-haiku-4-5-20251001";
+    expect(distillModel()).toBe("claude-haiku-4-5-20251001");
+    process.env.SUPERBRAIN_MODEL = "  claude-opus-4-7  ";
+    expect(distillModel()).toBe("claude-opus-4-7");
+    process.env.SUPERBRAIN_MODEL = "";
+    expect(distillModel()).toBe("claude-sonnet-4-6");
+    process.env.SUPERBRAIN_MODEL = "   ";
+    expect(distillModel()).toBe("claude-sonnet-4-6");
+  } finally {
+    if (prev === undefined) delete process.env.SUPERBRAIN_MODEL;
+    else process.env.SUPERBRAIN_MODEL = prev;
+  }
+});
+
+it("every `claude -p` invocation in src/distillRun.ts passes --model", () => {
+  const src = fs.readFileSync("src/distillRun.ts", "utf8");
+  // All claude-CLI invocations in the distill path must include the --model
+  // pin. Both the direct `execFileSync("claude", ...)` and our helper.
+  const calls = src.match(/execFileSync\("claude"[\s\S]*?\)/g) || [];
+  expect(calls.length).toBeGreaterThan(0);
+  for (const c of calls) {
+    expect(c, "missing --model pin: " + c).toMatch(/--model/);
+  }
+});


### PR DESCRIPTION
## Why

The detached `claude -p` distill and rollup spawns invoked `claude` **without** a `--model` flag, so they inherited the user's session model. For a user with their default set to **Opus 4.7**, that burned the daily quota in hours — exactly the legacy-scribe failure mode this plugin was meant to replace.

## What

Pin the model on every `claude -p` site in `src/distillRun.ts` via a single helper:

```ts
export function distillModel(): string {
  const v = process.env.SUPERBRAIN_MODEL;
  return (v && v.trim()) ? v.trim() : "claude-sonnet-4-6";
}
function callClaude(prompt: string): string {
  return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
}
```

Both checkpoint distill (`getEnvelope`) and rollup (`getRollupItems`) now go through `callClaude()`.

### Why Sonnet, not Haiku

Considered Haiku — rejected on quality grounds. The distiller **is** the product: classification (decision vs. capture vs. project fact), salience judgment, faithful summarization of hours-long session logs. Haiku 4.5 saves ~3-5× cost but degrades note quality enough that the vault loses value. Sonnet 4.6 is **1/5 the cost of Opus** with quality close enough to Opus that the user's complaint (daily quota in hours) is decisively fixed without sacrificing the product. Plus prompt-caching on the stable distill prompt makes effective Sonnet cost much lower than first-token pricing.

`SUPERBRAIN_MODEL` lets power users opt either way:
- `claude-haiku-4-5-20251001` — cheaper, accept lower note quality.
- `claude-opus-4-7` (best with `ANTHROPIC_API_KEY` to use the API path) — highest quality, bypass subscription limits.

### Migrate is intentionally NOT model-pinned

`/superbrain:migrate` runs **in the user's active session** (it's an LLM-driven slash command, not a `claude -p` spawn) — we don't control its model. Added a `# Tip` to `commands/migrate.md` recommending `/model claude-sonnet-4-6` before invoking on a big vault; this respects the user's session-model choice rather than overriding it.

## Tests

`tests/distillModel.test.ts`:

1. `distillModel()` defaults to `claude-sonnet-4-6`, honors `SUPERBRAIN_MODEL`, trims whitespace, falls back on empty/whitespace-only values.
2. Lint: every `execFileSync("claude", ...)` site in `src/distillRun.ts` passes `--model` — a future regression that drops the pin will fail CI.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm test` — **62 files / 148 tests** green
- `src` changed → `dist/src/distillRun.js` rebuilt (only that file)

## Updated

- `README.md`: new `SUPERBRAIN_MODEL` row in the Configuration table.
- `CHANGELOG.md`: `[Unreleased]` entry under Changed.
- `commands/migrate.md`: model-tip section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
