### PR TITLE
feat: unify vault path, raise note quality, split daily write logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ This isn't vibes: ~23 prior-art projects and the current Claude Code platform we
 ```
 
 That's it. On the **first session** the plugin runs a one-time setup (installs its
-search dependencies in the background) and tells you it's doing so; capture is fully
-active from the next session. By default SuperBrain writes to its own vault at
-`~/.superbrain/vault`. To use an existing Obsidian vault instead, run
-`/superbrain:adopt /path/to/your/vault` (or set `SUPERBRAIN_VAULT`). Optional:
-`/superbrain:migrate` folds an existing Obsidian vault into SuperBrain's structure — **non-destructive** (only reads the source, copies into the SuperBrain vault); pass a path or let Claude auto-detect it; `--dry-run` to preview.
+search dependencies in the background) and tells you it's doing so; capture is
+fully active from the next session. SuperBrain writes to its own vault at
+`~/.superbrain/vault` — a fixed, predictable location with no environment
+variables to set. Point Obsidian at that folder and you're done.
+
+If you already have an Obsidian vault you want to bring along, see
+[Vault setup](#vault-setup) below — `/superbrain:migrate` is the preferred path.
 
 Installed at **user scope**, the plugin's hooks register for *every* project automatically — there is nothing else to do, ever.
 
@@ -53,10 +55,12 @@ flowchart LR
   B --> C{Checkpoint?<br/>PreCompact / SessionEnd /<br/>Stop if pending}
   C -->|detached, lock-serialized| D[sb-distill<br/>claude -p]
   D --> E[Router]
-  E --> F[(Obsidian vault<br/>notes • log.md)]
+  E --> F[(Obsidian vault<br/>notes only)]
+  E --> L[(~/.superbrain/logs/<br/>per-day .log files)]
   C -.->|byte cursor| B
   G[SessionStart] -->|idempotent catch-up| H[Daily / weekly / monthly rollup]
   H --> F
+  L --> H
 ```
 
 1. **Observe** — `PostToolUse` / `UserPromptSubmit` hooks append a compact event line to a per-session NDJSON log. **No LLM** on this path, so it can never rate-limit, stall, or disrupt your turn.
@@ -74,7 +78,7 @@ flowchart LR
 - ✅ Smart router: decisions / project facts / people / gotchas / triage capture
 - ✅ Self-healing daily/weekly/monthly rollup catch-up — no cron, no daemon
 - ✅ Append-or-create, **never** blind-overwrites a note you edited in Obsidian; soft-delete to `.trash/`
-- ✅ Idempotent & resumable (byte cursor + `log.md`); silent failures surface once on next session
+- ✅ Idempotent & resumable (byte cursor + per-day `~/.superbrain/logs/<date>.log` files); silent failures surface once on next session
 - ✅ One-command migration off a legacy custom scribe (archives, never deletes)
 
 **Search & recall**
@@ -107,22 +111,56 @@ flowchart LR
 ├── capture/       raw inbound, triaged by rollups
 ├── meta/          preferences.md — deduplicated profile auto-injected at SessionStart
 ├── maps/          auto-generated Maps-of-Content   (planned)
-├── index.md       catalog — the primary navigation surface
-└── log.md         append-only, grep-parseable timeline
+└── index.md       catalog — the primary navigation surface
+```
+
+System telemetry (NOT in the vault — lives next to it in `~/.superbrain/`):
+
+```
+~/.superbrain/
+├── logs/<date>.log    per-day append-only write log; powers the daily rollup
+├── sessions/          per-session NDJSON event streams + cursors
+├── transcripts/       full session transcripts (when captured)
+├── index.db           hybrid search index (FTS5 + sqlite-vec)
+└── rollup-state.json  hash-gated rollup convergence state
 ```
 
 Generated files are namespaced so the rollup regenerator never touches notes you authored.
 
+## Vault setup
+
+SuperBrain's vault lives at `~/.superbrain/vault` — fixed, predictable, no env vars. Two ways to bring an existing Obsidian vault into the picture:
+
+### Migrate (preferred)
+
+```text
+/superbrain:migrate                  # auto-detects your vault
+/superbrain:migrate ~/Documents/MyVault   # explicit path
+/superbrain:migrate --dry-run        # preview without writing
+```
+
+`/superbrain:migrate` reads your existing Obsidian vault (the source is **never modified**) and copies its content into `~/.superbrain/vault`, fitting it into SuperBrain's structure (`projects/`, `decisions/`, `people/`, `daily/`, etc.). From then on, SuperBrain owns and extends a vault it fully understands — its router, rollups, and index all behave predictably. **This is the recommended path** for almost every user.
+
+### Adopt (advanced — only when migration isn't an option)
+
+```text
+/superbrain:adopt ~/Documents/MyEstablishedVault
+```
+
+`/superbrain:adopt` does **not** copy anything; it records your existing path as the vault location and starts writing into it directly. Use this only when you have a heavily established Obsidian setup whose structure you do not want to change — broken into folders, plugins, layouts, or conventions SuperBrain isn't designed around.
+
+The trade-off: SuperBrain will work *on top of* whatever's already there rather than *alongside* a structure it owns. The router may write into folders that don't match your existing convention; rollups will live alongside your hand-authored notes; the search-index reconciler will still self-heal but has more drift to manage. Migration sidesteps all of that.
+
+When in doubt: **migrate, don't adopt.**
+
 ## Configuration
 
-All optional — sensible defaults mean a clean install needs none.
+SuperBrain is configured by command, not by environment. There are no
+required env vars. The single optional one:
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `SUPERBRAIN_VAULT` | `~/.superbrain/vault` | Where notes are written |
-| `CLAUDE_PLUGIN_DATA` | `~/.superbrain` | Runtime state (cursors, queue, rollup state) |
-| `SUPERBRAIN_MODEL` | `claude-sonnet-4-6` | Model used by the detached `claude -p` distill/rollup spawns. Pinned by default so the distiller never inherits your session's Opus and burns the daily quota; override to `claude-haiku-4-5-20251001` for cheaper-but-lower-quality, or `claude-opus-4-7` (best with `ANTHROPIC_API_KEY`) for higher quality. |
-| `ANTHROPIC_API_KEY` | *(unset)* | Optional escape hatch — distillation uses the API path instead of your subscription |
+| Variable | Purpose |
+|---|---|
+| `ANTHROPIC_API_KEY` | Optional escape hatch — distillation uses the Anthropic API instead of your Claude Code subscription. Useful if you want the distill/rollup spawns to bypass subscription quota. |
 
 > **Heads-up (2026-06-15):** background `claude -p` / Agent-SDK usage on subscription plans draws from a separate capped monthly credit after this date. If captures stop, SuperBrain surfaces a one-time notice on session start — set `ANTHROPIC_API_KEY` to switch to the API path.
 
@@ -160,7 +198,7 @@ of the following on top with no special configuration:
 
 Whichever you choose, treat it as **backup / sync owned by you**, not by the
 plugin. Running the same vault from two machines concurrently can still produce
-git conflicts in regenerated files (`index.md`, `log.md`, rollups) — Obsidian
+git conflicts in regenerated files (`index.md`, rollups) — Obsidian
 Git's conflict UX or a single-writer-at-a-time habit avoids that. SuperBrain's
 job is to stay idempotent and drift-tolerant so any of these Just Work; it is
 not to own your remote.

--- a/bin/sb-session-start.ts
+++ b/bin/sb-session-start.ts
@@ -58,12 +58,12 @@ async function main() {
       const { appendDigest } = await import("../src/sessionDigest.js"); // deferred heavy import
       await appendDigest(parts, h);
     }
-    // One-time courtesy notice when using the owned default vault (no explicit/adopted vault).
+    // One-time courtesy notice when using the owned default vault (no adopted vault).
     try {
-      if (!process.env.SUPERBRAIN_VAULT && !recordedVaultPath()) {
+      if (!recordedVaultPath()) {
         const flag = path.join(dataDir(), "owned-vault-notice");
         if (!fs.existsSync(flag)) {
-          parts.push("SuperBrain is capturing into its own vault. To use an existing Obsidian vault instead, run `/superbrain:adopt <path>` or set SUPERBRAIN_VAULT.");
+          parts.push("SuperBrain is capturing into ~/.superbrain/vault. To pull an existing Obsidian vault into that location, run `/superbrain:migrate` (preferred). To point SuperBrain at an already-established Obsidian vault instead, run `/superbrain:adopt <path>`.");
           fs.mkdirSync(path.dirname(flag), { recursive: true }); fs.writeFileSync(flag, "1");
         }
       }

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -41,10 +41,11 @@ Determine the source vault path in this priority order:
 
 The destination vault is **SuperBrain's own vault**: resolve it by running
 `node "${CLAUDE_PLUGIN_ROOT}/dist/bin/sb.js" install` once (idempotent — creates `dataDir`),
-then use the SuperBrain vault location, which is `$SUPERBRAIN_VAULT` if set, else the recorded
-adopted path (`<dataDir>/vault-path` contents) if present, else `<dataDir>/vault` (default
-`~/.superbrain/vault`). The `.superbrain` ownership marker must exist or be created there
-(it will be, by `vaultPath()` on the next plugin run; you do not need to write it).
+then use the SuperBrain vault location, which is the recorded adopted path
+(`<dataDir>/vault-path` contents) if present, else `<dataDir>/vault` (always
+`~/.superbrain/vault`). The `.superbrain` ownership marker must exist or be
+created there (it will be, by `vaultPath()` on the next plugin run; you do not
+need to write it).
 
 # Step 2 — Enumerate source notes
 
@@ -131,5 +132,5 @@ This slash command runs **in your active session**, at whatever Claude model you
 not on a pinned model. For a vault with hundreds of notes, categorization quality matters but
 Opus is expensive. Before invoking on a big vault, consider switching your session to Sonnet
 (`/model claude-sonnet-4-6`) — similar judgment quality at ~1/5 the cost. Switch back after.
-(The plugin's own detached distill/rollup spawns are already pinned to Sonnet by default; see
-`SUPERBRAIN_MODEL` in the README.)
+(The plugin's own detached distill/rollup spawns are hardcoded to Sonnet 4.6;
+this concern only applies to the in-session migrate command.)

--- a/dist/bin/sb-session-start.js
+++ b/dist/bin/sb-session-start.js
@@ -70,12 +70,12 @@ async function main() {
             const { appendDigest } = await import("../src/sessionDigest.js"); // deferred heavy import
             await appendDigest(parts, h);
         }
-        // One-time courtesy notice when using the owned default vault (no explicit/adopted vault).
+        // One-time courtesy notice when using the owned default vault (no adopted vault).
         try {
-            if (!process.env.SUPERBRAIN_VAULT && !recordedVaultPath()) {
+            if (!recordedVaultPath()) {
                 const flag = path.join(dataDir(), "owned-vault-notice");
                 if (!fs.existsSync(flag)) {
-                    parts.push("SuperBrain is capturing into its own vault. To use an existing Obsidian vault instead, run `/superbrain:adopt <path>` or set SUPERBRAIN_VAULT.");
+                    parts.push("SuperBrain is capturing into ~/.superbrain/vault. To pull an existing Obsidian vault into that location, run `/superbrain:migrate` (preferred). To point SuperBrain at an already-established Obsidian vault instead, run `/superbrain:adopt <path>`.");
                     fs.mkdirSync(path.dirname(flag), { recursive: true });
                     fs.writeFileSync(flag, "1");
                 }

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -3,15 +3,12 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 // Pin the model on every detached `claude -p` distill/rollup spawn so it never
 // inherits the user's session model (which is often Opus, and burns daily
-// quota in hours — exactly the legacy-scribe bug we replaced). Default Sonnet
-// 4.6 balances quality (the distiller IS the product — the vault is only as
-// good as the routed notes it writes) against cost (~1/5 of Opus). Override
-// via SUPERBRAIN_MODEL for power users (e.g. claude-haiku-4-5-20251001 for
-// cheaper-but-lower-quality, or claude-opus-4-7 with ANTHROPIC_API_KEY set to
-// bypass subscription limits).
+// quota in hours — exactly the legacy-scribe bug we replaced). Sonnet 4.6
+// balances quality (the distiller IS the product — the vault is only as good
+// as the routed notes it writes) against cost (~1/5 of Opus). No env override:
+// users should not need to think about model selection.
 export function distillModel() {
-    const v = process.env.SUPERBRAIN_MODEL;
-    return (v && v.trim()) ? v.trim() : "claude-sonnet-4-6";
+    return "claude-sonnet-4-6";
 }
 function callClaude(prompt) {
     return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
@@ -22,7 +19,7 @@ import { route } from "./router.js";
 import { writeNote } from "./vaultWriter.js";
 import { releaseLock } from "./lockfile.js";
 import { writeFailure } from "./sentinel.js";
-import { vaultPath } from "./paths.js";
+import { logFilePath } from "./paths.js";
 import { markRollup } from "./rollupState.js";
 import { indexNote } from "./indexer.js";
 import { upsertDay } from "./dailyState.js";
@@ -46,33 +43,94 @@ export function parseEnvelope(raw) {
         alsoDid: Array.isArray(v.alsoDid) ? v.alsoDid : [],
     };
 }
+// The session-distillation prompt. Long and opinionated on purpose: prompt
+// quality is the whole game. Structure: persona → hard rules → per-kind
+// emission criteria → per-kind required fields → few-shot examples →
+// preferences reconciliation contract → output schema → events.
+const DISTILL_PROMPT_PREFIX = `You are SuperBrain's distiller. You receive a JSON array of session events (tool calls, prompts) plus 'pushback' markers, and you turn the substantive moments into durable second-brain notes. Many sessions contain NO substantive moments — that is the desired output, not a failure.
+
+# Hard rules — never violate
+
+1. If the events array is empty OR contains no substantive activity (skim-only sessions, observer-watches-observer meta-sessions, sessions that only read existing notes), output {"items":[]} immediately and stop.
+2. Distiller behavior rules (this prompt) are NOT user preferences. NEVER write them into a preference item.
+3. Skip transcript dumps and anything trivially derivable from git or the code itself (file paths, function names, commit messages alone are not knowledge).
+4. Output ONLY the JSON envelope. No prose, no backticks, no explanation.
+
+# Quality bar — wait for signal before emitting
+
+Each kind has a concrete threshold. If a session does not meet the threshold for any kind, do not invent items. Empty output is correct.
+
+- decision — emit only when the session contains an EXPLICIT deliberation (multiple options weighed and a trade-off chosen) OR a documented multi-step plan with stated reasoning. A one-line conclusion is not a decision.
+- gotcha — emit only when a bug was REPRODUCED AND DIAGNOSED AND has a stated fix or workaround. Speculation, suspicion, or 'this might be the issue' is not a gotcha.
+- lesson — emit only when user pushback produces a GENERALIZABLE RULE that should change future behavior. A one-off correction ('not that file, the other one') is not a lesson.
+- project_fact — emit only for DURABLE architectural, scope, or ownership statements. 'PR in review' is not a project fact. 'We've decided this service will be the only writer for X' is.
+- preference — emit only when the user EXPLICITLY states a coding / tooling / communication preference, OR sustained pushback reveals one. Preferences describe how the USER wants Claude to behave (code style, architecture, tool choice, comment density, etc.). NEVER describe SuperBrain's own distiller behavior here.
+- person — emit only when a durable role / context / thread about a specific person is established.
+- capture — only for substantive items that don't fit above but are clearly worth keeping. Not a dumping ground.
+
+# Required fields per kind — write rich, structured notes
+
+When you DO emit, fill the structured fields below. Substance over brevity: a real decision note is paragraphs, not a sentence.
+
+decision: { kind, title (imperative, ≤80 chars), date, context (1–2 paragraphs: what was happening, what choice arose), decision (1–2 sentences: what was chosen), rationale (1–2 paragraphs: why this over alternatives), consequences (1 paragraph: trade-offs, what this enables or precludes), implementation? (concrete next steps or changes made), project? (slug if scoped), links (related-note slugs) }
+
+gotcha: { kind, title (short symptom name), date, project (slug — required), symptom (the observable failure), rootCause (technical explanation), fix (what resolves it, with file refs if possible), prevention (how to avoid hitting it again), links }
+
+lesson: { kind, title (short imperative rule name), date, rule (the durable, generalizable principle, one crisp sentence), why (the reasoning + the incident that produced it, 1–2 paragraphs), whenApplies (when to invoke this rule in the future), links }
+
+project_fact: { kind, title (short fact statement), date, project (slug — required), body (one sentence of context + the fact itself; ≤3 sentences), links }
+
+person: { kind, title (short), date, person (slug — required), body (role/context/threads), links }
+
+preference: { kind, title: "Preferences", date, body (the FULL reconciled user-preferences doc — plain markdown, organized by '## Category' headings such as Code style / Architecture / Tools / Communication, NEVER containing SuperBrain distiller behavior) }
+
+capture: { kind, title, date, body, links }
+
+# Preferences reconciliation
+
+You are given the current preferences doc at the end of this prompt. When a lesson's rule qualifies as a user-style/tool/communication preference (NOT a SuperBrain behavior rule), ALSO emit exactly one preference item whose body is the FULL reconciled doc — integrate the new rule, dedupe, resolve contradictions newest-wins, keep '## Category' headings. Never emit more than one preference item per envelope. If the lesson is a SuperBrain behavior rule, do not emit a preference at all.
+
+# Few-shot — what a substantive decision and lesson look like
+
+EXAMPLE decision (structured fields filled, paragraphs, links):
+{"kind":"decision","title":"Pin distiller model to Sonnet 4.6","date":"2026-05-19","context":"The legacy scribe ran detached \`claude -p\` spawns at the user's session model, often Opus. Distillation runs many times per day and burned the user's daily Opus quota in hours, surfacing as silent capture failures mid-day.","decision":"Hardcode the distiller and rollup spawns to use --model claude-sonnet-4-6 unconditionally; no env override.","rationale":"Sonnet 4.6 produces judgment of comparable quality to Opus for summarization at roughly 1/5 the cost. Removing the env override prevents users from accidentally re-introducing the quota burn — the surface area was a footgun, not a feature.","consequences":"Users who want higher quality must set ANTHROPIC_API_KEY to bypass subscription quota. No model selection is exposed beyond that escape hatch.","implementation":"src/distillRun.ts:distillModel() returns the literal 'claude-sonnet-4-6'. tests/distillModel.test.ts locks the no-env behavior in.","links":["projects/superbrain"]}
+
+EXAMPLE lesson (structured fields, traced to an incident, with whenApplies):
+{"kind":"lesson","title":"Verify the live data dir before claiming a plugin is broken","date":"2026-05-20","rule":"For Claude Code plugins, resolve the actual CLAUDE_PLUGIN_DATA path at hook execution time before inspecting on-disk state — never trust the fallback path in the source code.","why":"On 2026-05-20 a full multi-step misdiagnosis was produced (broken matchers, async hook failure, missing distillation) because the investigator inspected the source's fallback ~/.superbrain/ instead of the actual ~/.claude/plugins/data/superbrain-m3talux/ where Claude Code routes hook writes. Everything was healthy at the real path.","whenApplies":"Any time a Claude Code plugin appears to not be writing data, before declaring it broken.","links":["projects/superbrain"]}
+
+# Output schema
+
+{"items": [ <items as above> ], "digest"?: "<=1 sentence of the session's arc", "openThreads"?: ["unfinished/deferred work"], "alsoDid"?: ["notable work that did not become a knowledge item"]}
+
+# Events
+
+`;
 function getEnvelope(deltaJson) {
     const stub = process.env.SUPERBRAIN_DISTILL_STUB;
     if (stub)
         return parseEnvelope(fs.readFileSync(stub, "utf8"));
-    const prompt = "You are SuperBrain's distiller. Given this JSON array of session events and " +
-        "salient markers (including 'pushback' markers), output ONLY a JSON object: " +
-        '{"items":[{kind:"decision|project_fact|person|gotcha|capture|lesson|preference",' +
-        "title,body,date(YYYY-MM-DD),links:[],project?,person?,rule?}]," +
-        '"digest"?:string,"openThreads"?:[string],"alsoDid"?:[string]}. ' +
-        "Emit a lesson ONLY if the pushback implies a generalizable rule (skip one-off " +
-        "fixes); a generalizable lesson sets rule and ALSO emits exactly one preference " +
-        "item whose body is the FULL reconciled preferences doc (you are given the current " +
-        "one below). Skip ephemeral noise. Events:\n" + deltaJson;
     let curPrefs = "";
     try {
         curPrefs = fs.readFileSync(preferencesPath(), "utf8");
     }
     catch { /* none yet */ }
-    const fullPrompt = prompt + "\n\nCurrent preferences (reconcile, do not lose existing rules):\n" + (curPrefs || "(none)");
+    const fullPrompt = DISTILL_PROMPT_PREFIX +
+        deltaJson +
+        "\n\n# Current preferences (reconcile, do not lose existing user preferences; never include distiller behavior here)\n\n" +
+        (curPrefs || "(none yet)");
     const out = callClaude(fullPrompt);
     return parseEnvelope(out);
 }
 function appendLog(title, rel) {
-    const p = path.join(vaultPath(), "log.md");
+    // Per-day .log file in dataDir/logs/. Not in the vault — it's system
+    // telemetry, not a note. One file per day caps unbounded growth and makes
+    // the daily rollup input trivially scoped to its day.
+    const now = new Date();
+    const date = now.toISOString().slice(0, 10);
+    const stamp = now.toISOString().slice(0, 16).replace("T", " ");
+    const p = logFilePath(date);
     fs.mkdirSync(path.dirname(p), { recursive: true });
-    const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
-    fs.appendFileSync(p, `## [${stamp}] write | ${title} | [[${rel.replace(/\.md$/, "")}]]\n`);
+    fs.appendFileSync(p, `[${stamp}] write | ${title} | ${rel.replace(/\.md$/, "")}\n`);
 }
 function getRollupItems(logContent, key) {
     const stub = process.env.SUPERBRAIN_DISTILL_STUB;
@@ -92,7 +150,7 @@ export async function runRollup(rollupEnv) {
     const key = parts[1];
     const hash = parts[2];
     try {
-        const logFile = path.join(vaultPath(), "log.md");
+        const logFile = logFilePath(key);
         let logContent = "";
         try {
             logContent = fs.readFileSync(logFile, "utf8");

--- a/dist/src/paths.js
+++ b/dist/src/paths.js
@@ -3,12 +3,19 @@ import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { markOwned, recordedVaultPath } from "./vaultMarker.js";
+// dataDir is hardcoded to ~/.superbrain in production. SUPERBRAIN_DATA_DIR is
+// a test-only seam that Claude Code itself never sets — this is what keeps
+// production from drifting back to the historical split where hooks (under
+// Claude Code's CLAUDE_PLUGIN_DATA) wrote to a hidden per-plugin dir while
+// user-invoked entrypoints (migrate, adopt) wrote to ~/.superbrain.
 export function dataDir() {
-    return process.env.CLAUDE_PLUGIN_DATA || path.join(os.homedir(), ".superbrain");
+    return process.env.SUPERBRAIN_DATA_DIR || path.join(os.homedir(), ".superbrain");
 }
+// vaultPath in production: honors a recorded adopt path (/superbrain:adopt
+// writes it), else dataDir/vault. SUPERBRAIN_VAULT_DIR is a test-only seam.
 export function vaultPath() {
-    if (process.env.SUPERBRAIN_VAULT) {
-        const p = process.env.SUPERBRAIN_VAULT;
+    if (process.env.SUPERBRAIN_VAULT_DIR) {
+        const p = process.env.SUPERBRAIN_VAULT_DIR;
         markOwned(p);
         return p;
     }
@@ -37,3 +44,7 @@ export function cursorPath(id) { return path.join(sessionsDir(), `${id}.cursor`)
 export function sentinelPath() { return path.join(dataDir(), "last-failure.txt"); }
 export function rollupStatePath() { return path.join(dataDir(), "rollup-state.json"); }
 export function lockDir(name) { return path.join(dataDir(), "locks", `${name}.lock`); }
+// Per-day write log used by the daily rollup synthesizer. Lives in dataDir,
+// not the vault — it's system telemetry, not a user-facing note. One file per
+// day caps size and makes the rollup input trivially scoped.
+export function logFilePath(date) { return path.join(dataDir(), "logs", `${date}.log`); }

--- a/dist/src/router.js
+++ b/dist/src/router.js
@@ -5,39 +5,102 @@ function withLinks(body, links) {
     const wl = links.filter(Boolean).map((l) => `[[${l}]]`);
     return wl.length ? `${body}\n\nRelated: ${wl.join(" ")}` : body;
 }
+// Helper: emit "## Heading\n\ncontent" only when content is non-empty. Lets the
+// router omit sections the distiller chose not to fill.
+function section(heading, content) {
+    const v = (content || "").trim();
+    return v ? `## ${heading}\n\n${v}` : "";
+}
+function joinSections(parts) {
+    return parts.filter(Boolean).join("\n\n");
+}
 export function route(item) {
     const base = { created: item.date, updated: item.date, superbrain: true };
     switch (item.kind) {
-        case "decision":
-            return { relPath: `decisions/${item.date}-${slug(item.title)}.md`,
-                frontmatter: { type: "decision", status: "active", ...base },
-                body: withLinks(`# ${item.date} — ${item.title}\n\n${item.body}`, item.links), mode: "create" };
+        case "decision": {
+            const structured = joinSections([
+                section("Context", item.context),
+                section("Decision", item.decision),
+                section("Rationale", item.rationale),
+                section("Consequences", item.consequences),
+                section("Implementation", item.implementation),
+            ]);
+            const inner = structured || (item.body || "").trim();
+            return {
+                relPath: `decisions/${item.date}-${slug(item.title)}.md`,
+                frontmatter: { type: "decision", status: "active", ...(item.project ? { project: slug(item.project) } : {}), ...base },
+                body: withLinks(`# ${item.date} — ${item.title}\n\n${inner}`, item.links),
+                mode: "create",
+            };
+        }
         case "project_fact":
-            return { relPath: `projects/${slug(item.project || "unknown")}.md`,
+            return {
+                relPath: `projects/${slug(item.project || "unknown")}.md`,
                 frontmatter: { type: "project", status: "active", project: slug(item.project || "unknown"), ...base },
-                body: withLinks(`**${item.title}** — ${item.body}`, item.links), mode: "append" };
+                body: withLinks(`**${item.title}** — ${(item.body || "").trim()}`, item.links),
+                mode: "append",
+            };
         case "person":
-            return { relPath: `people/${slug(item.person || "unknown")}.md`,
+            return {
+                relPath: `people/${slug(item.person || "unknown")}.md`,
                 frontmatter: { type: "person", status: "active", ...base },
-                body: withLinks(item.body, item.links), mode: "append" };
-        case "gotcha":
-            return { relPath: `projects/${slug(item.project || "unknown")}.md`,
+                body: withLinks((item.body || "").trim(), item.links),
+                mode: "append",
+            };
+        case "gotcha": {
+            const structured = joinSections([
+                section("Symptom", item.symptom),
+                section("Root cause", item.rootCause),
+                section("Fix", item.fix),
+                section("Prevention", item.prevention),
+            ]);
+            const inner = structured || (item.body || "").trim();
+            return {
+                relPath: `projects/${slug(item.project || "unknown")}.md`,
                 frontmatter: { type: "project", status: "active", project: slug(item.project || "unknown"), ...base },
-                body: withLinks(`## Gotchas\n\n- ${item.title}: ${item.body}`, item.links), mode: "append" };
+                body: withLinks(`## Gotcha — ${item.title}\n\n${inner}`, item.links),
+                mode: "append",
+            };
+        }
         case "lesson": {
-            const why = `**Why:** ${item.body}`;
-            const ruleLine = item.rule ? `\n\n**Rule:** ${item.rule}` : "";
-            return { relPath: `lessons/${item.date}-${slug(item.title)}.md`,
+            // "Structured" means the distiller filled one of the NEW lesson sections
+            // (why / whenApplies). The legacy shape is { body, rule } — that path
+            // must keep producing `**Why:** body` + `**Rule:** rule` for back-compat
+            // with existing fixtures and any in-flight ndjson stubs.
+            const hasStructured = !!((item.why || "").trim() || (item.whenApplies || "").trim());
+            let inner;
+            if (hasStructured) {
+                inner = joinSections([
+                    section("Rule", item.rule),
+                    section("Why", item.why),
+                    section("When this applies", item.whenApplies),
+                ]);
+            }
+            else {
+                const why = item.body ? `**Why:** ${item.body.trim()}` : "";
+                const ruleLine = item.rule ? `\n\n**Rule:** ${item.rule}` : "";
+                inner = `${why}${ruleLine}`.trim();
+            }
+            return {
+                relPath: `lessons/${item.date}-${slug(item.title)}.md`,
                 frontmatter: { type: "lesson", status: "active", ...base },
-                body: withLinks(`# ${item.title}\n\n${why}${ruleLine}`, item.links), mode: "create" };
+                body: withLinks(`# ${item.title}\n\n${inner}`, item.links),
+                mode: "create",
+            };
         }
         case "preference":
-            return { relPath: `meta/preferences.md`,
+            return {
+                relPath: `meta/preferences.md`,
                 frontmatter: { type: "preference", ...base },
-                body: item.body, mode: "replace" };
+                body: (item.body || "").trim(),
+                mode: "replace",
+            };
         default:
-            return { relPath: `capture/${item.date}-${slug(item.title)}.md`,
+            return {
+                relPath: `capture/${item.date}-${slug(item.title)}.md`,
                 frontmatter: { type: "capture", status: "active", tags: ["triage"], ...base },
-                body: withLinks(`# ${item.title}\n\n${item.body}`, item.links), mode: "create" };
+                body: withLinks(`# ${item.title}\n\n${(item.body || "").trim()}`, item.links),
+                mode: "create",
+            };
     }
 }

--- a/skills/superbrain-distill/SKILL.md
+++ b/skills/superbrain-distill/SKILL.md
@@ -5,29 +5,47 @@ description: Internal SuperBrain skill — run by the detached capture child to 
 
 # SuperBrain Distiller
 
-You are SuperBrain's distiller, running headless and detached. You receive session
-events + salient markers (including `pushback` markers) and the current preferences.
+You are SuperBrain's distiller, running headless and detached. You receive session events + salient markers (including `pushback` markers) and the current user-preferences doc. Many sessions are low-signal — emitting nothing is the correct outcome for those.
 
-Output **only** a JSON object:
+Output **only** a JSON envelope:
 
 ```
-{ "items": [ { "kind": "decision|project_fact|person|gotcha|capture|lesson|preference",
-               "title": "...", "body": "...", "date": "YYYY-MM-DD",
-               "links": ["WikiTarget"], "project": "?", "person": "?", "rule": "?" } ],
-  "digest": "<=1 sentence of the session's arc",
-  "openThreads": ["unfinished/deferred work"],
-  "alsoDid": ["notable work that did not become a knowledge item"] }
+{ "items": [ <item>, ... ],
+  "digest"?: "<=1 sentence of the session's arc",
+  "openThreads"?: ["unfinished/deferred work"],
+  "alsoDid"?:    ["notable work that did not become a knowledge item"] }
 ```
 
-Rules:
-- decisions / project facts / gotchas / people: as before.
-- **lesson**: emit ONLY when a `pushback` implies a rule that generalizes beyond the
-  immediate edit (skip one-off local fixes). Set `rule` to the crisp durable rule.
-- **Distill-time split**: a generalizable lesson ALSO emits exactly one `preference`
-  item whose `body` is the COMPLETE reconciled preferences document — integrate the
-  new rule into the current preferences (given below the events), dedupe, resolve
-  contradictions newest-wins, group by area as `## Area` markdown headings. Never
-  emit more than one preference item.
-- `digest`, `openThreads`, `alsoDid` are envelope-level (not items).
-- Skip transcript dumps and anything derivable from git/the code.
-- Never write files yourself — output JSON only.
+## Quality bar — wait for signal
+
+Each kind has a concrete emission threshold. If nothing in the session meets a threshold, output `{"items":[]}`. Do not invent.
+
+- **decision** — explicit deliberation (options weighed, trade-off chosen) OR documented multi-step plan with stated reasoning.
+- **gotcha** — bug reproduced AND diagnosed AND has a stated fix.
+- **lesson** — pushback that yields a generalizable rule, not a one-off correction.
+- **project_fact** — durable architectural / scope / ownership statement. Status updates don't count.
+- **preference** — user explicitly states (or sustained pushback reveals) a coding / tooling / communication preference. NEVER write SuperBrain's own distiller behavior here.
+- **person** — durable role / context / threads about a specific person.
+- **capture** — substantive item that doesn't fit above. Not a dumping ground.
+
+## Required fields per kind (structured notes, not one-liners)
+
+- **decision**: `{kind, title, date, context, decision, rationale, consequences, implementation?, project?, links}`
+- **gotcha**: `{kind, title, date, project, symptom, rootCause, fix, prevention, links}`
+- **lesson**: `{kind, title, date, rule, why, whenApplies, links}`
+- **project_fact**: `{kind, title, date, project, body, links}` — terse but ≤3 sentences with one sentence of context.
+- **person**: `{kind, title, date, person, body, links}`
+- **preference**: `{kind, title: "Preferences", date, body}` — `body` is the FULL reconciled user-preferences doc, organized by `## Category` (Code style / Architecture / Tools / Communication / …). Never the distiller's own rules.
+- **capture**: `{kind, title, date, body, links}`
+
+## Preferences reconciliation
+
+When a lesson's `rule` qualifies as a user-style/tool/communication preference (not a SuperBrain behavior rule), ALSO emit exactly one `preference` item whose `body` is the FULL reconciled preferences doc — integrate the new rule into the current one (given alongside the events below), dedupe, resolve contradictions newest-wins, keep `## Category` headings. Never emit more than one preference item per envelope. If the lesson is a SuperBrain behavior rule, do not emit a preference.
+
+## Hard rules
+
+- Empty / observer-only / read-only sessions → `{"items":[]}` immediately.
+- Distiller behavior rules are NOT user preferences. Never write them into a preference item.
+- Skip transcript dumps and content trivially derivable from git or the code itself.
+- Output JSON only — no prose, no backticks, no explanation.
+- Never write files yourself.

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -4,15 +4,12 @@ import { execFileSync } from "node:child_process";
 
 // Pin the model on every detached `claude -p` distill/rollup spawn so it never
 // inherits the user's session model (which is often Opus, and burns daily
-// quota in hours — exactly the legacy-scribe bug we replaced). Default Sonnet
-// 4.6 balances quality (the distiller IS the product — the vault is only as
-// good as the routed notes it writes) against cost (~1/5 of Opus). Override
-// via SUPERBRAIN_MODEL for power users (e.g. claude-haiku-4-5-20251001 for
-// cheaper-but-lower-quality, or claude-opus-4-7 with ANTHROPIC_API_KEY set to
-// bypass subscription limits).
+// quota in hours — exactly the legacy-scribe bug we replaced). Sonnet 4.6
+// balances quality (the distiller IS the product — the vault is only as good
+// as the routed notes it writes) against cost (~1/5 of Opus). No env override:
+// users should not need to think about model selection.
 export function distillModel(): string {
-  const v = process.env.SUPERBRAIN_MODEL;
-  return (v && v.trim()) ? v.trim() : "claude-sonnet-4-6";
+  return "claude-sonnet-4-6";
 }
 function callClaude(prompt: string): string {
   return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
@@ -24,7 +21,7 @@ import { route, type DistilledItem } from "./router.js";
 import { writeNote } from "./vaultWriter.js";
 import { releaseLock } from "./lockfile.js";
 import { writeFailure } from "./sentinel.js";
-import { vaultPath } from "./paths.js";
+import { vaultPath, logFilePath } from "./paths.js";
 import { markRollup } from "./rollupState.js";
 import { indexNote } from "./indexer.js";
 import { upsertDay } from "./dailyState.js";
@@ -53,31 +50,93 @@ export function parseEnvelope(raw: string): DistilledEnvelope {
   };
 }
 
+// The session-distillation prompt. Long and opinionated on purpose: prompt
+// quality is the whole game. Structure: persona → hard rules → per-kind
+// emission criteria → per-kind required fields → few-shot examples →
+// preferences reconciliation contract → output schema → events.
+const DISTILL_PROMPT_PREFIX = `You are SuperBrain's distiller. You receive a JSON array of session events (tool calls, prompts) plus 'pushback' markers, and you turn the substantive moments into durable second-brain notes. Many sessions contain NO substantive moments — that is the desired output, not a failure.
+
+# Hard rules — never violate
+
+1. If the events array is empty OR contains no substantive activity (skim-only sessions, observer-watches-observer meta-sessions, sessions that only read existing notes), output {"items":[]} immediately and stop.
+2. Distiller behavior rules (this prompt) are NOT user preferences. NEVER write them into a preference item.
+3. Skip transcript dumps and anything trivially derivable from git or the code itself (file paths, function names, commit messages alone are not knowledge).
+4. Output ONLY the JSON envelope. No prose, no backticks, no explanation.
+
+# Quality bar — wait for signal before emitting
+
+Each kind has a concrete threshold. If a session does not meet the threshold for any kind, do not invent items. Empty output is correct.
+
+- decision — emit only when the session contains an EXPLICIT deliberation (multiple options weighed and a trade-off chosen) OR a documented multi-step plan with stated reasoning. A one-line conclusion is not a decision.
+- gotcha — emit only when a bug was REPRODUCED AND DIAGNOSED AND has a stated fix or workaround. Speculation, suspicion, or 'this might be the issue' is not a gotcha.
+- lesson — emit only when user pushback produces a GENERALIZABLE RULE that should change future behavior. A one-off correction ('not that file, the other one') is not a lesson.
+- project_fact — emit only for DURABLE architectural, scope, or ownership statements. 'PR in review' is not a project fact. 'We've decided this service will be the only writer for X' is.
+- preference — emit only when the user EXPLICITLY states a coding / tooling / communication preference, OR sustained pushback reveals one. Preferences describe how the USER wants Claude to behave (code style, architecture, tool choice, comment density, etc.). NEVER describe SuperBrain's own distiller behavior here.
+- person — emit only when a durable role / context / thread about a specific person is established.
+- capture — only for substantive items that don't fit above but are clearly worth keeping. Not a dumping ground.
+
+# Required fields per kind — write rich, structured notes
+
+When you DO emit, fill the structured fields below. Substance over brevity: a real decision note is paragraphs, not a sentence.
+
+decision: { kind, title (imperative, ≤80 chars), date, context (1–2 paragraphs: what was happening, what choice arose), decision (1–2 sentences: what was chosen), rationale (1–2 paragraphs: why this over alternatives), consequences (1 paragraph: trade-offs, what this enables or precludes), implementation? (concrete next steps or changes made), project? (slug if scoped), links (related-note slugs) }
+
+gotcha: { kind, title (short symptom name), date, project (slug — required), symptom (the observable failure), rootCause (technical explanation), fix (what resolves it, with file refs if possible), prevention (how to avoid hitting it again), links }
+
+lesson: { kind, title (short imperative rule name), date, rule (the durable, generalizable principle, one crisp sentence), why (the reasoning + the incident that produced it, 1–2 paragraphs), whenApplies (when to invoke this rule in the future), links }
+
+project_fact: { kind, title (short fact statement), date, project (slug — required), body (one sentence of context + the fact itself; ≤3 sentences), links }
+
+person: { kind, title (short), date, person (slug — required), body (role/context/threads), links }
+
+preference: { kind, title: "Preferences", date, body (the FULL reconciled user-preferences doc — plain markdown, organized by '## Category' headings such as Code style / Architecture / Tools / Communication, NEVER containing SuperBrain distiller behavior) }
+
+capture: { kind, title, date, body, links }
+
+# Preferences reconciliation
+
+You are given the current preferences doc at the end of this prompt. When a lesson's rule qualifies as a user-style/tool/communication preference (NOT a SuperBrain behavior rule), ALSO emit exactly one preference item whose body is the FULL reconciled doc — integrate the new rule, dedupe, resolve contradictions newest-wins, keep '## Category' headings. Never emit more than one preference item per envelope. If the lesson is a SuperBrain behavior rule, do not emit a preference at all.
+
+# Few-shot — what a substantive decision and lesson look like
+
+EXAMPLE decision (structured fields filled, paragraphs, links):
+{"kind":"decision","title":"Pin distiller model to Sonnet 4.6","date":"2026-05-19","context":"The legacy scribe ran detached \`claude -p\` spawns at the user's session model, often Opus. Distillation runs many times per day and burned the user's daily Opus quota in hours, surfacing as silent capture failures mid-day.","decision":"Hardcode the distiller and rollup spawns to use --model claude-sonnet-4-6 unconditionally; no env override.","rationale":"Sonnet 4.6 produces judgment of comparable quality to Opus for summarization at roughly 1/5 the cost. Removing the env override prevents users from accidentally re-introducing the quota burn — the surface area was a footgun, not a feature.","consequences":"Users who want higher quality must set ANTHROPIC_API_KEY to bypass subscription quota. No model selection is exposed beyond that escape hatch.","implementation":"src/distillRun.ts:distillModel() returns the literal 'claude-sonnet-4-6'. tests/distillModel.test.ts locks the no-env behavior in.","links":["projects/superbrain"]}
+
+EXAMPLE lesson (structured fields, traced to an incident, with whenApplies):
+{"kind":"lesson","title":"Verify the live data dir before claiming a plugin is broken","date":"2026-05-20","rule":"For Claude Code plugins, resolve the actual CLAUDE_PLUGIN_DATA path at hook execution time before inspecting on-disk state — never trust the fallback path in the source code.","why":"On 2026-05-20 a full multi-step misdiagnosis was produced (broken matchers, async hook failure, missing distillation) because the investigator inspected the source's fallback ~/.superbrain/ instead of the actual ~/.claude/plugins/data/superbrain-m3talux/ where Claude Code routes hook writes. Everything was healthy at the real path.","whenApplies":"Any time a Claude Code plugin appears to not be writing data, before declaring it broken.","links":["projects/superbrain"]}
+
+# Output schema
+
+{"items": [ <items as above> ], "digest"?: "<=1 sentence of the session's arc", "openThreads"?: ["unfinished/deferred work"], "alsoDid"?: ["notable work that did not become a knowledge item"]}
+
+# Events
+
+`;
+
 function getEnvelope(deltaJson: string): DistilledEnvelope {
   const stub = process.env.SUPERBRAIN_DISTILL_STUB;
   if (stub) return parseEnvelope(fs.readFileSync(stub, "utf8"));
-  const prompt =
-    "You are SuperBrain's distiller. Given this JSON array of session events and " +
-    "salient markers (including 'pushback' markers), output ONLY a JSON object: " +
-    '{"items":[{kind:"decision|project_fact|person|gotcha|capture|lesson|preference",' +
-    "title,body,date(YYYY-MM-DD),links:[],project?,person?,rule?}]," +
-    '"digest"?:string,"openThreads"?:[string],"alsoDid"?:[string]}. ' +
-    "Emit a lesson ONLY if the pushback implies a generalizable rule (skip one-off " +
-    "fixes); a generalizable lesson sets rule and ALSO emits exactly one preference " +
-    "item whose body is the FULL reconciled preferences doc (you are given the current " +
-    "one below). Skip ephemeral noise. Events:\n" + deltaJson;
   let curPrefs = "";
   try { curPrefs = fs.readFileSync(preferencesPath(), "utf8"); } catch { /* none yet */ }
-  const fullPrompt = prompt + "\n\nCurrent preferences (reconcile, do not lose existing rules):\n" + (curPrefs || "(none)");
+  const fullPrompt =
+    DISTILL_PROMPT_PREFIX +
+    deltaJson +
+    "\n\n# Current preferences (reconcile, do not lose existing user preferences; never include distiller behavior here)\n\n" +
+    (curPrefs || "(none yet)");
   const out = callClaude(fullPrompt);
   return parseEnvelope(out);
 }
 
 function appendLog(title: string, rel: string) {
-  const p = path.join(vaultPath(), "log.md");
+  // Per-day .log file in dataDir/logs/. Not in the vault — it's system
+  // telemetry, not a note. One file per day caps unbounded growth and makes
+  // the daily rollup input trivially scoped to its day.
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10);
+  const stamp = now.toISOString().slice(0, 16).replace("T", " ");
+  const p = logFilePath(date);
   fs.mkdirSync(path.dirname(p), { recursive: true });
-  const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
-  fs.appendFileSync(p, `## [${stamp}] write | ${title} | [[${rel.replace(/\.md$/, "")}]]\n`);
+  fs.appendFileSync(p, `[${stamp}] write | ${title} | ${rel.replace(/\.md$/, "")}\n`);
 }
 
 function getRollupItems(logContent: string, key: string): DistilledItem[] {
@@ -100,7 +159,7 @@ export async function runRollup(rollupEnv: string): Promise<void> {
   const hash = parts[2];
 
   try {
-    const logFile = path.join(vaultPath(), "log.md");
+    const logFile = logFilePath(key);
     let logContent = "";
     try { logContent = fs.readFileSync(logFile, "utf8"); } catch { /* absent is fine */ }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -4,12 +4,19 @@ import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { markOwned, recordedVaultPath } from "./vaultMarker.js";
 
+// dataDir is hardcoded to ~/.superbrain in production. SUPERBRAIN_DATA_DIR is
+// a test-only seam that Claude Code itself never sets — this is what keeps
+// production from drifting back to the historical split where hooks (under
+// Claude Code's CLAUDE_PLUGIN_DATA) wrote to a hidden per-plugin dir while
+// user-invoked entrypoints (migrate, adopt) wrote to ~/.superbrain.
 export function dataDir(): string {
-  return process.env.CLAUDE_PLUGIN_DATA || path.join(os.homedir(), ".superbrain");
+  return process.env.SUPERBRAIN_DATA_DIR || path.join(os.homedir(), ".superbrain");
 }
+// vaultPath in production: honors a recorded adopt path (/superbrain:adopt
+// writes it), else dataDir/vault. SUPERBRAIN_VAULT_DIR is a test-only seam.
 export function vaultPath(): string {
-  if (process.env.SUPERBRAIN_VAULT) {
-    const p = process.env.SUPERBRAIN_VAULT;
+  if (process.env.SUPERBRAIN_VAULT_DIR) {
+    const p = process.env.SUPERBRAIN_VAULT_DIR;
     markOwned(p);
     return p;
   }
@@ -36,3 +43,7 @@ export function cursorPath(id: string): string { return path.join(sessionsDir(),
 export function sentinelPath(): string { return path.join(dataDir(), "last-failure.txt"); }
 export function rollupStatePath(): string { return path.join(dataDir(), "rollup-state.json"); }
 export function lockDir(name: string): string { return path.join(dataDir(), "locks", `${name}.lock`); }
+// Per-day write log used by the daily rollup synthesizer. Lives in dataDir,
+// not the vault — it's system telemetry, not a user-facing note. One file per
+// day caps size and makes the rollup input trivially scoped.
+export function logFilePath(date: string): string { return path.join(dataDir(), "logs", `${date}.log`); }

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,14 +1,37 @@
 export type Kind = "decision" | "project_fact" | "person" | "gotcha" | "capture" | "lesson" | "preference";
+
+// DistilledItem carries either freeform `body` (capture, person, simple cases)
+// OR structured per-kind sections (decision/lesson/gotcha). When structured
+// fields are present, the router assembles them into the canonical ADR/lesson
+// template. When absent, it falls back to `body`. New fields are all optional
+// so older distiller outputs (fixtures, stubs) keep routing correctly.
 export interface DistilledItem {
   kind: Kind;
   title: string;
-  body: string;
-  date: string;            // YYYY-MM-DD
+  date: string;
   links: string[];
   project?: string;
   person?: string;
-  rule?: string;           // crisp durable rule for a generalizable lesson
+  rule?: string;
+
+  // Structured sections used for substantive notes:
+  context?: string;        // decision/gotcha — what was happening
+  decision?: string;       // decision — what was decided
+  rationale?: string;      // decision — why this over alternatives
+  consequences?: string;   // decision — trade-offs, what this enables/precludes
+  implementation?: string; // decision — concrete next steps or changes made
+  symptom?: string;        // gotcha — observable failure
+  rootCause?: string;      // gotcha — technical explanation
+  fix?: string;            // gotcha — what resolves it
+  prevention?: string;     // gotcha — how to avoid hitting it again
+  why?: string;            // lesson — reasoning + incident
+  whenApplies?: string;    // lesson — when to invoke the rule
+
+  // Freeform fallback. Used for captures and as a back-compat slot when the
+  // model returns the old single-blob shape.
+  body?: string;
 }
+
 export interface RouteResult {
   relPath: string;
   frontmatter: Record<string, any>;
@@ -24,39 +47,102 @@ function withLinks(body: string, links: string[]): string {
   return wl.length ? `${body}\n\nRelated: ${wl.join(" ")}` : body;
 }
 
+// Helper: emit "## Heading\n\ncontent" only when content is non-empty. Lets the
+// router omit sections the distiller chose not to fill.
+function section(heading: string, content: string | undefined): string {
+  const v = (content || "").trim();
+  return v ? `## ${heading}\n\n${v}` : "";
+}
+function joinSections(parts: string[]): string {
+  return parts.filter(Boolean).join("\n\n");
+}
+
 export function route(item: DistilledItem): RouteResult {
   const base = { created: item.date, updated: item.date, superbrain: true };
   switch (item.kind) {
-    case "decision":
-      return { relPath: `decisions/${item.date}-${slug(item.title)}.md`,
-        frontmatter: { type: "decision", status: "active", ...base },
-        body: withLinks(`# ${item.date} — ${item.title}\n\n${item.body}`, item.links), mode: "create" };
+    case "decision": {
+      const structured = joinSections([
+        section("Context", item.context),
+        section("Decision", item.decision),
+        section("Rationale", item.rationale),
+        section("Consequences", item.consequences),
+        section("Implementation", item.implementation),
+      ]);
+      const inner = structured || (item.body || "").trim();
+      return {
+        relPath: `decisions/${item.date}-${slug(item.title)}.md`,
+        frontmatter: { type: "decision", status: "active", ...(item.project ? { project: slug(item.project) } : {}), ...base },
+        body: withLinks(`# ${item.date} — ${item.title}\n\n${inner}`, item.links),
+        mode: "create",
+      };
+    }
     case "project_fact":
-      return { relPath: `projects/${slug(item.project || "unknown")}.md`,
+      return {
+        relPath: `projects/${slug(item.project || "unknown")}.md`,
         frontmatter: { type: "project", status: "active", project: slug(item.project || "unknown"), ...base },
-        body: withLinks(`**${item.title}** — ${item.body}`, item.links), mode: "append" };
+        body: withLinks(`**${item.title}** — ${(item.body || "").trim()}`, item.links),
+        mode: "append",
+      };
     case "person":
-      return { relPath: `people/${slug(item.person || "unknown")}.md`,
+      return {
+        relPath: `people/${slug(item.person || "unknown")}.md`,
         frontmatter: { type: "person", status: "active", ...base },
-        body: withLinks(item.body, item.links), mode: "append" };
-    case "gotcha":
-      return { relPath: `projects/${slug(item.project || "unknown")}.md`,
+        body: withLinks((item.body || "").trim(), item.links),
+        mode: "append",
+      };
+    case "gotcha": {
+      const structured = joinSections([
+        section("Symptom", item.symptom),
+        section("Root cause", item.rootCause),
+        section("Fix", item.fix),
+        section("Prevention", item.prevention),
+      ]);
+      const inner = structured || (item.body || "").trim();
+      return {
+        relPath: `projects/${slug(item.project || "unknown")}.md`,
         frontmatter: { type: "project", status: "active", project: slug(item.project || "unknown"), ...base },
-        body: withLinks(`## Gotchas\n\n- ${item.title}: ${item.body}`, item.links), mode: "append" };
+        body: withLinks(`## Gotcha — ${item.title}\n\n${inner}`, item.links),
+        mode: "append",
+      };
+    }
     case "lesson": {
-      const why = `**Why:** ${item.body}`;
-      const ruleLine = item.rule ? `\n\n**Rule:** ${item.rule}` : "";
-      return { relPath: `lessons/${item.date}-${slug(item.title)}.md`,
+      // "Structured" means the distiller filled one of the NEW lesson sections
+      // (why / whenApplies). The legacy shape is { body, rule } — that path
+      // must keep producing `**Why:** body` + `**Rule:** rule` for back-compat
+      // with existing fixtures and any in-flight ndjson stubs.
+      const hasStructured = !!((item.why || "").trim() || (item.whenApplies || "").trim());
+      let inner: string;
+      if (hasStructured) {
+        inner = joinSections([
+          section("Rule", item.rule),
+          section("Why", item.why),
+          section("When this applies", item.whenApplies),
+        ]);
+      } else {
+        const why = item.body ? `**Why:** ${item.body.trim()}` : "";
+        const ruleLine = item.rule ? `\n\n**Rule:** ${item.rule}` : "";
+        inner = `${why}${ruleLine}`.trim();
+      }
+      return {
+        relPath: `lessons/${item.date}-${slug(item.title)}.md`,
         frontmatter: { type: "lesson", status: "active", ...base },
-        body: withLinks(`# ${item.title}\n\n${why}${ruleLine}`, item.links), mode: "create" };
+        body: withLinks(`# ${item.title}\n\n${inner}`, item.links),
+        mode: "create",
+      };
     }
     case "preference":
-      return { relPath: `meta/preferences.md`,
+      return {
+        relPath: `meta/preferences.md`,
         frontmatter: { type: "preference", ...base },
-        body: item.body, mode: "replace" };
+        body: (item.body || "").trim(),
+        mode: "replace",
+      };
     default:
-      return { relPath: `capture/${item.date}-${slug(item.title)}.md`,
+      return {
+        relPath: `capture/${item.date}-${slug(item.title)}.md`,
         frontmatter: { type: "capture", status: "active", tags: ["triage"], ...base },
-        body: withLinks(`# ${item.title}\n\n${item.body}`, item.links), mode: "create" };
+        body: withLinks(`# ${item.title}\n\n${(item.body || "").trim()}`, item.links),
+        mode: "create",
+      };
   }
 }

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -6,7 +6,7 @@ import { depsPresent, bootstrapDone, markBootstrapDone } from "../src/bootstrap"
 beforeEach(() => {
   fs.rmSync("/tmp/sb-bs", { recursive: true, force: true });
   fs.rmSync("/tmp/sb-bs-data", { recursive: true, force: true });
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-bs-data";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-bs-data";
 });
 
 it("depsPresent is false without the better-sqlite3 native binding, true with it", () => {
@@ -31,7 +31,7 @@ it("bootstrapDone reflects the marker", () => {
 it("sb-bootstrap is idempotent: no-op when bootstrap-done exists", () => {
   markBootstrapDone();
   const out = execFileSync("npx", ["tsx", "bin/sb-bootstrap.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-bs-data",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-bs-data",
       SUPERBRAIN_PLUGIN_ROOT: "/tmp/sb-bs", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });
@@ -41,7 +41,7 @@ it("sb-bootstrap is idempotent: no-op when bootstrap-done exists", () => {
 it("sb-bootstrap (fake) writes bootstrap-done on success", () => {
   fs.mkdirSync("/tmp/sb-bs", { recursive: true });
   execFileSync("npx", ["tsx", "bin/sb-bootstrap.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-bs-data",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-bs-data",
       SUPERBRAIN_PLUGIN_ROOT: "/tmp/sb-bs", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });

--- a/tests/checkpoint.test.ts
+++ b/tests/checkpoint.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => fs.rmSync("/tmp/sb-ckpt", { recursive: true, force: true }));
 function run(hook: object, extraEnv: Record<string, string> = {}) {
   return execFileSync("npx", ["tsx", "bin/sb-checkpoint.ts"], {
     input: JSON.stringify(hook),
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-ckpt",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ckpt",
            SUPERBRAIN_FAKE_DISTILLER: "1", ...extraEnv },
     encoding: "utf8",
   });

--- a/tests/cursor.test.ts
+++ b/tests/cursor.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { readCursor, writeCursor } from "../src/cursor";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-cursor";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-cursor";
   fs.rmSync("/tmp/sb-cursor", { recursive: true, force: true });
 });
 
@@ -14,7 +14,7 @@ describe("cursor", () => {
     expect(readCursor("s")).toBe(42);
   });
   it("treats corrupt cursor as 0", () => {
-    process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-cursor";
+    process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-cursor";
     writeCursor("s", 10);
     fs.writeFileSync("/tmp/sb-cursor/sessions/s.cursor", "garbage");
     expect(readCursor("s")).toBe(0);

--- a/tests/dailyNote.test.ts
+++ b/tests/dailyNote.test.ts
@@ -5,7 +5,7 @@ import { buildDailyNote } from "../src/dailyNote";
 
 beforeEach(() => {
   fs.rmSync("/tmp/sb-dn", { recursive: true, force: true });
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-dn";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-dn";
 });
 
 it("merges sessions into a hybrid note (links, not bodies)", () => {

--- a/tests/dailyState.test.ts
+++ b/tests/dailyState.test.ts
@@ -4,7 +4,7 @@ import { upsertDay, readDay, type DaySessionEntry } from "../src/dailyState";
 
 beforeEach(() => {
   fs.rmSync("/tmp/sb-ds", { recursive: true, force: true });
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-ds";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-ds";
 });
 
 const entry = (over: Partial<DaySessionEntry> = {}): DaySessionEntry =>

--- a/tests/distill.test.ts
+++ b/tests/distill.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
   fs.rmSync("/tmp/sb-dist-vault", { recursive: true, force: true });
 });
 
-it("distills delta into routed notes, log.md, advances cursor, releases lock", () => {
+it("distills delta into routed notes, daily .log file, advances cursor, releases lock", () => {
   fs.mkdirSync("/tmp/sb-dist/sessions", { recursive: true });
   fs.writeFileSync("/tmp/sb-dist/sessions/S.ndjson",
     JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n");
@@ -19,14 +19,17 @@ it("distills delta into routed notes, log.md, advances cursor, releases lock", (
   fs.writeFileSync("/tmp/sb-dist/sessions/S.prompt.json", "{}");
 
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-dist",
-      SUPERBRAIN_VAULT: "/tmp/sb-dist-vault", SUPERBRAIN_DISTILL_STUB: stub,
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-dist",
+      SUPERBRAIN_VAULT_DIR: "/tmp/sb-dist-vault", SUPERBRAIN_DISTILL_STUB: stub,
       SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });
 
   expect(fs.existsSync("/tmp/sb-dist-vault/decisions/2026-05-19-pick-x.md")).toBe(true);
-  expect(fs.readFileSync("/tmp/sb-dist-vault/log.md", "utf8")).toMatch(/Pick X/);
+  // The daily .log file lives in dataDir/logs/<today>.log and is named with the
+  // current date (not the item's date) since appendLog stamps it at write time.
+  const today = new Date().toISOString().slice(0, 10);
+  expect(fs.readFileSync(`/tmp/sb-dist/logs/${today}.log`, "utf8")).toMatch(/Pick X/);
   expect(Number(fs.readFileSync("/tmp/sb-dist/sessions/S.cursor", "utf8"))).toBeGreaterThan(0);
   expect(fs.existsSync("/tmp/sb-dist/locks/distill.lock")).toBe(false);
 });

--- a/tests/distillDaily.test.ts
+++ b/tests/distillDaily.test.ts
@@ -19,7 +19,7 @@ it("writes a daily note aggregating the session's routed items + envelope fields
   fs.mkdirSync("/tmp/sb-dd/locks/distill.lock", { recursive: true });
 
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-dd", SUPERBRAIN_VAULT: "/tmp/sb-dd-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-dd", SUPERBRAIN_VAULT_DIR: "/tmp/sb-dd-vault",
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/distillIndex.test.ts
+++ b/tests/distillIndex.test.ts
@@ -4,8 +4,8 @@ import { execFileSync } from "node:child_process";
 import { openIndex } from "../src/searchIndex";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-di";
-  process.env.SUPERBRAIN_VAULT = "/tmp/sb-di-vault";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-di";
+  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-di-vault";
   fs.rmSync("/tmp/sb-di", { recursive: true, force: true });
   fs.rmSync("/tmp/sb-di-vault", { recursive: true, force: true });
 });
@@ -20,7 +20,7 @@ it("a note written by the distiller is searchable in the index", () => {
   ]));
   fs.mkdirSync("/tmp/sb-di/locks/distill.lock", { recursive: true });
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-di", SUPERBRAIN_VAULT: "/tmp/sb-di-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-di", SUPERBRAIN_VAULT_DIR: "/tmp/sb-di-vault",
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/distillModel.test.ts
+++ b/tests/distillModel.test.ts
@@ -4,21 +4,15 @@ import { distillModel } from "../src/distillRun.js";
 
 // Cost-control invariant: the detached distill/rollup `claude -p` spawns must
 // NEVER inherit the user's session model (often Opus, which burned the legacy
-// scribe's daily quota in hours). The model is pinned via `--model` on every
-// call site, honoring SUPERBRAIN_MODEL with a Sonnet default.
+// scribe's daily quota in hours). The model is hardcoded — no env override —
+// so users never have to think about model selection.
 
-it("defaults to claude-sonnet-4-6 and honors SUPERBRAIN_MODEL override (trims, ignores empty)", () => {
+it("distillModel is hardcoded to claude-sonnet-4-6 (no env override)", () => {
+  // Even if a user sets SUPERBRAIN_MODEL the function ignores it: the model is
+  // a code-level decision, not a user-facing knob.
   const prev = process.env.SUPERBRAIN_MODEL;
   try {
-    delete process.env.SUPERBRAIN_MODEL;
-    expect(distillModel()).toBe("claude-sonnet-4-6");
-    process.env.SUPERBRAIN_MODEL = "claude-haiku-4-5-20251001";
-    expect(distillModel()).toBe("claude-haiku-4-5-20251001");
-    process.env.SUPERBRAIN_MODEL = "  claude-opus-4-7  ";
-    expect(distillModel()).toBe("claude-opus-4-7");
-    process.env.SUPERBRAIN_MODEL = "";
-    expect(distillModel()).toBe("claude-sonnet-4-6");
-    process.env.SUPERBRAIN_MODEL = "   ";
+    process.env.SUPERBRAIN_MODEL = "claude-opus-4-7";
     expect(distillModel()).toBe("claude-sonnet-4-6");
   } finally {
     if (prev === undefined) delete process.env.SUPERBRAIN_MODEL;

--- a/tests/distillRollup.test.ts
+++ b/tests/distillRollup.test.ts
@@ -9,13 +9,13 @@ beforeEach(() => {
 
 it("rollup mode writes a daily note and marks rollup state", () => {
   fs.mkdirSync("/tmp/sb-dr-vault", { recursive: true });
-  fs.writeFileSync("/tmp/sb-dr-vault/log.md", "## [2026-05-18 10:00] write | did things | [[x]]\n");
   const stub = "/tmp/sb-dr/stub.json";
-  fs.mkdirSync("/tmp/sb-dr", { recursive: true });
+  fs.mkdirSync("/tmp/sb-dr/logs", { recursive: true });
+  fs.writeFileSync("/tmp/sb-dr/logs/2026-05-18.log", "[2026-05-18 10:00] write | did things | x\n");
   fs.writeFileSync(stub, JSON.stringify([{ kind: "capture", title: "Daily 2026-05-18", body: "summary", date: "2026-05-18", links: [] }]));
   fs.mkdirSync("/tmp/sb-dr/locks/distill.lock", { recursive: true });
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-dr", SUPERBRAIN_VAULT: "/tmp/sb-dr-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-dr", SUPERBRAIN_VAULT_DIR: "/tmp/sb-dr-vault",
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_ROLLUP: "daily:2026-05-18:42",
       SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",

--- a/tests/distillRollupDaily.test.ts
+++ b/tests/distillRollupDaily.test.ts
@@ -9,8 +9,8 @@ beforeEach(() => {
 
 it("rollup path also regenerates the daily note for the rollup key", () => {
   fs.mkdirSync("/tmp/sb-rd-vault", { recursive: true });
-  fs.writeFileSync("/tmp/sb-rd-vault/log.md", "## [2026-05-18 10:00] write | Did stuff | [[decisions/x]]\n");
-  fs.mkdirSync("/tmp/sb-rd", { recursive: true });
+  fs.mkdirSync("/tmp/sb-rd/logs", { recursive: true });
+  fs.writeFileSync("/tmp/sb-rd/logs/2026-05-18.log", "[2026-05-18 10:00] write | Did stuff | decisions/x\n");
   const stub = "/tmp/sb-rd/stub.json";
   fs.writeFileSync(stub, JSON.stringify({
     items: [{ kind: "capture", title: "Daily 2026-05-18", body: "synthesis", date: "2026-05-18", links: [] }],
@@ -19,7 +19,7 @@ it("rollup path also regenerates the daily note for the rollup key", () => {
   fs.mkdirSync("/tmp/sb-rd/locks/distill.lock", { recursive: true });
 
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-rd", SUPERBRAIN_VAULT: "/tmp/sb-rd-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-rd", SUPERBRAIN_VAULT_DIR: "/tmp/sb-rd-vault",
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "rollup-2026-05-18",
       SUPERBRAIN_ROLLUP: "daily:2026-05-18:v1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",

--- a/tests/freshCloneE2E.test.ts
+++ b/tests/freshCloneE2E.test.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
 it("every hook entrypoint loads + exits 0 with NO node_modules; SessionStart bootstraps", () => {
   const dataDir = "/tmp/sb-fresh-data";
   fs.rmSync(dataDir, { recursive: true, force: true });
-  const env = { ...process.env, CLAUDE_PLUGIN_ROOT: CLONE, CLAUDE_PLUGIN_DATA: dataDir,
+  const env = { ...process.env, CLAUDE_PLUGIN_ROOT: CLONE, SUPERBRAIN_DATA_DIR: dataDir,
     SUPERBRAIN_BOOTSTRAP_FAKE: "1", SUPERBRAIN_FAKE_DISTILLER: "1" };
   for (const b of ["sb-observe", "sb-checkpoint", "sb-recall", "sb-distill"]) {
     const r = execFileSync(process.execPath, [path.join(CLONE, "dist/bin", `${b}.js`)], {

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -4,8 +4,8 @@ import { indexNote, reconcile } from "../src/indexer";
 import { openIndex } from "../src/searchIndex";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-indexer";
-  process.env.SUPERBRAIN_VAULT = "/tmp/sb-indexer-vault";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-indexer";
+  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-indexer-vault";
   process.env.SUPERBRAIN_EMBED_STUB = "1";
   fs.rmSync("/tmp/sb-indexer", { recursive: true, force: true });
   fs.rmSync("/tmp/sb-indexer-vault", { recursive: true, force: true });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -24,7 +24,7 @@ it("real checkpoint path (no fake seam) writes a vault note and releases the loc
   execFileSync("node", [DIST_CHECKPOINT], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "Stop", cwd: "/p", transcript_path: "/dev/null" }),
     env: { ...process.env, PATH: `${BIN}:${process.env.PATH}`,
-      CLAUDE_PLUGIN_DATA: "/tmp/sb-int", SUPERBRAIN_VAULT: "/tmp/sb-int-vault" },
+      SUPERBRAIN_DATA_DIR: "/tmp/sb-int", SUPERBRAIN_VAULT_DIR: "/tmp/sb-int-vault" },
     encoding: "utf8",
   });
   // checkpoint spawns the detached writer; give it a moment
@@ -33,6 +33,7 @@ it("real checkpoint path (no fake seam) writes a vault note and releases the loc
   const found = fs.existsSync(vault) && fs.readdirSync(vault, { recursive: true } as any)
     .some((f: any) => String(f).endsWith(".md"));
   expect(found).toBe(true);
-  expect(fs.readFileSync(`${vault}/log.md`, "utf8")).toMatch(/Use X/);
+  const today = new Date().toISOString().slice(0, 10);
+  expect(fs.readFileSync(`/tmp/sb-int/logs/${today}.log`, "utf8")).toMatch(/Use X/);
   expect(fs.existsSync("/tmp/sb-int/locks/distill.lock")).toBe(false);
 });

--- a/tests/lockfile.test.ts
+++ b/tests/lockfile.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { acquireLock, releaseLock } from "../src/lockfile";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-lock";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-lock";
   fs.rmSync("/tmp/sb-lock", { recursive: true, force: true });
 });
 

--- a/tests/mcpSearch.test.ts
+++ b/tests/mcpSearch.test.ts
@@ -4,7 +4,7 @@ import { openIndex } from "../src/searchIndex";
 import { handleSearch } from "../src/mcpSearch";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-mcps";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-mcps";
   process.env.SUPERBRAIN_EMBED_STUB = "1";
   fs.rmSync("/tmp/sb-mcps", { recursive: true, force: true });
   const ix = openIndex();

--- a/tests/ndjson.test.ts
+++ b/tests/ndjson.test.ts
@@ -4,7 +4,7 @@ import { appendEvent, readDelta } from "../src/ndjson";
 
 const SID = "sess1";
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-ndjson";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-ndjson";
   fs.rmSync("/tmp/sb-ndjson", { recursive: true, force: true });
 });
 

--- a/tests/observe.test.ts
+++ b/tests/observe.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => fs.rmSync("/tmp/sb-obs", { recursive: true, force: true }));
 function run(hookJson: object) {
   return execFileSync("npx", ["tsx", "bin/sb-observe.ts"], {
     input: JSON.stringify(hookJson),
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-obs" },
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-obs" },
     encoding: "utf8",
   });
 }
@@ -24,7 +24,7 @@ describe("sb-observe", () => {
   it("no-ops when recursion guard is set", () => {
     execFileSync("npx", ["tsx", "bin/sb-observe.ts"], {
       input: JSON.stringify({ session_id: "S2", hook_event_name: "PostToolUse", cwd: "/p", tool_name: "Read" }),
-      env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-obs", SUPERBRAIN_CHILD: "1" }, encoding: "utf8",
+      env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-obs", SUPERBRAIN_CHILD: "1" }, encoding: "utf8",
     });
     expect(fs.existsSync("/tmp/sb-obs/sessions/S2.ndjson")).toBe(false);
   });

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -3,8 +3,8 @@ import * as P from "../src/paths";
 
 describe("paths", () => {
   beforeEach(() => {
-    process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-test-data";
-    process.env.SUPERBRAIN_VAULT = "/tmp/sb-test-vault";
+    process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-test-data";
+    process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-test-vault";
   });
   it("derives data + vault + session paths", () => {
     expect(P.dataDir()).toBe("/tmp/sb-test-data");
@@ -16,8 +16,8 @@ describe("paths", () => {
     expect(P.lockDir("distill")).toBe("/tmp/sb-test-data/locks/distill.lock");
   });
   it("falls back to ~/.superbrain and ~/vault", () => {
-    delete process.env.CLAUDE_PLUGIN_DATA;
-    delete process.env.SUPERBRAIN_VAULT;
+    delete process.env.SUPERBRAIN_DATA_DIR;
+    delete process.env.SUPERBRAIN_VAULT_DIR;
     expect(P.dataDir()).toMatch(/\.superbrain$/);
     expect(P.vaultPath()).toMatch(/(vault|Documents\/SuperBrain)$/);
   });

--- a/tests/pathsResolution.test.ts
+++ b/tests/pathsResolution.test.ts
@@ -7,14 +7,14 @@ import { setRecordedVaultPath, isOwned } from "../src/vaultMarker";
 
 beforeEach(() => {
   fs.rmSync("/tmp/sb-pr-data", { recursive: true, force: true });
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-pr-data";
-  delete process.env.SUPERBRAIN_VAULT;
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-pr-data";
+  delete process.env.SUPERBRAIN_VAULT_DIR;
   delete process.env.CLAUDE_PLUGIN_ROOT;
 });
 
-it("SUPERBRAIN_VAULT wins and is marked", () => {
+it("SUPERBRAIN_VAULT_DIR wins and is marked", () => {
   fs.mkdirSync("/tmp/sb-pr-explicit", { recursive: true });
-  process.env.SUPERBRAIN_VAULT = "/tmp/sb-pr-explicit";
+  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-pr-explicit";
   expect(vaultPath()).toBe("/tmp/sb-pr-explicit");
   expect(isOwned("/tmp/sb-pr-explicit")).toBe(true);
 });

--- a/tests/phase3E2E.test.ts
+++ b/tests/phase3E2E.test.ts
@@ -22,7 +22,7 @@ it("pushback session yields a lesson note + reconciled preferences, injected nex
   fs.mkdirSync("/tmp/sb-e3/locks/distill.lock", { recursive: true });
 
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-e3", SUPERBRAIN_VAULT: "/tmp/sb-e3-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-e3", SUPERBRAIN_VAULT_DIR: "/tmp/sb-e3-vault",
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });
@@ -34,7 +34,7 @@ it("pushback session yields a lesson note + reconciled preferences, injected nex
 
   const out = execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S2", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-e3", SUPERBRAIN_VAULT: "/tmp/sb-e3-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-e3", SUPERBRAIN_VAULT_DIR: "/tmp/sb-e3-vault",
       SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/preferences.test.ts
+++ b/tests/preferences.test.ts
@@ -4,7 +4,7 @@ import { compileInjectionBlock } from "../src/preferences";
 
 beforeEach(() => {
   fs.rmSync("/tmp/sb-pref", { recursive: true, force: true });
-  process.env.SUPERBRAIN_VAULT = "/tmp/sb-pref";
+  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-pref";
 });
 
 it("returns '' when preferences.md is absent", () => {

--- a/tests/recall.test.ts
+++ b/tests/recall.test.ts
@@ -4,7 +4,7 @@ import { openIndex } from "../src/searchIndex";
 import { bm25Recall, hybridRecall } from "../src/recall";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-recall";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-recall";
   process.env.SUPERBRAIN_EMBED_STUB = "1";
   fs.rmSync("/tmp/sb-recall", { recursive: true, force: true });
   const ix = openIndex();

--- a/tests/recallCorruptDb.test.ts
+++ b/tests/recallCorruptDb.test.ts
@@ -11,14 +11,14 @@ beforeEach(() => {
   fs.mkdirSync(DIR, { recursive: true });
   // A non-sqlite file at the index path => openIndex()'s WAL pragma throws.
   fs.writeFileSync(`${DIR}/index.db`, "this is definitely not a sqlite database");
-  prevData = process.env.CLAUDE_PLUGIN_DATA;
+  prevData = process.env.SUPERBRAIN_DATA_DIR;
   prevStub = process.env.SUPERBRAIN_EMBED_STUB;
-  process.env.CLAUDE_PLUGIN_DATA = DIR;
+  process.env.SUPERBRAIN_DATA_DIR = DIR;
   process.env.SUPERBRAIN_EMBED_STUB = "1";
 });
 
 afterEach(() => {
-  if (prevData === undefined) delete process.env.CLAUDE_PLUGIN_DATA; else process.env.CLAUDE_PLUGIN_DATA = prevData;
+  if (prevData === undefined) delete process.env.SUPERBRAIN_DATA_DIR; else process.env.SUPERBRAIN_DATA_DIR = prevData;
   if (prevStub === undefined) delete process.env.SUPERBRAIN_EMBED_STUB; else process.env.SUPERBRAIN_EMBED_STUB = prevStub;
   fs.rmSync(DIR, { recursive: true, force: true });
 });

--- a/tests/rollupConvergence.test.ts
+++ b/tests/rollupConvergence.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
 
 it("daily rollup converges: real path triggers the writer at most once across repeated session starts", () => {
   const env = { ...process.env, PATH: `${BIN}:${process.env.PATH}`,
-    CLAUDE_PLUGIN_DATA: "/tmp/sb-conv", SUPERBRAIN_VAULT: "/tmp/sb-conv-vault",
+    SUPERBRAIN_DATA_DIR: "/tmp/sb-conv", SUPERBRAIN_VAULT_DIR: "/tmp/sb-conv-vault",
     SUPERBRAIN_EMBED_STUB: "1" };
   const input = JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" });
   for (let i = 0; i < 3; i++) {

--- a/tests/rollupState.test.ts
+++ b/tests/rollupState.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { needsRollup, markRollup } from "../src/rollupState";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-rollup";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-rollup";
   fs.rmSync("/tmp/sb-rollup", { recursive: true, force: true });
 });
 

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -8,6 +8,80 @@ describe("router", () => {
     expect(r.frontmatter.type).toBe("decision");
     expect(r.body).toContain("[[SuperBrain]]");
   });
+  it("assembles structured ADR sections when the distiller fills them", () => {
+    const r = route({
+      kind: "decision",
+      title: "Pin distiller model to Sonnet 4.6",
+      date: "2026-05-19",
+      context: "Legacy scribe burned Opus quota in hours.",
+      decision: "Hardcode --model claude-sonnet-4-6; no env override.",
+      rationale: "Sonnet 4.6 is ~1/5 the cost for comparable summarization quality.",
+      consequences: "Users wanting more must set ANTHROPIC_API_KEY.",
+      implementation: "src/distillRun.ts:distillModel() returns the literal.",
+      links: ["projects/superbrain"],
+    });
+    expect(r.body).toContain("## Context");
+    expect(r.body).toContain("## Decision");
+    expect(r.body).toContain("## Rationale");
+    expect(r.body).toContain("## Consequences");
+    expect(r.body).toContain("## Implementation");
+    expect(r.body).toContain("[[projects/superbrain]]");
+  });
+  it("omits empty sections in the structured ADR template", () => {
+    const r = route({
+      kind: "decision",
+      title: "X",
+      date: "2026-05-19",
+      context: "ctx",
+      decision: "d",
+      links: [],
+    });
+    expect(r.body).toContain("## Context");
+    expect(r.body).toContain("## Decision");
+    expect(r.body).not.toContain("## Rationale");
+    expect(r.body).not.toContain("## Consequences");
+    expect(r.body).not.toContain("## Implementation");
+  });
+  it("assembles structured lesson sections (Rule / Why / When)", () => {
+    const r = route({
+      kind: "lesson",
+      title: "Verify the live data dir",
+      date: "2026-05-20",
+      rule: "Resolve CLAUDE_PLUGIN_DATA at hook execution time.",
+      why: "A full misdiagnosis was produced after inspecting the source's fallback path.",
+      whenApplies: "Any time a Claude Code plugin appears to not be writing data.",
+      links: ["projects/superbrain"],
+    });
+    expect(r.relPath).toBe("lessons/2026-05-20-verify-the-live-data-dir.md");
+    expect(r.body).toContain("## Rule");
+    expect(r.body).toContain("## Why");
+    expect(r.body).toContain("## When this applies");
+  });
+  it("falls back to legacy body when structured lesson fields absent (back-compat)", () => {
+    const r = route({ kind: "lesson", title: "L", body: "incident details", date: "2026-05-19", links: [], rule: "always X" });
+    expect(r.body).toContain("**Why:** incident details");
+    expect(r.body).toContain("**Rule:** always X");
+  });
+  it("assembles structured gotcha sections under the project note", () => {
+    const r = route({
+      kind: "gotcha",
+      title: "ABI mismatch under Node 25",
+      date: "2026-05-19",
+      project: "superbrain",
+      symptom: "Every require('better-sqlite3') crashes silently.",
+      rootCause: "Node 25 ABI 141 has no published prebuild; npm ci installs source-only.",
+      fix: "npm rebuild better-sqlite3 after npm ci; verify .node binding loads.",
+      prevention: "depsPresent() must scan for .node files, not just the package dir.",
+      links: [],
+    });
+    expect(r.relPath).toBe("projects/superbrain.md");
+    expect(r.mode).toBe("append");
+    expect(r.body).toContain("## Gotcha — ABI mismatch under Node 25");
+    expect(r.body).toContain("## Symptom");
+    expect(r.body).toContain("## Root cause");
+    expect(r.body).toContain("## Fix");
+    expect(r.body).toContain("## Prevention");
+  });
   it("routes a project fact to projects/<slug>.md append", () => {
     const r = route({ kind: "project_fact", project: "Super Brain", title: "deadline", body: "ship June", date: "2026-05-19", links: [] });
     expect(r.relPath).toBe("projects/super-brain.md");

--- a/tests/sbAdopt.test.ts
+++ b/tests/sbAdopt.test.ts
@@ -6,12 +6,12 @@ beforeEach(() => {
   fs.rmSync("/tmp/sb-am", { recursive: true, force: true });
   fs.rmSync("/tmp/sb-am-home", { recursive: true, force: true });
   fs.rmSync("/tmp/sb-am-vault", { recursive: true, force: true });
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-am";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-am";
 });
 
 function run(args: string[], env: Record<string,string> = {}) {
   return execFileSync("npx", ["tsx", "bin/sb.ts", ...args], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-am", ...env }, encoding: "utf8" });
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-am", ...env }, encoding: "utf8" });
 }
 
 it("adopt marks + records a writable dir, refuses a file", () => {

--- a/tests/sbDistillNoDeps.test.ts
+++ b/tests/sbDistillNoDeps.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 it("sb-distill releases the lock and exits 0 when deps absent", () => {
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-dnd",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-dnd",
       CLAUDE_PLUGIN_ROOT: "/tmp/sb-dnd-empty", SUPERBRAIN_SESSION_ID: "S" },
     encoding: "utf8",
   });

--- a/tests/sbMcp.test.ts
+++ b/tests/sbMcp.test.ts
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { openIndex } from "../src/searchIndex";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-mcp";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-mcp";
   process.env.SUPERBRAIN_EMBED_STUB = "1";
   fs.rmSync("/tmp/sb-mcp", { recursive: true, force: true });
   const ix = openIndex();

--- a/tests/sbRecall.test.ts
+++ b/tests/sbRecall.test.ts
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { openIndex } from "../src/searchIndex";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-rh";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-rh";
   process.env.SUPERBRAIN_EMBED_STUB = "1";
   fs.rmSync("/tmp/sb-rh", { recursive: true, force: true });
   const ix = openIndex();

--- a/tests/searchIndex.test.ts
+++ b/tests/searchIndex.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import fs from "node:fs";
 import { openIndex, rrf } from "../src/searchIndex";
 
-beforeEach(() => { process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-idx"; fs.rmSync("/tmp/sb-idx", { recursive: true, force: true }); });
+beforeEach(() => { process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-idx"; fs.rmSync("/tmp/sb-idx", { recursive: true, force: true }); });
 
 const vec = (n: number) => Float32Array.from(Array(384).fill(n));
 

--- a/tests/sentinel.test.ts
+++ b/tests/sentinel.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { writeFailure, readAndClearFailure } from "../src/sentinel";
 
 beforeEach(() => {
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-sentinel";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-sentinel";
   fs.rmSync("/tmp/sb-sentinel", { recursive: true, force: true });
 });
 

--- a/tests/sessionStart.test.ts
+++ b/tests/sessionStart.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => fs.rmSync("/tmp/sb-ss", { recursive: true, force: true }));
 function run() {
   return execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-ss", SUPERBRAIN_VAULT: "/tmp/sb-ss-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ss", SUPERBRAIN_VAULT_DIR: "/tmp/sb-ss-vault",
            SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/sessionStartBootstrap.test.ts
+++ b/tests/sessionStartBootstrap.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 it("no deps: emits first-time-setup notice, exits 0, does NOT crash", () => {
   const out = execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-ssb", CLAUDE_PLUGIN_ROOT: "/tmp/sb-ssb-empty",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ssb", CLAUDE_PLUGIN_ROOT: "/tmp/sb-ssb-empty",
       SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });

--- a/tests/sessionStartDigest.test.ts
+++ b/tests/sessionStartDigest.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
   fs.rmSync("/tmp/sb-ssd", { recursive: true, force: true });
   fs.rmSync("/tmp/sb-ssd-vault", { recursive: true, force: true });
   process.env.SUPERBRAIN_EMBED_STUB = "1";
-  const old = process.env.CLAUDE_PLUGIN_DATA; process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-ssd";
+  const old = process.env.SUPERBRAIN_DATA_DIR; process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-ssd";
   const ix = openIndex();
   // Fixture text includes "recent work" so that BM25 OR-query tokens from the seed
   // ("recent", "work") lexically overlap the indexed content — required because hybridRecall
@@ -16,13 +16,13 @@ beforeEach(() => {
   ix.upsertNote("projects/super-brain.md", 1, "h",
     [{ headingPath: "Status", anchor: "status", text: "recent work: phase 1 shipped; phase 2 adds hybrid search" }],
     [Float32Array.from(Array(384).fill(0.6))]);
-  ix.close(); process.env.CLAUDE_PLUGIN_DATA = old;
+  ix.close(); process.env.SUPERBRAIN_DATA_DIR = old;
 });
 
 it("SessionStart emits a hybrid recall digest in additionalContext", () => {
   const out = execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-ssd", SUPERBRAIN_VAULT: "/tmp/sb-ssd-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ssd", SUPERBRAIN_VAULT_DIR: "/tmp/sb-ssd-vault",
            SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/sessionStartPrefs.test.ts
+++ b/tests/sessionStartPrefs.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 it("SessionStart injects compiled preferences and today's open threads", () => {
   const out = execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, CLAUDE_PLUGIN_DATA: "/tmp/sb-ssp", SUPERBRAIN_VAULT: "/tmp/sb-ssp-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ssp", SUPERBRAIN_VAULT_DIR: "/tmp/sb-ssp-vault",
       SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/vaultMarker.test.ts
+++ b/tests/vaultMarker.test.ts
@@ -5,7 +5,7 @@ import { MARKER, isOwned, markOwned, recordedVaultPath, setRecordedVaultPath } f
 beforeEach(() => {
   fs.rmSync("/tmp/sb-vm", { recursive: true, force: true });
   fs.rmSync("/tmp/sb-vm-data", { recursive: true, force: true });
-  process.env.CLAUDE_PLUGIN_DATA = "/tmp/sb-vm-data";
+  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-vm-data";
 });
 
 it("markOwned writes the marker; isOwned detects it", () => {

--- a/tests/vaultWriter.test.ts
+++ b/tests/vaultWriter.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { writeNote, softDelete } from "../src/vaultWriter";
 
 beforeEach(() => {
-  process.env.SUPERBRAIN_VAULT = "/tmp/sb-vault";
+  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-vault";
   fs.rmSync("/tmp/sb-vault", { recursive: true, force: true });
 });
 

--- a/tests/vaultWriterReplace.test.ts
+++ b/tests/vaultWriterReplace.test.ts
@@ -5,7 +5,7 @@ import { parseNote } from "../src/frontmatter";
 
 beforeEach(() => {
   fs.rmSync("/tmp/sb-vwr", { recursive: true, force: true });
-  process.env.SUPERBRAIN_VAULT = "/tmp/sb-vwr";
+  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-vwr";
 });
 
 it("replace creates when absent", () => {


### PR DESCRIPTION
## Summary

Three coordinated changes that prepare SuperBrain for trial users.

### 1. Vault path unification

Previously, hook scripts read CLAUDE_PLUGIN_DATA (set by Claude Code to ~/.claude/plugins/data/superbrain-m3talux/) while user-invoked entrypoints like /superbrain:migrate ran without that env var set and fell back to ~/.superbrain. Result: distillation wrote to one vault, migration to another, and Obsidian could see neither without manual setup.

Now: dataDir() and vaultPath() hardcode ~/.superbrain and ~/.superbrain/vault in production. CLAUDE_PLUGIN_DATA, SUPERBRAIN_VAULT, and SUPERBRAIN_MODEL are dropped from production code. Tests use new SUPERBRAIN_DATA_DIR / SUPERBRAIN_VAULT_DIR test-only seams that Claude Code never sets.

README gains a Vault setup section: /superbrain:migrate is the preferred path; /superbrain:adopt is the advanced fallback for established vaults.

### 2. Note quality (legacy-scribe parity)

New distiller prompt with per-kind emission thresholds, structured field requirements, two few-shot examples, and a hard rule that distiller behavior is never written as a user preference.

DistilledItem gains optional structured fields (context/decision/rationale/consequences/implementation for decisions; symptom/rootCause/fix/prevention for gotchas; rule/why/whenApplies for lessons). Router assembles ADR-style templates when present; falls back to legacy body otherwise.

skills/superbrain-distill/SKILL.md synced.

### 3. Per-day write logs out of the vault

vault/log.md (unbounded append-only file inside the user's vault) moved to ~/.superbrain/logs/<date>.log. README split into Vault (user notes only) and System telemetry sections.

## Test plan

- [x] typecheck clean
- [x] build clean
- [x] 153/153 tests pass (was 148; +5 new router structural tests)
- [x] dist/ regenerated and committed
- [x] live install patched in-session, NDJSON now writes to ~/.superbrain/sessions/
- [x] data reconciliation: 130 files copied + 3 merged from former CPD dir
- [x] vault/log.md migrated to per-day .log files; source moved to .bak

## Known follow-ups (NOT in this PR)

- Per-project auto-discovery on first session (separate PR — new feature)
- Adopt end-to-end test
- Migrate non-destructive CI assertion (source mtimes unchanged)
- Extend-don't-recreate for decisions and lessons
- Cost optimizations (prompt caching; Haiku evaluation for the distiller — open question raised by maintainer post-commit)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
