### PR TITLE
fix(bootstrap): per-install sentinel + /superbrain:discover slash command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/bin/sb-bootstrap.ts
+++ b/bin/sb-bootstrap.ts
@@ -1,16 +1,22 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { acquireLock, releaseLock } from "../src/lockfile.js";
-import { bootstrapDone, markBootstrapDone } from "../src/bootstrap.js";
+import { bootstrapDone, markBootstrapDone, depsPresent } from "../src/bootstrap.js";
 import { writeFailure } from "../src/sentinel.js";
 
 function main() {
-  if (bootstrapDone()) { console.log("bootstrap already done"); process.exit(0); }
+  const root = process.env.SUPERBRAIN_PLUGIN_ROOT || process.cwd();
+  // Conjoined check: skip only when BOTH the per-install sentinel exists AND
+  // the better-sqlite3 native binding is actually present in this install.
+  // Without the depsPresent half, a stale sentinel from an earlier plugin
+  // version (or a Node ABI change) traps the new install in a permanent
+  // "bootstrap pending" state — bootstrap fires, sees sentinel, exits,
+  // depsPresent stays false forever. See PR for the Node 25 / 0.3.0 trap.
+  if (bootstrapDone(root) && depsPresent(root)) { console.log("bootstrap already done"); process.exit(0); }
   if (!acquireLock("bootstrap", { maxAgeMs: 20 * 60 * 1000 })) { process.exit(0); }
   try {
-    const root = process.env.SUPERBRAIN_PLUGIN_ROOT || process.cwd();
     if (process.env.SUPERBRAIN_BOOTSTRAP_FAKE === "1") {
-      markBootstrapDone();
+      markBootstrapDone(root);
     } else {
       execFileSync("npm", ["ci", "--omit=dev"], { cwd: root, stdio: "ignore" });
       // `npm ci` does NOT guarantee better-sqlite3's native addon: on a Node
@@ -24,7 +30,7 @@ function main() {
         ["-e", "require(require('node:path').join(process.cwd(),'node_modules','better-sqlite3'))"],
         { cwd: root, stdio: "ignore" },
       );
-      markBootstrapDone();
+      markBootstrapDone(root);
     }
   } catch (e: any) {
     writeFailure(`bootstrap failed (npm ci / better-sqlite3 native build): ${e?.message || e}`);

--- a/bin/sb-discover.ts
+++ b/bin/sb-discover.ts
@@ -1,17 +1,27 @@
 #!/usr/bin/env node
-import { runDiscover } from "../src/discoverer.js";
+import { runDiscover, runDiscoverForce } from "../src/discoverer.js";
 import { depsPresent } from "../src/bootstrap.js";
 import { pluginRoot } from "../src/paths.js";
 
 // Detached, lock-serialized project discoverer. Spawned by sb-session-start
-// the first time a session opens in an unknown project. Fire-and-forget —
-// failures land in the sentinel, never the user's session.
+// the first time a session opens in an unknown project (auto mode). Also
+// invokable manually via `/superbrain:discover` (force mode) — `--force`
+// runs even when a project note already exists and appends a
+// `## SuperBrain discovery (date)` section instead of overwriting.
+// Fire-and-forget; failures land in the sentinel.
 async function main() {
   if (!depsPresent(pluginRoot())) { process.exit(0); }
-  const projectDir = process.env.SUPERBRAIN_PROJECT_DIR
+  const args = process.argv.slice(2);
+  const force = args.includes("--force");
+  const positional = args.filter(a => !a.startsWith("--"));
+  const projectDir = positional[0]
+    || process.env.SUPERBRAIN_PROJECT_DIR
     || process.env.CLAUDE_PROJECT_DIR
     || process.cwd();
-  try { await runDiscover(projectDir); } catch { /* sentinel handles errors inside runDiscover */ }
+  try {
+    if (force) await runDiscoverForce(projectDir);
+    else await runDiscover(projectDir);
+  } catch { /* sentinel handles errors inside runDiscover */ }
   process.exit(0);
 }
 if ((process.argv[1] && process.argv[1].endsWith("sb-discover.ts")) || process.argv[1]?.endsWith("sb-discover.js")) main();

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -13,7 +13,7 @@ async function main() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
-  const server = new McpServer({ name: "superbrain", version: "0.3.0" });
+  const server = new McpServer({ name: "superbrain", version: "0.3.1" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).",

--- a/bin/sb-session-start.ts
+++ b/bin/sb-session-start.ts
@@ -54,7 +54,7 @@ async function main() {
     const root = pluginRoot();
     if (!depsPresent(root)) {
       runBootstrap(root);
-      parts.push("SuperBrain is finishing first-time setup (installing search dependencies). Capture resumes automatically next session.");
+      parts.push("SuperBrain is rebuilding native dependencies for this install (one-time per plugin version). Capture resumes automatically next session.");
     } else {
       const { appendDigest } = await import("../src/sessionDigest.js"); // deferred heavy import
       await appendDigest(parts, h);

--- a/commands/discover.md
+++ b/commands/discover.md
@@ -1,0 +1,43 @@
+---
+name: discover
+description: Generate a substantive project note for the current (or specified) repo. Forces a fresh discovery — if a project note already exists, appends a new `## SuperBrain discovery (date)` section without clobbering existing content. Use when SuperBrain didn't auto-discover (e.g., the project's slug collided with a note migrated from a legacy vault), or to refresh an out-of-date project note.
+---
+
+# /superbrain:discover
+
+Manual project discovery. Auto-discovery only fires on first session in a project with **no existing note** — this command bypasses that gate.
+
+## What it does
+
+1. Walks the project tree (bounded: 600 files, depth 5, vendored/build dirs skipped).
+2. Reads manifests + `CLAUDE.md` + `README` + `Dockerfile` (each capped at 8 KB).
+3. Invokes one detached `claude -p sonnet-4-6` call with the gathered context.
+4. Writes a structured project note covering: stack, architecture, top-level folders, key files, docs, conventions, open questions.
+5. **If the project note already exists**, appends a fresh `## SuperBrain discovery (YYYY-MM-DD)` section at the bottom — never overwrites user content. **If no note exists**, creates one with full `discovered: true` frontmatter.
+
+## How to invoke
+
+Step 1 — determine the target project directory:
+
+- If an argument was passed to the slash command, treat it as an absolute path (or relative to the current working directory). Verify it exists and is a directory.
+- Otherwise, default to `$CLAUDE_PROJECT_DIR` (the project the current session opened in).
+
+Step 2 — invoke the discoverer binary directly. This must use the plugin's own dist so the prompt and model are consistent with auto-discovery:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/dist/bin/sb-discover.js" --force "<project_dir>"
+```
+
+The process is detached internally and finishes in ~10-30 seconds depending on project size. The resulting note will appear at `~/.superbrain/vault/projects/<slug>.md` where `<slug>` is the lowercased, hyphenated basename of the project directory.
+
+Step 3 — when the call returns, tell the user:
+
+- The path of the project note that was written/updated.
+- Whether discovery created a new note or appended a `## SuperBrain discovery` section to an existing one (check the note's contents to confirm).
+- If the file was not produced (rare — usually means `claude -p` itself failed), check `~/.superbrain/last-failure.txt` and surface the message.
+
+## What this is NOT
+
+- Not a replacement for `/superbrain:migrate` — migrate imports an existing Obsidian vault into SuperBrain's structure; discover synthesizes a project note from a code repo.
+- Not a refresh of all known projects — runs against one project at a time. Re-run on each one as needed.
+- Not a vault-wide rebuild — does not touch `index.db`, `sessions/`, daily notes, or any other note.

--- a/dist/bin/sb-bootstrap.js
+++ b/dist/bin/sb-bootstrap.js
@@ -1,10 +1,17 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { acquireLock, releaseLock } from "../src/lockfile.js";
-import { bootstrapDone, markBootstrapDone } from "../src/bootstrap.js";
+import { bootstrapDone, markBootstrapDone, depsPresent } from "../src/bootstrap.js";
 import { writeFailure } from "../src/sentinel.js";
 function main() {
-    if (bootstrapDone()) {
+    const root = process.env.SUPERBRAIN_PLUGIN_ROOT || process.cwd();
+    // Conjoined check: skip only when BOTH the per-install sentinel exists AND
+    // the better-sqlite3 native binding is actually present in this install.
+    // Without the depsPresent half, a stale sentinel from an earlier plugin
+    // version (or a Node ABI change) traps the new install in a permanent
+    // "bootstrap pending" state — bootstrap fires, sees sentinel, exits,
+    // depsPresent stays false forever. See PR for the Node 25 / 0.3.0 trap.
+    if (bootstrapDone(root) && depsPresent(root)) {
         console.log("bootstrap already done");
         process.exit(0);
     }
@@ -12,9 +19,8 @@ function main() {
         process.exit(0);
     }
     try {
-        const root = process.env.SUPERBRAIN_PLUGIN_ROOT || process.cwd();
         if (process.env.SUPERBRAIN_BOOTSTRAP_FAKE === "1") {
-            markBootstrapDone();
+            markBootstrapDone(root);
         }
         else {
             execFileSync("npm", ["ci", "--omit=dev"], { cwd: root, stdio: "ignore" });
@@ -25,7 +31,7 @@ function main() {
             // the sentinel fires and SessionStart retries next session.
             execFileSync("npm", ["rebuild", "better-sqlite3"], { cwd: root, stdio: "ignore" });
             execFileSync(process.execPath, ["-e", "require(require('node:path').join(process.cwd(),'node_modules','better-sqlite3'))"], { cwd: root, stdio: "ignore" });
-            markBootstrapDone();
+            markBootstrapDone(root);
         }
     }
     catch (e) {

--- a/dist/bin/sb-discover.js
+++ b/dist/bin/sb-discover.js
@@ -1,19 +1,29 @@
 #!/usr/bin/env node
-import { runDiscover } from "../src/discoverer.js";
+import { runDiscover, runDiscoverForce } from "../src/discoverer.js";
 import { depsPresent } from "../src/bootstrap.js";
 import { pluginRoot } from "../src/paths.js";
 // Detached, lock-serialized project discoverer. Spawned by sb-session-start
-// the first time a session opens in an unknown project. Fire-and-forget —
-// failures land in the sentinel, never the user's session.
+// the first time a session opens in an unknown project (auto mode). Also
+// invokable manually via `/superbrain:discover` (force mode) — `--force`
+// runs even when a project note already exists and appends a
+// `## SuperBrain discovery (date)` section instead of overwriting.
+// Fire-and-forget; failures land in the sentinel.
 async function main() {
     if (!depsPresent(pluginRoot())) {
         process.exit(0);
     }
-    const projectDir = process.env.SUPERBRAIN_PROJECT_DIR
+    const args = process.argv.slice(2);
+    const force = args.includes("--force");
+    const positional = args.filter(a => !a.startsWith("--"));
+    const projectDir = positional[0]
+        || process.env.SUPERBRAIN_PROJECT_DIR
         || process.env.CLAUDE_PROJECT_DIR
         || process.cwd();
     try {
-        await runDiscover(projectDir);
+        if (force)
+            await runDiscoverForce(projectDir);
+        else
+            await runDiscover(projectDir);
     }
     catch { /* sentinel handles errors inside runDiscover */ }
     process.exit(0);

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -12,7 +12,7 @@ async function main() {
     const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
-    const server = new McpServer({ name: "superbrain", version: "0.3.0" });
+    const server = new McpServer({ name: "superbrain", version: "0.3.1" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).", { query: z.string(), k: z.number().optional() }, async ({ query, k }) => (await handleSearch({ query, k })));
     const transport = new StdioServerTransport();
     server.connect(transport).catch(() => process.exit(1));

--- a/dist/bin/sb-session-start.js
+++ b/dist/bin/sb-session-start.js
@@ -65,7 +65,7 @@ async function main() {
         const root = pluginRoot();
         if (!depsPresent(root)) {
             runBootstrap(root);
-            parts.push("SuperBrain is finishing first-time setup (installing search dependencies). Capture resumes automatically next session.");
+            parts.push("SuperBrain is rebuilding native dependencies for this install (one-time per plugin version). Capture resumes automatically next session.");
         }
         else {
             const { appendDigest } = await import("../src/sessionDigest.js"); // deferred heavy import

--- a/dist/src/bootstrap.js
+++ b/dist/src/bootstrap.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dataDir } from "./paths.js";
+import { pluginRoot as defaultPluginRoot } from "./paths.js";
 // Bounded search for a compiled native addon (*.node) within a directory.
 function hasDotNode(dir) {
     let entries;
@@ -43,16 +43,26 @@ export function depsPresent(pluginRoot) {
         return false;
     }
 }
-function doneFile() { return path.join(dataDir(), "bootstrap-done"); }
-export function bootstrapDone() { return fs.existsSync(doneFile()); }
-export function markBootstrapDone() {
-    fs.mkdirSync(path.dirname(doneFile()), { recursive: true });
-    fs.writeFileSync(doneFile(), new Date().toISOString());
+// bootstrap-done is PER-INSTALL: written inside the plugin's own version dir
+// at `<pluginRoot>/.bootstrap-done`. This is critical because Claude Code
+// installs each plugin version in a fresh directory, and a global sentinel
+// (the old design at ~/.superbrain/bootstrap-done) would inherit "done"
+// across upgrades while the new install's node_modules still lacks the
+// rebuilt better-sqlite3 native binding. Per-install + the depsPresent()
+// conjoined check in bin/sb-bootstrap.ts together make bootstrap self-heal
+// across plugin upgrades and Node ABI changes.
+function doneFile(root) { return path.join(root, ".bootstrap-done"); }
+export function bootstrapDone(root = defaultPluginRoot()) {
+    return fs.existsSync(doneFile(root));
+}
+export function markBootstrapDone(root = defaultPluginRoot()) {
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(doneFile(root), new Date().toISOString());
 }
 // Detached, fire-and-forget. The dedicated bin/sb-bootstrap.js runs `npm ci`
 // under a lock and writes bootstrap-done / the sentinel itself.
 export function runBootstrap(pluginRoot) {
-    if (bootstrapDone())
+    if (bootstrapDone(pluginRoot) && depsPresent(pluginRoot))
         return;
     try {
         const runner = fileURLToPath(new URL("../bin/sb-bootstrap.js", import.meta.url));

--- a/dist/src/discoverer.js
+++ b/dist/src/discoverer.js
@@ -177,6 +177,12 @@ function callClaudeForDiscovery(prompt) {
     }
     return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
 }
+// Auto-discovery: fires from sb-session-start the first time a session opens
+// in a project with no existing note. Never overwrites — `isUnknownProject`
+// gate skips any project that already has a `projects/<slug>.md`. To force
+// discovery on a project that already has a note (e.g. one migrated from a
+// legacy vault with no real content), use `runDiscoverForce` via the
+// /superbrain:discover slash command.
 export async function runDiscover(projectDir) {
     if (!projectDir || !fs.existsSync(projectDir))
         return;
@@ -184,6 +190,22 @@ export async function runDiscover(projectDir) {
         return;
     if (!isUnknownProject(projectDir))
         return;
+    return runDiscoveryWrite(projectDir, "create");
+}
+// Forced discovery: runs even if a project note already exists. In that case
+// the synthesized body is appended under a `## SuperBrain discovery (date)`
+// heading rather than replacing the file, so user-authored content is never
+// clobbered. Used by `/superbrain:discover` for manual re-discovery on
+// migrated stubs and for explicit refreshes.
+export async function runDiscoverForce(projectDir) {
+    if (!projectDir || !fs.existsSync(projectDir))
+        return;
+    if (!looksLikeCodeProject(projectDir))
+        return;
+    const mode = isUnknownProject(projectDir) ? "create" : "append";
+    return runDiscoveryWrite(projectDir, mode);
+}
+async function runDiscoveryWrite(projectDir, mode) {
     if (!acquireLock("discover"))
         return;
     try {
@@ -196,22 +218,30 @@ export async function runDiscover(projectDir) {
             return;
         }
         const date = new Date().toISOString().slice(0, 10);
-        const frontmatter = [
-            "---",
-            "type: project",
-            "status: active",
-            `project: ${projectSlug(projectDir)}`,
-            `project_dir: ${JSON.stringify(projectDir)}`,
-            "discovered: true",
-            `created: '${date}'`,
-            `updated: '${date}'`,
-            "superbrain: true",
-            "---",
-            "",
-        ].join("\n");
         const notePath = projectNotePath(projectDir);
         fs.mkdirSync(path.dirname(notePath), { recursive: true });
-        fs.writeFileSync(notePath, frontmatter + body + "\n");
+        if (mode === "create") {
+            const frontmatter = [
+                "---",
+                "type: project",
+                "status: active",
+                `project: ${projectSlug(projectDir)}`,
+                `project_dir: ${JSON.stringify(projectDir)}`,
+                "discovered: true",
+                `created: '${date}'`,
+                `updated: '${date}'`,
+                "superbrain: true",
+                "---",
+                "",
+            ].join("\n");
+            fs.writeFileSync(notePath, frontmatter + body + "\n");
+        }
+        else {
+            // Append-only: never clobber user-authored content, never reorder
+            // existing sections, just stamp a fresh discovery block at the bottom.
+            const section = `\n\n## SuperBrain discovery (${date})\n\n${body}\n`;
+            fs.appendFileSync(notePath, section);
+        }
     }
     catch (e) {
         try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dataDir } from "./paths.js";
+import { pluginRoot as defaultPluginRoot } from "./paths.js";
 
 // Bounded search for a compiled native addon (*.node) within a directory.
 function hasDotNode(dir: string): boolean {
@@ -34,17 +34,27 @@ export function depsPresent(pluginRoot: string): boolean {
   } catch { return false; }
 }
 
-function doneFile(): string { return path.join(dataDir(), "bootstrap-done"); }
-export function bootstrapDone(): boolean { return fs.existsSync(doneFile()); }
-export function markBootstrapDone(): void {
-  fs.mkdirSync(path.dirname(doneFile()), { recursive: true });
-  fs.writeFileSync(doneFile(), new Date().toISOString());
+// bootstrap-done is PER-INSTALL: written inside the plugin's own version dir
+// at `<pluginRoot>/.bootstrap-done`. This is critical because Claude Code
+// installs each plugin version in a fresh directory, and a global sentinel
+// (the old design at ~/.superbrain/bootstrap-done) would inherit "done"
+// across upgrades while the new install's node_modules still lacks the
+// rebuilt better-sqlite3 native binding. Per-install + the depsPresent()
+// conjoined check in bin/sb-bootstrap.ts together make bootstrap self-heal
+// across plugin upgrades and Node ABI changes.
+function doneFile(root: string): string { return path.join(root, ".bootstrap-done"); }
+export function bootstrapDone(root: string = defaultPluginRoot()): boolean {
+  return fs.existsSync(doneFile(root));
+}
+export function markBootstrapDone(root: string = defaultPluginRoot()): void {
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(doneFile(root), new Date().toISOString());
 }
 
 // Detached, fire-and-forget. The dedicated bin/sb-bootstrap.js runs `npm ci`
 // under a lock and writes bootstrap-done / the sentinel itself.
 export function runBootstrap(pluginRoot: string): void {
-  if (bootstrapDone()) return;
+  if (bootstrapDone(pluginRoot) && depsPresent(pluginRoot)) return;
   try {
     const runner = fileURLToPath(new URL("../bin/sb-bootstrap.js", import.meta.url));
     spawn(process.execPath, [runner], {

--- a/src/discoverer.ts
+++ b/src/discoverer.ts
@@ -174,11 +174,32 @@ function callClaudeForDiscovery(prompt: string): string {
   return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
 }
 
+// Auto-discovery: fires from sb-session-start the first time a session opens
+// in a project with no existing note. Never overwrites — `isUnknownProject`
+// gate skips any project that already has a `projects/<slug>.md`. To force
+// discovery on a project that already has a note (e.g. one migrated from a
+// legacy vault with no real content), use `runDiscoverForce` via the
+// /superbrain:discover slash command.
 export async function runDiscover(projectDir: string): Promise<void> {
   if (!projectDir || !fs.existsSync(projectDir)) return;
   if (!looksLikeCodeProject(projectDir)) return;
   if (!isUnknownProject(projectDir)) return;
+  return runDiscoveryWrite(projectDir, "create");
+}
 
+// Forced discovery: runs even if a project note already exists. In that case
+// the synthesized body is appended under a `## SuperBrain discovery (date)`
+// heading rather than replacing the file, so user-authored content is never
+// clobbered. Used by `/superbrain:discover` for manual re-discovery on
+// migrated stubs and for explicit refreshes.
+export async function runDiscoverForce(projectDir: string): Promise<void> {
+  if (!projectDir || !fs.existsSync(projectDir)) return;
+  if (!looksLikeCodeProject(projectDir)) return;
+  const mode = isUnknownProject(projectDir) ? "create" : "append";
+  return runDiscoveryWrite(projectDir, mode);
+}
+
+async function runDiscoveryWrite(projectDir: string, mode: "create" | "append"): Promise<void> {
   if (!acquireLock("discover")) return;
   try {
     const { paths, truncated } = walkBounded(projectDir);
@@ -190,22 +211,29 @@ export async function runDiscover(projectDir: string): Promise<void> {
       return;
     }
     const date = new Date().toISOString().slice(0, 10);
-    const frontmatter = [
-      "---",
-      "type: project",
-      "status: active",
-      `project: ${projectSlug(projectDir)}`,
-      `project_dir: ${JSON.stringify(projectDir)}`,
-      "discovered: true",
-      `created: '${date}'`,
-      `updated: '${date}'`,
-      "superbrain: true",
-      "---",
-      "",
-    ].join("\n");
     const notePath = projectNotePath(projectDir);
     fs.mkdirSync(path.dirname(notePath), { recursive: true });
-    fs.writeFileSync(notePath, frontmatter + body + "\n");
+    if (mode === "create") {
+      const frontmatter = [
+        "---",
+        "type: project",
+        "status: active",
+        `project: ${projectSlug(projectDir)}`,
+        `project_dir: ${JSON.stringify(projectDir)}`,
+        "discovered: true",
+        `created: '${date}'`,
+        `updated: '${date}'`,
+        "superbrain: true",
+        "---",
+        "",
+      ].join("\n");
+      fs.writeFileSync(notePath, frontmatter + body + "\n");
+    } else {
+      // Append-only: never clobber user-authored content, never reorder
+      // existing sections, just stamp a fresh discovery block at the bottom.
+      const section = `\n\n## SuperBrain discovery (${date})\n\n${body}\n`;
+      fs.appendFileSync(notePath, section);
+    }
   } catch (e: any) {
     try { writeFailure(`discovery failed for ${projectDir}: ${e?.message || e}`); } catch { /* noop */ }
   } finally {

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -22,14 +22,24 @@ it("depsPresent is false without the better-sqlite3 native binding, true with it
   expect(depsPresent("/tmp/sb-bs")).toBe(true);
 });
 
-it("bootstrapDone reflects the marker", () => {
-  expect(bootstrapDone()).toBe(false);
-  markBootstrapDone();
-  expect(bootstrapDone()).toBe(true);
+it("bootstrapDone reflects the per-install marker", () => {
+  fs.mkdirSync("/tmp/sb-bs", { recursive: true });
+  expect(bootstrapDone("/tmp/sb-bs")).toBe(false);
+  markBootstrapDone("/tmp/sb-bs");
+  expect(bootstrapDone("/tmp/sb-bs")).toBe(true);
+  // A different install dir must have its own independent sentinel — that's
+  // the whole point of moving bootstrap-done per-install.
+  fs.mkdirSync("/tmp/sb-bs-other", { recursive: true });
+  expect(bootstrapDone("/tmp/sb-bs-other")).toBe(false);
 });
 
-it("sb-bootstrap is idempotent: no-op when bootstrap-done exists", () => {
-  markBootstrapDone();
+it("sb-bootstrap is idempotent only when BOTH sentinel exists AND deps present", () => {
+  fs.mkdirSync("/tmp/sb-bs", { recursive: true });
+  markBootstrapDone("/tmp/sb-bs");
+  // Without the native binding, sentinel alone is not enough — bootstrap must
+  // still run to rebuild. Stage a fake binding so the conjoined check passes.
+  fs.mkdirSync("/tmp/sb-bs/node_modules/better-sqlite3/build/Release", { recursive: true });
+  fs.writeFileSync("/tmp/sb-bs/node_modules/better-sqlite3/build/Release/better_sqlite3.node", "");
   const out = execFileSync("npx", ["tsx", "bin/sb-bootstrap.ts"], {
     env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-bs-data",
       SUPERBRAIN_PLUGIN_ROOT: "/tmp/sb-bs", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
@@ -38,12 +48,28 @@ it("sb-bootstrap is idempotent: no-op when bootstrap-done exists", () => {
   expect(out).toMatch(/already done/);
 });
 
-it("sb-bootstrap (fake) writes bootstrap-done on success", () => {
+it("sb-bootstrap (fake) writes per-install bootstrap-done on success", () => {
   fs.mkdirSync("/tmp/sb-bs", { recursive: true });
   execFileSync("npx", ["tsx", "bin/sb-bootstrap.ts"], {
     env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-bs-data",
       SUPERBRAIN_PLUGIN_ROOT: "/tmp/sb-bs", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });
-  expect(bootstrapDone()).toBe(true);
+  expect(bootstrapDone("/tmp/sb-bs")).toBe(true);
+});
+
+it("sb-bootstrap re-runs when sentinel exists but native binding is missing (upgrade self-heal)", () => {
+  // Simulates the Node 25 / 0.3.0 trap: stale sentinel from a previous install
+  // survives into a new plugin version dir that has no .node binary yet.
+  // Old code would short-circuit on sentinel and leave deps broken forever.
+  // New code re-runs because the conjoined check fails.
+  fs.mkdirSync("/tmp/sb-bs", { recursive: true });
+  markBootstrapDone("/tmp/sb-bs");
+  // No better-sqlite3 native binding staged — depsPresent is false.
+  const out = execFileSync("npx", ["tsx", "bin/sb-bootstrap.ts"], {
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-bs-data",
+      SUPERBRAIN_PLUGIN_ROOT: "/tmp/sb-bs", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
+    encoding: "utf8",
+  });
+  expect(out).not.toMatch(/already done/);
 });

--- a/tests/freshCloneE2E.test.ts
+++ b/tests/freshCloneE2E.test.ts
@@ -27,5 +27,5 @@ it("every hook entrypoint loads + exits 0 with NO node_modules; SessionStart boo
   const ss = execFileSync(process.execPath, [path.join(CLONE, "dist/bin/sb-session-start.js")], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
     env, encoding: "utf8" });
-  expect(ss).toMatch(/first-time setup/i);
+  expect(ss).toMatch(/rebuilding native dependencies/i);
 });

--- a/tests/sessionStartBootstrap.test.ts
+++ b/tests/sessionStartBootstrap.test.ts
@@ -8,13 +8,13 @@ beforeEach(() => {
   fs.mkdirSync("/tmp/sb-ssb-empty", { recursive: true });
 });
 
-it("no deps: emits first-time-setup notice, exits 0, does NOT crash", () => {
+it("no deps: emits the rebuilding-native-deps notice, exits 0, does NOT crash", () => {
   const out = execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
     env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ssb", CLAUDE_PLUGIN_ROOT: "/tmp/sb-ssb-empty",
       SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });
-  expect(out).toMatch(/first-time setup/i);
+  expect(out).toMatch(/rebuilding native dependencies/i);
   expect(out).toMatch(/additionalContext/);
 });


### PR DESCRIPTION
## Summary

Two related fixes. (1) Plugin upgrades no longer get permanently stuck on the previous version's bootstrap sentinel. (2) Discovery is now manually invokable on projects whose slug collides with an existing migrated note.

## The bug: stale-sentinel upgrade trap

`bootstrap-done` used to live at `~/.superbrain/bootstrap-done` — **a global flag.** Every plugin upgrade installs into a fresh directory (`cache/m3talux/superbrain/<version>/`) with its own `node_modules`. `npm ci` runs but does NOT rebuild `better-sqlite3` native binding — on Node ABIs without published prebuilds (e.g. Node 25 / ABI 141), the new dir ends up source-only with no `.node` binary.

When SessionStart fires from the new install, `depsPresent(pluginRoot)` returns false and `runBootstrap` spawns `sb-bootstrap.js` — which **immediately exits because the global sentinel already says "done"** (written by the previous install). `depsPresent` stays false forever. Discovery (and everything else gated on it) silently skips.

## Fix

- **`bootstrap-done` moves to `<pluginRoot>/.bootstrap-done`** — per-install. New version dirs have no sentinel, so bootstrap runs fresh and rebuilds the native binding.
- **`sb-bootstrap.ts` conjoins the gate:** `if (bootstrapDone(root) && depsPresent(root)) skip`. If either is false, re-run. Belt-and-braces: also self-heals on Node version changes (binding goes stale → depsPresent false → bootstrap reruns even within the same install).
- **Reworded the SessionStart banner** from `first-time setup` to `rebuilding native dependencies for this install` — accurate for both fresh installs and upgrades.

## `/superbrain:discover` manual command

Auto-discovery only fires when no project note exists. Yesterday's `/superbrain:migrate` brought 30+ project notes over from a legacy Obsidian vault — each one already exists, so auto-discovery skips them. `/superbrain:discover` is the escape hatch:

- New `commands/discover.md` runs `node bin/sb-discover.js --force <project-dir>`.
- Force mode runs even when a note exists, and **appends** a `## SuperBrain discovery (YYYY-MM-DD)` section instead of overwriting. User content is never clobbered.
- Refactored `src/discoverer.ts`: `runDiscover` (auto, gated) and `runDiscoverForce` (manual, append-on-existing, create-on-missing) share a single write helper.

## Test plan

- [x] typecheck clean
- [x] build clean
- [x] **166/166 tests pass** (was 165 + 1 new "re-runs when sentinel exists but binding missing" test)
- [x] freshCloneE2E + sessionStartBootstrap updated for new banner wording
- [x] new test asserts per-install sentinel isolation
- [x] dist/ regenerated and committed
- [x] live cache patched + 0.3.0 install manually unstuck — `better_sqlite3.node` now present, per-install sentinel written

## Version

`0.3.0` → `0.3.1` (patch — bug fix + non-breaking addition of the slash command).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>