### PR TITLE
feat: one-shot project discovery on first session in an unknown repo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ flowchart LR
 **Capture**
 
 - ✅ Globally installed, zero per-project setup, **no API key** (reuses your Claude Code auth)
+- ✅ **One-shot project discovery** on first session in an unknown repo: walks the tree, reads the manifests + CLAUDE.md + README, asks one Sonnet call to produce a substantive `projects/<slug>.md` (stack / architecture / top-level folders / key files / docs / conventions / open questions). Once per project, ever. Never overwrites an existing note.
 - ✅ Automatic capture that does **not** degrade on multi-day sessions
 - ✅ Plain Obsidian markdown — wikilinks, frontmatter, fully `git`-portable, zero lock-in
 - ✅ Smart router: decisions / project facts / people / gotchas / triage capture

--- a/bin/sb-discover.ts
+++ b/bin/sb-discover.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { runDiscover } from "../src/discoverer.js";
+import { depsPresent } from "../src/bootstrap.js";
+import { pluginRoot } from "../src/paths.js";
+
+// Detached, lock-serialized project discoverer. Spawned by sb-session-start
+// the first time a session opens in an unknown project. Fire-and-forget —
+// failures land in the sentinel, never the user's session.
+async function main() {
+  if (!depsPresent(pluginRoot())) { process.exit(0); }
+  const projectDir = process.env.SUPERBRAIN_PROJECT_DIR
+    || process.env.CLAUDE_PROJECT_DIR
+    || process.cwd();
+  try { await runDiscover(projectDir); } catch { /* sentinel handles errors inside runDiscover */ }
+  process.exit(0);
+}
+if ((process.argv[1] && process.argv[1].endsWith("sb-discover.ts")) || process.argv[1]?.endsWith("sb-discover.js")) main();

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -13,7 +13,7 @@ async function main() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
-  const server = new McpServer({ name: "superbrain", version: "0.2.0" });
+  const server = new McpServer({ name: "superbrain", version: "0.3.0" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).",

--- a/bin/sb-session-start.ts
+++ b/bin/sb-session-start.ts
@@ -9,6 +9,7 @@ import { dataDir, vaultPath, pluginRoot } from "../src/paths.js";
 import { isChild, buildDistillCommand } from "../src/distillerEngine.js";
 import { depsPresent, runBootstrap } from "../src/bootstrap.js";
 import { recordedVaultPath } from "../src/vaultMarker.js";
+import { isUnknownProject, looksLikeCodeProject } from "../src/discoverer.js";
 
 // Stable per-day gate value. The rollup's own writes cannot change this string,
 // so needsRollup returns false for an already-processed key → converges.
@@ -78,6 +79,24 @@ async function main() {
           detached: true, stdio: "ignore",
           env: { ...process.env, SUPERBRAIN_CHILD: "1" }, cwd: vaultPath(),
         }).unref();
+      } catch { /* non-fatal */ }
+    }
+
+    // First-time project discovery: if this session opened in a project we
+    // have no note for yet, spawn a one-shot detached discoverer. Runs at
+    // most once per project (the existence of the project note is the gate)
+    // and never blocks the session. Failures land in the sentinel.
+    if (process.env.SUPERBRAIN_FAKE_DISTILLER !== "1" && depsPresent(root)) {
+      try {
+        const projectDir = h.cwd || process.env.CLAUDE_PROJECT_DIR;
+        if (projectDir && looksLikeCodeProject(projectDir) && isUnknownProject(projectDir)) {
+          const discoverer = fileURLToPath(new URL("./sb-discover.js", import.meta.url));
+          spawn(process.execPath, [discoverer], {
+            detached: true, stdio: "ignore",
+            env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PROJECT_DIR: projectDir },
+          }).unref();
+          parts.push(`SuperBrain is mapping this project for the first time — a project note will appear in the vault shortly.`);
+        }
       } catch { /* non-fatal */ }
     }
 

--- a/dist/bin/sb-discover.js
+++ b/dist/bin/sb-discover.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { runDiscover } from "../src/discoverer.js";
+import { depsPresent } from "../src/bootstrap.js";
+import { pluginRoot } from "../src/paths.js";
+// Detached, lock-serialized project discoverer. Spawned by sb-session-start
+// the first time a session opens in an unknown project. Fire-and-forget —
+// failures land in the sentinel, never the user's session.
+async function main() {
+    if (!depsPresent(pluginRoot())) {
+        process.exit(0);
+    }
+    const projectDir = process.env.SUPERBRAIN_PROJECT_DIR
+        || process.env.CLAUDE_PROJECT_DIR
+        || process.cwd();
+    try {
+        await runDiscover(projectDir);
+    }
+    catch { /* sentinel handles errors inside runDiscover */ }
+    process.exit(0);
+}
+if ((process.argv[1] && process.argv[1].endsWith("sb-discover.ts")) || process.argv[1]?.endsWith("sb-discover.js"))
+    main();

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -12,7 +12,7 @@ async function main() {
     const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
-    const server = new McpServer({ name: "superbrain", version: "0.2.0" });
+    const server = new McpServer({ name: "superbrain", version: "0.3.0" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).", { query: z.string(), k: z.number().optional() }, async ({ query, k }) => (await handleSearch({ query, k })));
     const transport = new StdioServerTransport();
     server.connect(transport).catch(() => process.exit(1));

--- a/dist/bin/sb-session-start.js
+++ b/dist/bin/sb-session-start.js
@@ -9,6 +9,7 @@ import { dataDir, vaultPath, pluginRoot } from "../src/paths.js";
 import { isChild, buildDistillCommand } from "../src/distillerEngine.js";
 import { depsPresent, runBootstrap } from "../src/bootstrap.js";
 import { recordedVaultPath } from "../src/vaultMarker.js";
+import { isUnknownProject, looksLikeCodeProject } from "../src/discoverer.js";
 // Stable per-day gate value. The rollup's own writes cannot change this string,
 // so needsRollup returns false for an already-processed key → converges.
 const ROLLUP_HASH = "v1";
@@ -91,6 +92,24 @@ async function main() {
                     detached: true, stdio: "ignore",
                     env: { ...process.env, SUPERBRAIN_CHILD: "1" }, cwd: vaultPath(),
                 }).unref();
+            }
+            catch { /* non-fatal */ }
+        }
+        // First-time project discovery: if this session opened in a project we
+        // have no note for yet, spawn a one-shot detached discoverer. Runs at
+        // most once per project (the existence of the project note is the gate)
+        // and never blocks the session. Failures land in the sentinel.
+        if (process.env.SUPERBRAIN_FAKE_DISTILLER !== "1" && depsPresent(root)) {
+            try {
+                const projectDir = h.cwd || process.env.CLAUDE_PROJECT_DIR;
+                if (projectDir && looksLikeCodeProject(projectDir) && isUnknownProject(projectDir)) {
+                    const discoverer = fileURLToPath(new URL("./sb-discover.js", import.meta.url));
+                    spawn(process.execPath, [discoverer], {
+                        detached: true, stdio: "ignore",
+                        env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PROJECT_DIR: projectDir },
+                    }).unref();
+                    parts.push(`SuperBrain is mapping this project for the first time — a project note will appear in the vault shortly.`);
+                }
             }
             catch { /* non-fatal */ }
         }

--- a/dist/src/discoverer.js
+++ b/dist/src/discoverer.js
@@ -1,0 +1,225 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { vaultPath } from "./paths.js";
+import { slug } from "./router.js";
+import { acquireLock, releaseLock } from "./lockfile.js";
+import { writeFailure } from "./sentinel.js";
+import { distillModel } from "./model.js";
+// Discovery: on a session opening in a project we've never seen before,
+// produce ~/.superbrain/vault/projects/<slug>.md with a substantive code map
+// the next session can read. One Sonnet call per project, ever. After that
+// the note is "known" (its existence is the gate) and further distillation
+// only appends to it via the normal router path.
+// Directories the walk always skips. Heavy, vendored, or build output —
+// adding them to the prompt context would just blow the token budget.
+const HEAVY_DIRS = new Set([
+    "node_modules", ".git", "dist", "build", "out", "target", "vendor",
+    "__pycache__", ".venv", "venv", ".next", ".nuxt", ".turbo",
+    ".cache", ".idea", ".vscode", "coverage", ".pytest_cache",
+    ".gradle", ".mvn", "bin", "obj",
+]);
+// Hard caps so a giant repo never spirals.
+const MAX_FILES = 600;
+const MAX_DEPTH = 5;
+const MAX_MANIFEST_BYTES = 8192;
+// Files read in full to anchor the discovery prompt context.
+const MANIFEST_FILES = [
+    "README.md", "README.rst", "README", "README.txt",
+    "package.json", "pyproject.toml", "Cargo.toml", "go.mod",
+    "requirements.txt", "Gemfile", "composer.json", "pom.xml", "build.gradle",
+    "tsconfig.json", "Makefile", "Dockerfile", "docker-compose.yml",
+    "CLAUDE.md", ".claude.md", "AGENTS.md", "CONTRIBUTING.md",
+    "LICENSE", "LICENSE.md",
+];
+export function projectSlug(projectDir) {
+    return slug(path.basename(projectDir));
+}
+export function projectNotePath(projectDir) {
+    return path.join(vaultPath(), "projects", `${projectSlug(projectDir)}.md`);
+}
+// "Unknown" = no project note exists yet. Once discovery (or any distillation)
+// has produced the file, we never re-discover — that protects user edits and
+// avoids ever burning tokens twice on the same project.
+export function isUnknownProject(projectDir) {
+    try {
+        return !fs.existsSync(projectNotePath(projectDir));
+    }
+    catch {
+        return false;
+    }
+}
+// Heuristic gate: don't trigger discovery on directories that aren't actually
+// code projects (the user's home, a random tmp dir, etc.).
+export function looksLikeCodeProject(projectDir) {
+    try {
+        if (fs.existsSync(path.join(projectDir, ".git")))
+            return true;
+        for (const name of MANIFEST_FILES) {
+            if (fs.existsSync(path.join(projectDir, name)))
+                return true;
+        }
+        return false;
+    }
+    catch {
+        return false;
+    }
+}
+function walkBounded(root) {
+    const out = [];
+    let truncated = false;
+    const queue = [{ dir: root, depth: 0 }];
+    while (queue.length) {
+        if (out.length >= MAX_FILES) {
+            truncated = true;
+            break;
+        }
+        const { dir, depth } = queue.shift();
+        if (depth > MAX_DEPTH)
+            continue;
+        let entries = [];
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        }
+        catch {
+            continue;
+        }
+        for (const e of entries) {
+            // Skip hidden entries except .github (workflows are signal).
+            if (e.name.startsWith(".") && e.name !== ".github")
+                continue;
+            if (HEAVY_DIRS.has(e.name))
+                continue;
+            const full = path.join(dir, e.name);
+            if (e.isDirectory()) {
+                queue.push({ dir: full, depth: depth + 1 });
+            }
+            else if (e.isFile()) {
+                out.push(path.relative(root, full));
+                if (out.length >= MAX_FILES) {
+                    truncated = true;
+                    break;
+                }
+            }
+        }
+    }
+    return { paths: out, truncated };
+}
+function readManifests(root) {
+    const out = [];
+    for (const name of MANIFEST_FILES) {
+        const p = path.join(root, name);
+        try {
+            const stat = fs.statSync(p);
+            if (!stat.isFile())
+                continue;
+            const raw = fs.readFileSync(p, "utf8");
+            out.push({ name, content: raw.slice(0, MAX_MANIFEST_BYTES) });
+        }
+        catch { /* absent — skip */ }
+    }
+    return out;
+}
+const DISCOVERY_PROMPT_PREFIX = `You are SuperBrain's project discoverer. You receive a project's manifest files (README, package manifests, CLAUDE.md, Dockerfile, etc.) and a bounded list of source-file paths under it. Produce a substantive project note that a future Claude Code session would read to bootstrap context.
+
+# Hard rules
+
+1. Output ONLY the markdown body of the project note — no prose around it, no backticks fencing the entire output.
+2. Start with the project name as an H1, then the sections below in order.
+3. Be specific. Extract claims from the actual manifests and file list, not generic templates. If something is genuinely unknown, write "Unknown" rather than guess.
+4. Keep the whole note under 600 lines.
+
+# Required sections (in this exact order)
+
+# <Project name from manifests, or directory name>
+
+> One-sentence elevator description (from README, package description, or inferred from the file list).
+
+## Stack
+- Primary language(s).
+- Framework(s) / runtime / build system.
+- Package manager(s).
+- 3–7 load-bearing libraries if visible.
+
+## Architecture
+One or two paragraphs describing the architectural pattern (monolith, microservices, library, CLI, framework adapter, etc.), the entry point(s), and the dataflow at a high level. Cite specific files where useful.
+
+## Top-level folders
+A bullet per top-level folder explaining what lives there and what it owns. Skip vendored/build dirs.
+
+## Key files
+3–10 bullets pointing to the most load-bearing files. Format: \`path/to/file.ext\` — one-line purpose.
+
+## Docs
+Pointers to documentation that exists in the repo (README, CONTRIBUTING, docs/, design docs). If there is none, write "None at this layer".
+
+## Conventions
+Anything visible about the project's conventions: linting, formatting, test runner, CI workflow, commit style, branch model. If unknown, "Unknown".
+
+## Open questions
+Things a new contributor would still need to ask. Be concrete — not "what does it do" but "what is the relationship between X and Y" or "is Z deprecated in favor of W".
+
+`;
+export function buildDiscoveryPrompt(input) {
+    const parts = [DISCOVERY_PROMPT_PREFIX];
+    parts.push(`# Project directory\n\n\`${input.projectDir}\`\n`);
+    parts.push(`# Manifest files\n`);
+    for (const m of input.manifests) {
+        parts.push(`## ${m.name}\n\n\`\`\`\n${m.content}\n\`\`\`\n`);
+    }
+    parts.push(`# Source file paths (${input.paths.length}${input.truncated ? `, TRUNCATED at ${MAX_FILES}` : ""})\n`);
+    parts.push("```\n" + input.paths.join("\n") + "\n```\n");
+    return parts.join("\n");
+}
+function callClaudeForDiscovery(prompt) {
+    if (process.env.SUPERBRAIN_DISCOVER_STUB) {
+        return fs.readFileSync(process.env.SUPERBRAIN_DISCOVER_STUB, "utf8");
+    }
+    return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
+}
+export async function runDiscover(projectDir) {
+    if (!projectDir || !fs.existsSync(projectDir))
+        return;
+    if (!looksLikeCodeProject(projectDir))
+        return;
+    if (!isUnknownProject(projectDir))
+        return;
+    if (!acquireLock("discover"))
+        return;
+    try {
+        const { paths, truncated } = walkBounded(projectDir);
+        const manifests = readManifests(projectDir);
+        const prompt = buildDiscoveryPrompt({ projectDir, manifests, paths, truncated });
+        const body = callClaudeForDiscovery(prompt).trim();
+        if (!body) {
+            writeFailure(`discovery returned empty body for ${projectDir}`);
+            return;
+        }
+        const date = new Date().toISOString().slice(0, 10);
+        const frontmatter = [
+            "---",
+            "type: project",
+            "status: active",
+            `project: ${projectSlug(projectDir)}`,
+            `project_dir: ${JSON.stringify(projectDir)}`,
+            "discovered: true",
+            `created: '${date}'`,
+            `updated: '${date}'`,
+            "superbrain: true",
+            "---",
+            "",
+        ].join("\n");
+        const notePath = projectNotePath(projectDir);
+        fs.mkdirSync(path.dirname(notePath), { recursive: true });
+        fs.writeFileSync(notePath, frontmatter + body + "\n");
+    }
+    catch (e) {
+        try {
+            writeFailure(`discovery failed for ${projectDir}: ${e?.message || e}`);
+        }
+        catch { /* noop */ }
+    }
+    finally {
+        releaseLock("discover");
+    }
+}

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -1,15 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { distillModel } from "./model.js";
+export { distillModel };
 // Pin the model on every detached `claude -p` distill/rollup spawn so it never
-// inherits the user's session model (which is often Opus, and burns daily
-// quota in hours — exactly the legacy-scribe bug we replaced). Sonnet 4.6
-// balances quality (the distiller IS the product — the vault is only as good
-// as the routed notes it writes) against cost (~1/5 of Opus). No env override:
-// users should not need to think about model selection.
-export function distillModel() {
-    return "claude-sonnet-4-6";
-}
+// inherits the user's session model (often Opus, which burned the legacy
+// scribe's daily quota in hours). Sonnet 4.6 balances quality (the distiller
+// IS the product — the vault is only as good as the routed notes it writes)
+// against cost (~1/3 of Opus). No env override: users should not need to
+// think about model selection. The model constant lives in src/model.ts so
+// import-safe entrypoints can read it without pulling the rest of the
+// distill graph through gray-matter etc.
 function callClaude(prompt) {
     return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
 }

--- a/dist/src/model.js
+++ b/dist/src/model.js
@@ -1,0 +1,8 @@
+// Hardcoded model for every detached `claude -p` spawn (distill, daily
+// rollup, project discovery). Sonnet 4.6 — see src/distillRun.ts for the
+// full rationale. Kept in its own tiny module with no deps so import-safe
+// entrypoints (bin/*) can reference it without pulling vaultWriter →
+// gray-matter into the load graph before depsPresent() runs.
+export function distillModel() {
+    return "claude-sonnet-4-6";
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",

--- a/src/discoverer.ts
+++ b/src/discoverer.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { vaultPath } from "./paths.js";
+import { slug } from "./router.js";
+import { acquireLock, releaseLock } from "./lockfile.js";
+import { writeFailure } from "./sentinel.js";
+import { distillModel } from "./model.js";
+
+// Discovery: on a session opening in a project we've never seen before,
+// produce ~/.superbrain/vault/projects/<slug>.md with a substantive code map
+// the next session can read. One Sonnet call per project, ever. After that
+// the note is "known" (its existence is the gate) and further distillation
+// only appends to it via the normal router path.
+
+// Directories the walk always skips. Heavy, vendored, or build output —
+// adding them to the prompt context would just blow the token budget.
+const HEAVY_DIRS = new Set([
+  "node_modules", ".git", "dist", "build", "out", "target", "vendor",
+  "__pycache__", ".venv", "venv", ".next", ".nuxt", ".turbo",
+  ".cache", ".idea", ".vscode", "coverage", ".pytest_cache",
+  ".gradle", ".mvn", "bin", "obj",
+]);
+
+// Hard caps so a giant repo never spirals.
+const MAX_FILES = 600;
+const MAX_DEPTH = 5;
+const MAX_MANIFEST_BYTES = 8192;
+
+// Files read in full to anchor the discovery prompt context.
+const MANIFEST_FILES = [
+  "README.md", "README.rst", "README", "README.txt",
+  "package.json", "pyproject.toml", "Cargo.toml", "go.mod",
+  "requirements.txt", "Gemfile", "composer.json", "pom.xml", "build.gradle",
+  "tsconfig.json", "Makefile", "Dockerfile", "docker-compose.yml",
+  "CLAUDE.md", ".claude.md", "AGENTS.md", "CONTRIBUTING.md",
+  "LICENSE", "LICENSE.md",
+];
+
+export function projectSlug(projectDir: string): string {
+  return slug(path.basename(projectDir));
+}
+
+export function projectNotePath(projectDir: string): string {
+  return path.join(vaultPath(), "projects", `${projectSlug(projectDir)}.md`);
+}
+
+// "Unknown" = no project note exists yet. Once discovery (or any distillation)
+// has produced the file, we never re-discover — that protects user edits and
+// avoids ever burning tokens twice on the same project.
+export function isUnknownProject(projectDir: string): boolean {
+  try { return !fs.existsSync(projectNotePath(projectDir)); }
+  catch { return false; }
+}
+
+// Heuristic gate: don't trigger discovery on directories that aren't actually
+// code projects (the user's home, a random tmp dir, etc.).
+export function looksLikeCodeProject(projectDir: string): boolean {
+  try {
+    if (fs.existsSync(path.join(projectDir, ".git"))) return true;
+    for (const name of MANIFEST_FILES) {
+      if (fs.existsSync(path.join(projectDir, name))) return true;
+    }
+    return false;
+  } catch { return false; }
+}
+
+interface WalkResult { paths: string[]; truncated: boolean; }
+function walkBounded(root: string): WalkResult {
+  const out: string[] = [];
+  let truncated = false;
+  const queue: Array<{ dir: string; depth: number }> = [{ dir: root, depth: 0 }];
+  while (queue.length) {
+    if (out.length >= MAX_FILES) { truncated = true; break; }
+    const { dir, depth } = queue.shift()!;
+    if (depth > MAX_DEPTH) continue;
+    let entries: fs.Dirent[] = [];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      // Skip hidden entries except .github (workflows are signal).
+      if (e.name.startsWith(".") && e.name !== ".github") continue;
+      if (HEAVY_DIRS.has(e.name)) continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        queue.push({ dir: full, depth: depth + 1 });
+      } else if (e.isFile()) {
+        out.push(path.relative(root, full));
+        if (out.length >= MAX_FILES) { truncated = true; break; }
+      }
+    }
+  }
+  return { paths: out, truncated };
+}
+
+interface Manifest { name: string; content: string; }
+function readManifests(root: string): Manifest[] {
+  const out: Manifest[] = [];
+  for (const name of MANIFEST_FILES) {
+    const p = path.join(root, name);
+    try {
+      const stat = fs.statSync(p);
+      if (!stat.isFile()) continue;
+      const raw = fs.readFileSync(p, "utf8");
+      out.push({ name, content: raw.slice(0, MAX_MANIFEST_BYTES) });
+    } catch { /* absent — skip */ }
+  }
+  return out;
+}
+
+const DISCOVERY_PROMPT_PREFIX = `You are SuperBrain's project discoverer. You receive a project's manifest files (README, package manifests, CLAUDE.md, Dockerfile, etc.) and a bounded list of source-file paths under it. Produce a substantive project note that a future Claude Code session would read to bootstrap context.
+
+# Hard rules
+
+1. Output ONLY the markdown body of the project note — no prose around it, no backticks fencing the entire output.
+2. Start with the project name as an H1, then the sections below in order.
+3. Be specific. Extract claims from the actual manifests and file list, not generic templates. If something is genuinely unknown, write "Unknown" rather than guess.
+4. Keep the whole note under 600 lines.
+
+# Required sections (in this exact order)
+
+# <Project name from manifests, or directory name>
+
+> One-sentence elevator description (from README, package description, or inferred from the file list).
+
+## Stack
+- Primary language(s).
+- Framework(s) / runtime / build system.
+- Package manager(s).
+- 3–7 load-bearing libraries if visible.
+
+## Architecture
+One or two paragraphs describing the architectural pattern (monolith, microservices, library, CLI, framework adapter, etc.), the entry point(s), and the dataflow at a high level. Cite specific files where useful.
+
+## Top-level folders
+A bullet per top-level folder explaining what lives there and what it owns. Skip vendored/build dirs.
+
+## Key files
+3–10 bullets pointing to the most load-bearing files. Format: \`path/to/file.ext\` — one-line purpose.
+
+## Docs
+Pointers to documentation that exists in the repo (README, CONTRIBUTING, docs/, design docs). If there is none, write "None at this layer".
+
+## Conventions
+Anything visible about the project's conventions: linting, formatting, test runner, CI workflow, commit style, branch model. If unknown, "Unknown".
+
+## Open questions
+Things a new contributor would still need to ask. Be concrete — not "what does it do" but "what is the relationship between X and Y" or "is Z deprecated in favor of W".
+
+`;
+
+interface BuildPromptInput {
+  projectDir: string;
+  manifests: Manifest[];
+  paths: string[];
+  truncated: boolean;
+}
+
+export function buildDiscoveryPrompt(input: BuildPromptInput): string {
+  const parts: string[] = [DISCOVERY_PROMPT_PREFIX];
+  parts.push(`# Project directory\n\n\`${input.projectDir}\`\n`);
+  parts.push(`# Manifest files\n`);
+  for (const m of input.manifests) {
+    parts.push(`## ${m.name}\n\n\`\`\`\n${m.content}\n\`\`\`\n`);
+  }
+  parts.push(`# Source file paths (${input.paths.length}${input.truncated ? `, TRUNCATED at ${MAX_FILES}` : ""})\n`);
+  parts.push("```\n" + input.paths.join("\n") + "\n```\n");
+  return parts.join("\n");
+}
+
+function callClaudeForDiscovery(prompt: string): string {
+  if (process.env.SUPERBRAIN_DISCOVER_STUB) {
+    return fs.readFileSync(process.env.SUPERBRAIN_DISCOVER_STUB, "utf8");
+  }
+  return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
+}
+
+export async function runDiscover(projectDir: string): Promise<void> {
+  if (!projectDir || !fs.existsSync(projectDir)) return;
+  if (!looksLikeCodeProject(projectDir)) return;
+  if (!isUnknownProject(projectDir)) return;
+
+  if (!acquireLock("discover")) return;
+  try {
+    const { paths, truncated } = walkBounded(projectDir);
+    const manifests = readManifests(projectDir);
+    const prompt = buildDiscoveryPrompt({ projectDir, manifests, paths, truncated });
+    const body = callClaudeForDiscovery(prompt).trim();
+    if (!body) {
+      writeFailure(`discovery returned empty body for ${projectDir}`);
+      return;
+    }
+    const date = new Date().toISOString().slice(0, 10);
+    const frontmatter = [
+      "---",
+      "type: project",
+      "status: active",
+      `project: ${projectSlug(projectDir)}`,
+      `project_dir: ${JSON.stringify(projectDir)}`,
+      "discovered: true",
+      `created: '${date}'`,
+      `updated: '${date}'`,
+      "superbrain: true",
+      "---",
+      "",
+    ].join("\n");
+    const notePath = projectNotePath(projectDir);
+    fs.mkdirSync(path.dirname(notePath), { recursive: true });
+    fs.writeFileSync(notePath, frontmatter + body + "\n");
+  } catch (e: any) {
+    try { writeFailure(`discovery failed for ${projectDir}: ${e?.message || e}`); } catch { /* noop */ }
+  } finally {
+    releaseLock("discover");
+  }
+}

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -1,16 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { distillModel } from "./model.js";
+export { distillModel };
 
 // Pin the model on every detached `claude -p` distill/rollup spawn so it never
-// inherits the user's session model (which is often Opus, and burns daily
-// quota in hours — exactly the legacy-scribe bug we replaced). Sonnet 4.6
-// balances quality (the distiller IS the product — the vault is only as good
-// as the routed notes it writes) against cost (~1/5 of Opus). No env override:
-// users should not need to think about model selection.
-export function distillModel(): string {
-  return "claude-sonnet-4-6";
-}
+// inherits the user's session model (often Opus, which burned the legacy
+// scribe's daily quota in hours). Sonnet 4.6 balances quality (the distiller
+// IS the product — the vault is only as good as the routed notes it writes)
+// against cost (~1/3 of Opus). No env override: users should not need to
+// think about model selection. The model constant lives in src/model.ts so
+// import-safe entrypoints can read it without pulling the rest of the
+// distill graph through gray-matter etc.
 function callClaude(prompt: string): string {
   return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,8 @@
+// Hardcoded model for every detached `claude -p` spawn (distill, daily
+// rollup, project discovery). Sonnet 4.6 — see src/distillRun.ts for the
+// full rationale. Kept in its own tiny module with no deps so import-safe
+// entrypoints (bin/*) can reference it without pulling vaultWriter →
+// gray-matter into the load graph before depsPresent() runs.
+export function distillModel(): string {
+  return "claude-sonnet-4-6";
+}

--- a/tests/discoverer.test.ts
+++ b/tests/discoverer.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  projectSlug, projectNotePath, isUnknownProject, looksLikeCodeProject,
+  buildDiscoveryPrompt, runDiscover,
+} from "../src/discoverer";
+
+const TMP = path.join(os.tmpdir(), `sb-discover-${process.pid}`);
+
+beforeEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  process.env.SUPERBRAIN_DATA_DIR = path.join(TMP, "data");
+  process.env.SUPERBRAIN_VAULT_DIR = path.join(TMP, "vault");
+});
+
+describe("discoverer — gates", () => {
+  it("projectSlug uses the basename, hyphenated and lowercased", () => {
+    expect(projectSlug("/Users/alex/Projects/Vibe/SuperBrain")).toBe("superbrain");
+    expect(projectSlug("/tmp/My Cool Repo")).toBe("my-cool-repo");
+  });
+
+  it("isUnknownProject is true when no project note exists", () => {
+    const proj = path.join(TMP, "fresh-project");
+    fs.mkdirSync(proj, { recursive: true });
+    expect(isUnknownProject(proj)).toBe(true);
+  });
+
+  it("isUnknownProject is false when a project note already exists", () => {
+    const proj = path.join(TMP, "existing-project");
+    fs.mkdirSync(proj, { recursive: true });
+    const notePath = projectNotePath(proj);
+    fs.mkdirSync(path.dirname(notePath), { recursive: true });
+    fs.writeFileSync(notePath, "# existing\n");
+    expect(isUnknownProject(proj)).toBe(false);
+  });
+
+  it("looksLikeCodeProject recognizes a .git dir", () => {
+    const proj = path.join(TMP, "git-project");
+    fs.mkdirSync(path.join(proj, ".git"), { recursive: true });
+    expect(looksLikeCodeProject(proj)).toBe(true);
+  });
+
+  it("looksLikeCodeProject recognizes a package.json", () => {
+    const proj = path.join(TMP, "npm-project");
+    fs.mkdirSync(proj, { recursive: true });
+    fs.writeFileSync(path.join(proj, "package.json"), "{}\n");
+    expect(looksLikeCodeProject(proj)).toBe(true);
+  });
+
+  it("looksLikeCodeProject rejects a plain directory with no manifests", () => {
+    const proj = path.join(TMP, "not-a-project");
+    fs.mkdirSync(proj, { recursive: true });
+    fs.writeFileSync(path.join(proj, "random.txt"), "hello\n");
+    expect(looksLikeCodeProject(proj)).toBe(false);
+  });
+});
+
+describe("discoverer — prompt construction", () => {
+  it("includes every required section heading the model must produce", () => {
+    const prompt = buildDiscoveryPrompt({
+      projectDir: "/tmp/x", manifests: [], paths: ["a.ts"], truncated: false,
+    });
+    for (const heading of ["## Stack", "## Architecture", "## Top-level folders",
+      "## Key files", "## Docs", "## Conventions", "## Open questions"]) {
+      expect(prompt).toContain(heading);
+    }
+  });
+
+  it("inlines each manifest's content as a code block in the prompt", () => {
+    const prompt = buildDiscoveryPrompt({
+      projectDir: "/tmp/x",
+      manifests: [{ name: "package.json", content: '{"name":"foo"}' }],
+      paths: [],
+      truncated: false,
+    });
+    expect(prompt).toContain("## package.json");
+    expect(prompt).toContain('{"name":"foo"}');
+  });
+
+  it("flags truncation in the source-paths section when the walk was capped", () => {
+    const prompt = buildDiscoveryPrompt({
+      projectDir: "/tmp/x", manifests: [], paths: ["a.ts", "b.ts"], truncated: true,
+    });
+    expect(prompt).toContain("TRUNCATED");
+  });
+});
+
+describe("discoverer — runDiscover (stubbed)", () => {
+  it("writes a project note with discovered:true frontmatter on success", async () => {
+    const proj = path.join(TMP, "stub-project");
+    fs.mkdirSync(proj, { recursive: true });
+    fs.writeFileSync(path.join(proj, "package.json"), '{"name":"stub"}\n');
+
+    const stubBody = "# Stub Project\n\n> A test project.\n\n## Stack\n- TypeScript\n";
+    const stubPath = path.join(TMP, "discover-stub.md");
+    fs.writeFileSync(stubPath, stubBody);
+    process.env.SUPERBRAIN_DISCOVER_STUB = stubPath;
+
+    try {
+      await runDiscover(proj);
+      const notePath = projectNotePath(proj);
+      expect(fs.existsSync(notePath)).toBe(true);
+      const written = fs.readFileSync(notePath, "utf8");
+      expect(written).toContain("discovered: true");
+      expect(written).toContain("# Stub Project");
+      expect(written).toContain(`project: stub-project`);
+    } finally {
+      delete process.env.SUPERBRAIN_DISCOVER_STUB;
+    }
+  });
+
+  it("does NOT overwrite an existing project note (idempotent)", async () => {
+    const proj = path.join(TMP, "existing-project-2");
+    fs.mkdirSync(proj, { recursive: true });
+    fs.writeFileSync(path.join(proj, ".git"), "");  // dummy file so looksLike passes
+    const notePath = projectNotePath(proj);
+    fs.mkdirSync(path.dirname(notePath), { recursive: true });
+    const original = "# existing user content — must not be clobbered\n";
+    fs.writeFileSync(notePath, original);
+
+    const stubPath = path.join(TMP, "discover-stub2.md");
+    fs.writeFileSync(stubPath, "# discovered\n");
+    process.env.SUPERBRAIN_DISCOVER_STUB = stubPath;
+    try {
+      await runDiscover(proj);
+      expect(fs.readFileSync(notePath, "utf8")).toBe(original);
+    } finally {
+      delete process.env.SUPERBRAIN_DISCOVER_STUB;
+    }
+  });
+
+  it("does not run on a non-code directory", async () => {
+    const proj = path.join(TMP, "not-code");
+    fs.mkdirSync(proj, { recursive: true });
+    fs.writeFileSync(path.join(proj, "notes.txt"), "hi\n");
+    const stubPath = path.join(TMP, "discover-stub3.md");
+    fs.writeFileSync(stubPath, "# discovered\n");
+    process.env.SUPERBRAIN_DISCOVER_STUB = stubPath;
+    try {
+      await runDiscover(proj);
+      expect(fs.existsSync(projectNotePath(proj))).toBe(false);
+    } finally {
+      delete process.env.SUPERBRAIN_DISCOVER_STUB;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

When a Claude Code session opens in a project SuperBrain has never written a note for, spawn a detached `sb-discover` child that walks the tree (bounded: 600 files, depth 5, heavy dirs skipped), reads manifests + CLAUDE.md + README + Dockerfile (each capped at 8KB), and asks one Sonnet 4.6 call to produce a substantive `projects/<slug>.md`.

The output is structured by required sections — **Stack / Architecture / Top-level folders / Key files / Docs / Conventions / Open questions** — so the next session can bootstrap context without re-reading the codebase.

## Properties

- **At most once per project, ever.** The existence of the project note is the gate. Never overwrites existing user content.
- **Lock-serialized.** Two parallel SessionStarts in the same project produce one discovery.
- **Fire-and-forget.** Detached child, never blocks the user's session. Failures land in the sentinel.
- **Cost-bounded.** ~one Sonnet call per project (~$0.05–0.20 of input tokens once, never again).
- **Import-safe.** New `src/discoverer.ts` has no heavy deps; `distillModel()` extracted to `src/model.ts` so the discoverer can read it without pulling distillRun → vaultWriter → gray-matter into the import graph before `depsPresent()` runs (per `freshCloneE2E.test.ts` contract).

## Files changed

- **New:** `src/discoverer.ts`, `bin/sb-discover.ts`, `src/model.ts`, `tests/discoverer.test.ts` (12 unit tests).
- **Modified:** `bin/sb-session-start.ts` wires the spawn; `src/distillRun.ts` re-exports `distillModel` from the new `model.ts`; README updated; four version sites bumped to 0.3.0.

## Test plan

- [x] typecheck clean
- [x] build clean
- [x] **165/165 tests pass** (was 153 + 12 discoverer tests)
- [x] freshCloneE2E still passes (import-safety guarantee preserved)
- [x] dist/ regenerated and committed
- [x] live install cache patched in-session

## Known follow-ups (NOT in this PR)

- Manual `/superbrain:discover` slash command for re-running discovery on demand.
- Gitignore-aware walk (currently skips standard heavy dirs by name; doesn't parse `.gitignore`).
- Adopt end-to-end test (carried over from previous PR).
- Migrate non-destructive CI assertion (carried over).
- Cost optimizations: Anthropic prompt caching for the distill prompt; deterministic empty-session skip before the spawn.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>