### PR TITLE
feat(discovery): four-stage detection cascade + umbrella fan-out

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/bin/sb-discover.ts
+++ b/bin/sb-discover.ts
@@ -13,13 +13,14 @@ async function main() {
   if (!depsPresent(pluginRoot())) { process.exit(0); }
   const args = process.argv.slice(2);
   const force = args.includes("--force");
+  const all = args.includes("--all");
   const positional = args.filter(a => !a.startsWith("--"));
   const projectDir = positional[0]
     || process.env.SUPERBRAIN_PROJECT_DIR
     || process.env.CLAUDE_PROJECT_DIR
     || process.cwd();
   try {
-    if (force) await runDiscoverForce(projectDir);
+    if (force) await runDiscoverForce(projectDir, { all });
     else await runDiscover(projectDir);
   } catch { /* sentinel handles errors inside runDiscover */ }
   process.exit(0);

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -13,7 +13,7 @@ async function main() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
-  const server = new McpServer({ name: "superbrain", version: "0.3.1" });
+  const server = new McpServer({ name: "superbrain", version: "0.4.0" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).",

--- a/commands/discover.md
+++ b/commands/discover.md
@@ -22,19 +22,34 @@ Step 1 — determine the target project directory:
 - If an argument was passed to the slash command, treat it as an absolute path (or relative to the current working directory). Verify it exists and is a directory.
 - Otherwise, default to `$CLAUDE_PROJECT_DIR` (the project the current session opened in).
 
-Step 2 — invoke the discoverer binary directly. This must use the plugin's own dist so the prompt and model are consistent with auto-discovery:
+Step 2 — invoke the discoverer binary. The plugin classifies the target through the four-stage detection cascade (blocklist → strong-signal → workspace declaration → implicit umbrella) and handles single-project vs umbrella fan-out internally.
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/dist/bin/sb-discover.js" --force "<project_dir>"
 ```
 
-The process is detached internally and finishes in ~10-30 seconds depending on project size. The resulting note will appear at `~/.superbrain/vault/projects/<slug>.md` where `<slug>` is the lowercased, hyphenated basename of the project directory.
+If the user explicitly asked to refresh every sub-project under an umbrella (not just the missing ones), pass `--all` too:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/dist/bin/sb-discover.js" --force --all "<project_dir>"
+```
+
+What the binary actually does given `<project_dir>`:
+
+- **Blocked path** (HOME, Documents, Library, /tmp, etc.) → silent skip, no note. Tell the user the path is on the blocklist and discovery cannot run there.
+- **No strong project signal** (just a README or LICENSE, no real manifest) → silent skip. Tell the user the directory doesn't look like a code project.
+- **Single project** → one note at `~/.superbrain/vault/projects/<slug>.md`. If the note already exists, a fresh `## SuperBrain discovery (date)` section is appended.
+- **Umbrella / monorepo** (workspace declaration or ≥2 sibling sub-projects detected) → one note per detected child (capped at 8), each named `<umbrella-slug>-<child-slug>.md` with `umbrella: <umbrella-slug>` frontmatter. Without `--all`, only children whose note doesn't exist yet are written; with `--all`, every child's note gets a fresh appended section.
+- **Sub-project of an umbrella, opened directly** → discovery treats it as a single project but with umbrella context, so the slug is correctly prefixed.
+
+Discovery decisions and skip reasons are written to `~/.superbrain/discovery.log` for traceability.
 
 Step 3 — when the call returns, tell the user:
 
-- The path of the project note that was written/updated.
-- Whether discovery created a new note or appended a `## SuperBrain discovery` section to an existing one (check the note's contents to confirm).
-- If the file was not produced (rare — usually means `claude -p` itself failed), check `~/.superbrain/last-failure.txt` and surface the message.
+- For single-project discovery: the path of the project note that was written or updated.
+- For umbrella fan-out: the umbrella name, how many children were detected, and the paths of the notes that were written (or skipped because they already exist and `--all` was not passed). If any children were dropped because they exceeded the cap (>8), surface that and suggest running `/superbrain:discover <child>` on each.
+- If discovery was a no-op (blocked or no-signal), explain the gate that fired by reading the last line(s) of `~/.superbrain/discovery.log`.
+- If `claude -p` itself failed (rare), check `~/.superbrain/last-failure.txt` and surface the message.
 
 ## What this is NOT
 

--- a/dist/bin/sb-discover.js
+++ b/dist/bin/sb-discover.js
@@ -14,6 +14,7 @@ async function main() {
     }
     const args = process.argv.slice(2);
     const force = args.includes("--force");
+    const all = args.includes("--all");
     const positional = args.filter(a => !a.startsWith("--"));
     const projectDir = positional[0]
         || process.env.SUPERBRAIN_PROJECT_DIR
@@ -21,7 +22,7 @@ async function main() {
         || process.cwd();
     try {
         if (force)
-            await runDiscoverForce(projectDir);
+            await runDiscoverForce(projectDir, { all });
         else
             await runDiscover(projectDir);
     }

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -12,7 +12,7 @@ async function main() {
     const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
-    const server = new McpServer({ name: "superbrain", version: "0.3.1" });
+    const server = new McpServer({ name: "superbrain", version: "0.4.0" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).", { query: z.string(), k: z.number().optional() }, async ({ query, k }) => (await handleSearch({ query, k })));
     const transport = new StdioServerTransport();
     server.connect(transport).catch(() => process.exit(1));

--- a/dist/src/discoverer.js
+++ b/dist/src/discoverer.js
@@ -1,29 +1,25 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { vaultPath } from "./paths.js";
-import { slug } from "./router.js";
+import { vaultPath, dataDir } from "./paths.js";
 import { acquireLock, releaseLock } from "./lockfile.js";
 import { writeFailure } from "./sentinel.js";
 import { distillModel } from "./model.js";
-// Discovery: on a session opening in a project we've never seen before,
-// produce ~/.superbrain/vault/projects/<slug>.md with a substantive code map
-// the next session can read. One Sonnet call per project, ever. After that
-// the note is "known" (its existence is the gate) and further distillation
-// only appends to it via the normal router path.
-// Directories the walk always skips. Heavy, vendored, or build output —
-// adding them to the prompt context would just blow the token budget.
+import { classifyPath, basenameSlug, hasStrongSignal, isBlockedPath } from "./projectDetect.js";
+// Discovery: synthesize a substantive `projects/<slug>.md` for a code repo
+// the user just opened a session in. The detection cascade lives in
+// projectDetect.ts; this module owns the walking, prompt construction,
+// claude -p call, file write, and umbrella fan-out.
+const MAX_FILES = 600;
+const MAX_DEPTH = 5;
+const MAX_MANIFEST_BYTES = 8192;
+const MAX_SUBPROJECTS_PER_UMBRELLA = 8;
 const HEAVY_DIRS = new Set([
     "node_modules", ".git", "dist", "build", "out", "target", "vendor",
     "__pycache__", ".venv", "venv", ".next", ".nuxt", ".turbo",
     ".cache", ".idea", ".vscode", "coverage", ".pytest_cache",
     ".gradle", ".mvn", "bin", "obj",
 ]);
-// Hard caps so a giant repo never spirals.
-const MAX_FILES = 600;
-const MAX_DEPTH = 5;
-const MAX_MANIFEST_BYTES = 8192;
-// Files read in full to anchor the discovery prompt context.
 const MANIFEST_FILES = [
     "README.md", "README.rst", "README", "README.txt",
     "package.json", "pyproject.toml", "Cargo.toml", "go.mod",
@@ -32,34 +28,55 @@ const MANIFEST_FILES = [
     "CLAUDE.md", ".claude.md", "AGENTS.md", "CONTRIBUTING.md",
     "LICENSE", "LICENSE.md",
 ];
-export function projectSlug(projectDir) {
-    return slug(path.basename(projectDir));
+export function projectSlug(projectDir, umbrella) {
+    const base = basenameSlug(projectDir);
+    return umbrella ? `${umbrella.slug}-${base}` : base;
 }
-export function projectNotePath(projectDir) {
-    return path.join(vaultPath(), "projects", `${projectSlug(projectDir)}.md`);
-}
-// "Unknown" = no project note exists yet. Once discovery (or any distillation)
-// has produced the file, we never re-discover — that protects user edits and
-// avoids ever burning tokens twice on the same project.
-export function isUnknownProject(projectDir) {
+// Slug uniqueness for STANDALONE single-project discovery (no umbrella ctx).
+// If the bare basename slug is already taken by a different project_dir, fall
+// back to "<parent>-<basename>". Honors the existing note's project_dir
+// frontmatter to distinguish "same project re-discovered" from "name clash."
+function uniqueStandaloneSlug(projectDir) {
+    const base = basenameSlug(projectDir);
+    const existing = path.join(vaultPath(), "projects", `${base}.md`);
+    if (!fs.existsSync(existing))
+        return base;
     try {
-        return !fs.existsSync(projectNotePath(projectDir));
+        const content = fs.readFileSync(existing, "utf8");
+        const m = content.match(/^project_dir:\s*"?(.+?)"?\s*$/m);
+        // No project_dir field at all → assume legacy/migrated note for the same
+        // project. Don't disambiguate; share the slug. Only disambiguate when
+        // there's an EXPLICIT, MISMATCHING project_dir — that's the unambiguous
+        // "two different real projects collided on basename" case.
+        if (!m)
+            return base;
+        if (path.resolve(m[1].trim()) === path.resolve(projectDir))
+            return base;
+    }
+    catch { /* ignore */ }
+    const parentBase = basenameSlug(path.dirname(projectDir));
+    return parentBase ? `${parentBase}-${base}` : base;
+}
+export function projectNotePath(projectDir, umbrella) {
+    const s = umbrella ? projectSlug(projectDir, umbrella) : uniqueStandaloneSlug(projectDir);
+    return path.join(vaultPath(), "projects", `${s}.md`);
+}
+export function isUnknownProject(projectDir, umbrella) {
+    try {
+        return !fs.existsSync(projectNotePath(projectDir, umbrella));
     }
     catch {
         return false;
     }
 }
-// Heuristic gate: don't trigger discovery on directories that aren't actually
-// code projects (the user's home, a random tmp dir, etc.).
+// Re-exported for sb-session-start's old import path (the integration there
+// only checks "should we even spawn?"). Both gates are subsumed by
+// classifyPath, but keeping these as thin shims minimizes drift.
 export function looksLikeCodeProject(projectDir) {
     try {
-        if (fs.existsSync(path.join(projectDir, ".git")))
-            return true;
-        for (const name of MANIFEST_FILES) {
-            if (fs.existsSync(path.join(projectDir, name)))
-                return true;
-        }
-        return false;
+        if (isBlockedPath(projectDir).blocked)
+            return false;
+        return hasStrongSignal(projectDir);
     }
     catch {
         return false;
@@ -85,7 +102,6 @@ function walkBounded(root) {
             continue;
         }
         for (const e of entries) {
-            // Skip hidden entries except .github (workflows are signal).
             if (e.name.startsWith(".") && e.name !== ".github")
                 continue;
             if (HEAVY_DIRS.has(e.name))
@@ -163,10 +179,11 @@ Things a new contributor would still need to ask. Be concrete — not "what does
 export function buildDiscoveryPrompt(input) {
     const parts = [DISCOVERY_PROMPT_PREFIX];
     parts.push(`# Project directory\n\n\`${input.projectDir}\`\n`);
+    if (input.umbrella)
+        parts.push(`# Umbrella context\n\nThis project is one sub-project of \`${input.umbrella.dir}\`. Mention it as the parent umbrella in the note's intro paragraph; otherwise treat this sub-project on its own merits.\n`);
     parts.push(`# Manifest files\n`);
-    for (const m of input.manifests) {
+    for (const m of input.manifests)
         parts.push(`## ${m.name}\n\n\`\`\`\n${m.content}\n\`\`\`\n`);
-    }
     parts.push(`# Source file paths (${input.paths.length}${input.truncated ? `, TRUNCATED at ${MAX_FILES}` : ""})\n`);
     parts.push("```\n" + input.paths.join("\n") + "\n```\n");
     return parts.join("\n");
@@ -177,56 +194,45 @@ function callClaudeForDiscovery(prompt) {
     }
     return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
 }
-// Auto-discovery: fires from sb-session-start the first time a session opens
-// in a project with no existing note. Never overwrites — `isUnknownProject`
-// gate skips any project that already has a `projects/<slug>.md`. To force
-// discovery on a project that already has a note (e.g. one migrated from a
-// legacy vault with no real content), use `runDiscoverForce` via the
-// /superbrain:discover slash command.
-export async function runDiscover(projectDir) {
-    if (!projectDir || !fs.existsSync(projectDir))
-        return;
-    if (!looksLikeCodeProject(projectDir))
-        return;
-    if (!isUnknownProject(projectDir))
-        return;
-    return runDiscoveryWrite(projectDir, "create");
+// Append a single trace line to ~/.superbrain/discovery.log so users (and we)
+// can diagnose why discovery did or did not fire for a given path. Never
+// fatal — the file is best-effort observability, not load-bearing.
+function logTrace(line) {
+    try {
+        const p = path.join(dataDir(), "discovery.log");
+        fs.mkdirSync(path.dirname(p), { recursive: true });
+        const stamp = new Date().toISOString().replace("T", " ").slice(0, 19);
+        fs.appendFileSync(p, `[${stamp}] ${line}\n`);
+    }
+    catch { /* never propagate */ }
 }
-// Forced discovery: runs even if a project note already exists. In that case
-// the synthesized body is appended under a `## SuperBrain discovery (date)`
-// heading rather than replacing the file, so user-authored content is never
-// clobbered. Used by `/superbrain:discover` for manual re-discovery on
-// migrated stubs and for explicit refreshes.
-export async function runDiscoverForce(projectDir) {
-    if (!projectDir || !fs.existsSync(projectDir))
+async function runDiscoveryWrite(opts) {
+    const { projectDir, umbrella, mode } = opts;
+    if (!acquireLock("discover")) {
+        logTrace(`skip ${projectDir}: discover lock held`);
         return;
-    if (!looksLikeCodeProject(projectDir))
-        return;
-    const mode = isUnknownProject(projectDir) ? "create" : "append";
-    return runDiscoveryWrite(projectDir, mode);
-}
-async function runDiscoveryWrite(projectDir, mode) {
-    if (!acquireLock("discover"))
-        return;
+    }
     try {
         const { paths, truncated } = walkBounded(projectDir);
         const manifests = readManifests(projectDir);
-        const prompt = buildDiscoveryPrompt({ projectDir, manifests, paths, truncated });
+        const prompt = buildDiscoveryPrompt({ projectDir, manifests, paths, truncated, umbrella });
         const body = callClaudeForDiscovery(prompt).trim();
         if (!body) {
             writeFailure(`discovery returned empty body for ${projectDir}`);
+            logTrace(`fail ${projectDir}: empty body from claude -p`);
             return;
         }
         const date = new Date().toISOString().slice(0, 10);
-        const notePath = projectNotePath(projectDir);
+        const notePath = projectNotePath(projectDir, umbrella);
         fs.mkdirSync(path.dirname(notePath), { recursive: true });
         if (mode === "create") {
-            const frontmatter = [
+            const fm = [
                 "---",
                 "type: project",
                 "status: active",
-                `project: ${projectSlug(projectDir)}`,
+                `project: ${projectSlug(projectDir, umbrella)}`,
                 `project_dir: ${JSON.stringify(projectDir)}`,
+                ...(umbrella ? [`umbrella: ${umbrella.slug}`] : []),
                 "discovered: true",
                 `created: '${date}'`,
                 `updated: '${date}'`,
@@ -234,13 +240,13 @@ async function runDiscoveryWrite(projectDir, mode) {
                 "---",
                 "",
             ].join("\n");
-            fs.writeFileSync(notePath, frontmatter + body + "\n");
+            fs.writeFileSync(notePath, fm + body + "\n");
+            logTrace(`wrote ${notePath} (create${umbrella ? `, umbrella=${umbrella.slug}` : ""})`);
         }
         else {
-            // Append-only: never clobber user-authored content, never reorder
-            // existing sections, just stamp a fresh discovery block at the bottom.
             const section = `\n\n## SuperBrain discovery (${date})\n\n${body}\n`;
             fs.appendFileSync(notePath, section);
+            logTrace(`appended ${notePath} (force)`);
         }
     }
     catch (e) {
@@ -248,8 +254,87 @@ async function runDiscoveryWrite(projectDir, mode) {
             writeFailure(`discovery failed for ${projectDir}: ${e?.message || e}`);
         }
         catch { /* noop */ }
+        logTrace(`fail ${projectDir}: ${e?.message || e}`);
     }
     finally {
         releaseLock("discover");
     }
 }
+// Auto-discovery: fires from sb-session-start on a fresh session opening in
+// an unknown project. Routes through the four-stage classifier; "blocked"
+// and "skip" outcomes silently write a trace line and return.
+export async function runDiscover(cwd) {
+    if (!cwd || !fs.existsSync(cwd)) {
+        logTrace(`skip: cwd missing or empty`);
+        return;
+    }
+    const c = classifyPath(cwd);
+    if (c.kind === "blocked") {
+        logTrace(`skip ${cwd}: ${c.reason}`);
+        return;
+    }
+    if (c.kind === "skip") {
+        logTrace(`skip ${cwd}: ${c.reason}`);
+        return;
+    }
+    if (c.kind === "single") {
+        if (!isUnknownProject(c.projectDir, c.umbrella)) {
+            logTrace(`skip ${c.projectDir}: already has a project note`);
+            return;
+        }
+        await runDiscoveryWrite({ projectDir: c.projectDir, umbrella: c.umbrella, mode: "create" });
+        return;
+    }
+    // Umbrella: fan out, one Sonnet call per child, capped.
+    const slice = c.children.slice(0, MAX_SUBPROJECTS_PER_UMBRELLA);
+    const dropped = c.children.length - slice.length;
+    const umbrella = { dir: c.projectDir, slug: basenameSlug(c.projectDir) };
+    logTrace(`umbrella ${c.projectDir} (tool=${c.tool}): ${c.children.length} children, discovering ${slice.length}${dropped ? `, ${dropped} dropped (over cap)` : ""}`);
+    for (const child of slice) {
+        if (!isUnknownProject(child, umbrella)) {
+            logTrace(`skip umbrella child ${child}: already has a project note`);
+            continue;
+        }
+        await runDiscoveryWrite({ projectDir: child, umbrella, mode: "create" });
+    }
+}
+// Force-mode (manual /superbrain:discover). Runs even when a project note
+// already exists, in append mode — appends a fresh "## SuperBrain discovery
+// (date)" section without clobbering user content. Honors umbrella detection:
+// at an umbrella root, fans out to children with the same append semantics.
+// `--all` overrides the "only missing children" default at umbrella roots
+// (without --all, force at an umbrella root only writes children that lack a
+// project note yet).
+export async function runDiscoverForce(cwd, opts = {}) {
+    if (!cwd || !fs.existsSync(cwd))
+        return;
+    const c = classifyPath(cwd);
+    if (c.kind === "blocked") {
+        logTrace(`force skip ${cwd}: ${c.reason}`);
+        return;
+    }
+    if (c.kind === "skip") {
+        logTrace(`force skip ${cwd}: ${c.reason}`);
+        return;
+    }
+    if (c.kind === "single") {
+        const mode = isUnknownProject(c.projectDir, c.umbrella) ? "create" : "append";
+        await runDiscoveryWrite({ projectDir: c.projectDir, umbrella: c.umbrella, mode });
+        return;
+    }
+    // Umbrella under force: same fan-out, but per-child mode depends on existence
+    // (append if note exists, create if not) — unless --all, which forces append
+    // for every child whose note already exists too.
+    const slice = c.children.slice(0, MAX_SUBPROJECTS_PER_UMBRELLA);
+    const umbrella = { dir: c.projectDir, slug: basenameSlug(c.projectDir) };
+    for (const child of slice) {
+        const exists = !isUnknownProject(child, umbrella);
+        if (exists && !opts.all) {
+            logTrace(`force skip umbrella child ${child}: note exists (use --all to append)`);
+            continue;
+        }
+        const mode = exists ? "append" : "create";
+        await runDiscoveryWrite({ projectDir: child, umbrella, mode });
+    }
+}
+export { classifyPath, isBlockedPath };

--- a/dist/src/projectDetect.js
+++ b/dist/src/projectDetect.js
@@ -1,0 +1,191 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { detectWorkspaces } from "./workspaces.js";
+// Project classification: a four-stage cascade that decides what (if
+// anything) discovery should do for a given session cwd. Pure file-system
+// inspection — no LLM calls, no network. Designed to return in <50ms.
+//
+//   Stage 1: path blocklist (HOME, Documents, /tmp, /Library, …)
+//   Stage 2: strong-signal check (real manifests, not just README/LICENSE)
+//   Stage 3: explicit workspace declaration (pnpm-workspace.yaml, etc.)
+//   Stage 4: implicit umbrella (≥2 sibling subdirs each strong-signal)
+//
+// Each stage is a hard gate. Failure = stop, no discovery, no Sonnet call.
+const STRONG_FILES = [
+    ".git", "package.json", "pyproject.toml", "setup.py", "setup.cfg", "Pipfile",
+    "go.mod", "go.work", "Cargo.toml", "pom.xml",
+    "settings.gradle", "settings.gradle.kts", "build.gradle", "build.gradle.kts",
+    "Gemfile", "composer.json", "mix.exs", "pubspec.yaml", "Package.swift",
+    "Project.toml", "stack.yaml", "cabal.project",
+    "flake.nix", "deno.json", "deno.jsonc", "bun.lock", "bun.lockb",
+    "pnpm-workspace.yaml", "MODULE.bazel", "WORKSPACE", "WORKSPACE.bazel",
+    "CLAUDE.md", ".claude", ".mcp.json", "AGENTS.md",
+];
+// Suffix-matched strong signals (Xcode bundles, .NET projects, Haskell cabal).
+const STRONG_SUFFIXES = [".xcodeproj", ".xcworkspace", ".sln", ".csproj", ".fsproj", ".vbproj", ".cabal"];
+export function hasStrongSignal(dir) {
+    try {
+        for (const m of STRONG_FILES) {
+            if (fs.existsSync(path.join(dir, m)))
+                return true;
+        }
+        let entries;
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        }
+        catch {
+            return false;
+        }
+        for (const e of entries) {
+            for (const sfx of STRONG_SUFFIXES)
+                if (e.name.endsWith(sfx))
+                    return true;
+        }
+        return false;
+    }
+    catch {
+        return false;
+    }
+}
+// Directories the implicit-umbrella scan skips. They're never themselves a
+// "sub-project" and walking into them costs us nothing useful.
+const HEAVY_DIRS = new Set([
+    "node_modules", ".git", "dist", "build", "out", "target", "vendor",
+    "__pycache__", ".venv", "venv", ".next", ".nuxt", ".turbo",
+    ".cache", ".idea", ".vscode", "coverage", ".pytest_cache",
+    ".gradle", ".mvn", "bin", "obj",
+]);
+function homedir() { return process.env.HOME || os.homedir(); }
+// Path classification. Exposed for tests and for the "why was this skipped?"
+// trace written to ~/.superbrain/discovery.log. SUPERBRAIN_TEST_BYPASS_BLOCKLIST
+// is an internal seam — tests using /tmp paths set it; Claude Code never does.
+export function isBlockedPath(p) {
+    if (process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST === "1")
+        return { blocked: false };
+    const HOME = homedir();
+    const abs = path.resolve(p);
+    // Exact-match blocklist. The literal home dir and standard user folders
+    // are never project roots even when they coincidentally contain a stray
+    // manifest from an extracted archive.
+    const exactBlocked = new Set([
+        "/", HOME,
+        path.join(HOME, "Desktop"), path.join(HOME, "Documents"),
+        path.join(HOME, "Downloads"), path.join(HOME, "Music"),
+        path.join(HOME, "Movies"), path.join(HOME, "Videos"),
+        path.join(HOME, "Pictures"), path.join(HOME, "Public"),
+        path.join(HOME, "Templates"),
+        path.join(HOME, "Dropbox"), path.join(HOME, "OneDrive"),
+        path.join(HOME, "Google Drive"),
+    ]);
+    if (exactBlocked.has(abs))
+        return { blocked: true, reason: `exact-match blocklist: ${abs}` };
+    // Cloud-sync providers: block the root, allow nested projects.
+    const cloudParent = path.join(HOME, "Library", "CloudStorage");
+    if (path.dirname(abs) === cloudParent)
+        return { blocked: true, reason: `cloud-sync root: ${abs}` };
+    // Prefix-match blocklist. Anything inside a cache / config / credential /
+    // package-manager state tree is system data, not a user project.
+    const prefixes = [
+        "/tmp/", "/var/tmp/", "/private/tmp/", "/private/var/folders/",
+        "/usr/", "/opt/", "/etc/", "/proc/", "/sys/", "/dev/", "/run/", "/boot/", "/snap/",
+        "/Applications/", "/Library/", "/System/", "/Volumes/", "/Network/",
+        path.join(HOME, ".cache") + "/",
+        path.join(HOME, ".config") + "/",
+        path.join(HOME, ".local", "share") + "/",
+        path.join(HOME, ".local", "state") + "/",
+        path.join(HOME, "Library") + "/",
+        path.join(HOME, ".npm") + "/", path.join(HOME, ".yarn") + "/",
+        path.join(HOME, ".pnpm-store") + "/", path.join(HOME, ".bun") + "/",
+        path.join(HOME, ".deno") + "/", path.join(HOME, ".cargo") + "/",
+        path.join(HOME, ".rustup") + "/", path.join(HOME, ".gradle") + "/",
+        path.join(HOME, ".m2") + "/", path.join(HOME, ".gem") + "/",
+        path.join(HOME, ".bundle") + "/", path.join(HOME, ".pyenv") + "/",
+        path.join(HOME, ".virtualenvs") + "/", path.join(HOME, ".nvm") + "/",
+        path.join(HOME, ".asdf") + "/", path.join(HOME, ".mise") + "/",
+        path.join(HOME, ".claude") + "/",
+        path.join(HOME, ".ssh") + "/", path.join(HOME, ".gnupg") + "/",
+        path.join(HOME, ".aws") + "/", path.join(HOME, ".kube") + "/",
+        path.join(HOME, ".docker") + "/",
+    ];
+    const TMPDIR = process.env.TMPDIR;
+    if (TMPDIR)
+        prefixes.push(TMPDIR.endsWith("/") ? TMPDIR : TMPDIR + "/");
+    for (const pref of prefixes) {
+        if (abs + "/" === pref)
+            return { blocked: true, reason: `prefix-blocklist root: ${pref}` };
+        if (abs.startsWith(pref))
+            return { blocked: true, reason: `prefix-blocklist: ${pref}` };
+    }
+    return { blocked: false };
+}
+function basenameSlug(p) {
+    return path.basename(p).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "untitled";
+}
+function findImplicitSubprojects(dir) {
+    const out = [];
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    }
+    catch {
+        return out;
+    }
+    for (const e of entries) {
+        if (!e.isDirectory())
+            continue;
+        if (e.name.startsWith("."))
+            continue;
+        if (HEAVY_DIRS.has(e.name))
+            continue;
+        const sub = path.join(dir, e.name);
+        if (hasStrongSignal(sub))
+            out.push(sub);
+    }
+    return out;
+}
+// Does `parent` qualify as an umbrella that includes `child`?
+// Used when the user opens directly inside a sub-project — we need to detect
+// that the parent is an umbrella so we can prefix the slug correctly.
+function isUmbrellaParentOf(parent, child) {
+    if (!hasStrongSignal(parent))
+        return { is: false, tool: "" };
+    const ws = detectWorkspaces(parent);
+    if (ws) {
+        if (ws.children.some(c => path.resolve(c) === path.resolve(child)))
+            return { is: true, tool: ws.tool };
+    }
+    const implicit = findImplicitSubprojects(parent);
+    if (implicit.length >= 2 && implicit.some(c => path.resolve(c) === path.resolve(child))) {
+        return { is: true, tool: "implicit" };
+    }
+    return { is: false, tool: "" };
+}
+export function classifyPath(cwd) {
+    const abs = path.resolve(cwd);
+    const block = isBlockedPath(abs);
+    if (block.blocked)
+        return { kind: "blocked", reason: block.reason || "blocked" };
+    if (!hasStrongSignal(abs))
+        return { kind: "skip", reason: `no strong project signal at ${abs}` };
+    // We have a strong signal. Two questions: am I a child of an umbrella, or
+    // am I myself an umbrella? Walk up one level to check the first.
+    const parent = path.dirname(abs);
+    if (parent !== abs && !isBlockedPath(parent).blocked) {
+        const ub = isUmbrellaParentOf(parent, abs);
+        if (ub.is) {
+            return { kind: "single", projectDir: abs, umbrella: { dir: parent, slug: basenameSlug(parent) } };
+        }
+    }
+    // Am I an umbrella? Explicit workspace declaration wins over heuristic.
+    const ws = detectWorkspaces(abs);
+    if (ws && ws.children.length >= 2) {
+        return { kind: "umbrella", projectDir: abs, tool: ws.tool, children: ws.children };
+    }
+    const implicit = findImplicitSubprojects(abs);
+    if (implicit.length >= 2) {
+        return { kind: "umbrella", projectDir: abs, tool: "implicit", children: implicit };
+    }
+    return { kind: "single", projectDir: abs };
+}
+export { basenameSlug };

--- a/dist/src/workspaces.js
+++ b/dist/src/workspaces.js
@@ -1,0 +1,289 @@
+import fs from "node:fs";
+import path from "node:path";
+// Workspace / monorepo manifest parsers. Each parser inspects a single
+// declaration file at a given root and returns the absolute paths of declared
+// children, or null if no declaration is present. No external dependencies —
+// the module must stay import-safe so the discoverer can load it from
+// sb-session-start before bootstrap completes.
+// Minimal glob expansion supporting only the patterns actually used by
+// workspace manifests: literal paths, single-segment `*`, and double-star
+// `**`. Patterns are split on `/`; each `*` segment matches a single
+// directory entry; `**` matches any depth. Returns absolute directory paths
+// that exist on disk.
+function expandGlob(root, pattern) {
+    if (!pattern.includes("*")) {
+        const abs = path.resolve(root, pattern);
+        return fs.existsSync(abs) && fs.statSync(abs).isDirectory() ? [abs] : [];
+    }
+    const segments = pattern.split("/").filter(Boolean);
+    let frontier = [path.resolve(root)];
+    for (const seg of segments) {
+        const next = [];
+        for (const dir of frontier) {
+            let entries;
+            try {
+                entries = fs.readdirSync(dir, { withFileTypes: true });
+            }
+            catch {
+                continue;
+            }
+            if (seg === "**") {
+                // Match any depth — include dir itself and recurse into every child.
+                next.push(dir);
+                const stack = entries.filter(e => e.isDirectory() && !e.name.startsWith("."));
+                for (const sub of stack)
+                    next.push(path.join(dir, sub.name));
+            }
+            else if (seg === "*") {
+                for (const e of entries) {
+                    if (e.isDirectory() && !e.name.startsWith("."))
+                        next.push(path.join(dir, e.name));
+                }
+            }
+            else if (seg.includes("*")) {
+                const re = new RegExp("^" + seg.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$");
+                for (const e of entries) {
+                    if (e.isDirectory() && re.test(e.name))
+                        next.push(path.join(dir, e.name));
+                }
+            }
+            else {
+                const candidate = path.join(dir, seg);
+                if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory())
+                    next.push(candidate);
+            }
+        }
+        frontier = next;
+    }
+    return Array.from(new Set(frontier));
+}
+function applyExcludes(included, excludePatterns, root) {
+    if (!excludePatterns.length)
+        return included;
+    const excluded = new Set();
+    for (const e of excludePatterns)
+        for (const p of expandGlob(root, e))
+            excluded.add(p);
+    return included.filter(p => !excluded.has(p));
+}
+function dedupe(paths) {
+    return Array.from(new Set(paths.map(p => path.resolve(p))));
+}
+// npm / yarn classic / yarn berry / bun all read `workspaces` from the root
+// package.json. yarn classic also accepts `{ packages: [...] }`.
+export function parseNpmYarnBunWorkspaces(rootDir) {
+    const pj = path.join(rootDir, "package.json");
+    if (!fs.existsSync(pj))
+        return null;
+    let parsed;
+    try {
+        parsed = JSON.parse(fs.readFileSync(pj, "utf8"));
+    }
+    catch {
+        return null;
+    }
+    let patterns;
+    if (Array.isArray(parsed.workspaces))
+        patterns = parsed.workspaces;
+    else if (parsed.workspaces && Array.isArray(parsed.workspaces.packages))
+        patterns = parsed.workspaces.packages;
+    if (!patterns || !patterns.length)
+        return null;
+    const includes = patterns.filter(p => typeof p === "string" && !p.startsWith("!"));
+    const excludes = patterns.filter(p => typeof p === "string" && p.startsWith("!")).map(p => p.slice(1));
+    const expanded = [];
+    for (const p of includes)
+        expanded.push(...expandGlob(rootDir, p));
+    const filtered = applyExcludes(expanded, excludes, rootDir);
+    // Each declared workspace MUST itself have a package.json to count.
+    return dedupe(filtered).filter(d => fs.existsSync(path.join(d, "package.json")));
+}
+// pnpm-workspace.yaml at root. We parse just `packages:` + `- ...` lines —
+// no general YAML support needed, the file is always this shape.
+export function parsePnpmWorkspace(rootDir) {
+    const p = path.join(rootDir, "pnpm-workspace.yaml");
+    if (!fs.existsSync(p))
+        return null;
+    const text = fs.readFileSync(p, "utf8");
+    const lines = text.split("\n");
+    let inPackages = false;
+    const patterns = [];
+    for (const raw of lines) {
+        const line = raw.replace(/#.*$/, "");
+        if (/^packages\s*:/.test(line)) {
+            inPackages = true;
+            continue;
+        }
+        if (inPackages) {
+            // Next top-level key terminates the packages list.
+            if (/^[a-zA-Z_-]/.test(line)) {
+                inPackages = false;
+                continue;
+            }
+            const m = line.match(/^\s+-\s+["']?([^"'\s]+)["']?\s*$/);
+            if (m)
+                patterns.push(m[1]);
+        }
+    }
+    if (!patterns.length)
+        return null;
+    const includes = patterns.filter(p => !p.startsWith("!"));
+    const excludes = patterns.filter(p => p.startsWith("!")).map(p => p.slice(1));
+    const expanded = [];
+    for (const pat of includes)
+        expanded.push(...expandGlob(rootDir, pat));
+    const filtered = applyExcludes(expanded, excludes, rootDir);
+    return dedupe(filtered).filter(d => fs.existsSync(path.join(d, "package.json")));
+}
+// Cargo: `[workspace] members = [...]` + optional `exclude = [...]`.
+export function parseCargoWorkspace(rootDir) {
+    const p = path.join(rootDir, "Cargo.toml");
+    if (!fs.existsSync(p))
+        return null;
+    const text = fs.readFileSync(p, "utf8");
+    // Find the [workspace] section. Crude but sufficient: scan until next [section].
+    const wsStart = text.search(/^\s*\[workspace\]/m);
+    if (wsStart < 0)
+        return null;
+    let wsEnd = text.indexOf("\n[", wsStart + 1);
+    if (wsEnd < 0)
+        wsEnd = text.length;
+    const section = text.slice(wsStart, wsEnd);
+    function readArray(name) {
+        const m = section.match(new RegExp(name + "\\s*=\\s*\\[([\\s\\S]*?)\\]"));
+        if (!m)
+            return [];
+        return [...m[1].matchAll(/["']([^"']+)["']/g)].map(x => x[1]);
+    }
+    const members = readArray("members");
+    if (!members.length)
+        return null;
+    const excludes = readArray("exclude");
+    const expanded = [];
+    for (const pat of members)
+        expanded.push(...expandGlob(rootDir, pat));
+    const filtered = applyExcludes(expanded, excludes, rootDir);
+    return dedupe(filtered).filter(d => fs.existsSync(path.join(d, "Cargo.toml")));
+}
+// go.work: `use ( ./a ./b )` or single `use ./a` lines.
+export function parseGoWork(rootDir) {
+    const p = path.join(rootDir, "go.work");
+    if (!fs.existsSync(p))
+        return null;
+    const text = fs.readFileSync(p, "utf8");
+    const lines = text.split("\n").map(l => l.replace(/\/\/.*$/, "").trim()).filter(Boolean);
+    const paths = [];
+    let inBlock = false;
+    for (const ln of lines) {
+        if (/^use\s*\(/.test(ln)) {
+            inBlock = true;
+            const rest = ln.replace(/^use\s*\(/, "").trim();
+            if (rest && rest !== ")")
+                paths.push(rest);
+            continue;
+        }
+        if (inBlock) {
+            if (ln === ")") {
+                inBlock = false;
+                continue;
+            }
+            paths.push(ln);
+        }
+        else {
+            const m = ln.match(/^use\s+(.+)$/);
+            if (m)
+                paths.push(m[1].trim());
+        }
+    }
+    if (!paths.length)
+        return null;
+    const abs = paths.map(p => path.resolve(rootDir, p)).filter(d => fs.existsSync(path.join(d, "go.mod")));
+    return dedupe(abs);
+}
+// Maven multi-module: <modules><module>foo</module>...</modules>.
+export function parseMavenModules(rootDir) {
+    const p = path.join(rootDir, "pom.xml");
+    if (!fs.existsSync(p))
+        return null;
+    const text = fs.readFileSync(p, "utf8");
+    const block = text.match(/<modules>([\s\S]*?)<\/modules>/);
+    if (!block)
+        return null;
+    const mods = [...block[1].matchAll(/<module>\s*([^<\s][^<]*?)\s*<\/module>/g)].map(m => m[1].trim());
+    if (!mods.length)
+        return null;
+    const abs = mods.map(m => path.resolve(rootDir, m)).filter(d => fs.existsSync(path.join(d, "pom.xml")));
+    return dedupe(abs);
+}
+// Gradle multi-module: settings.gradle(.kts) with `include 'a', 'b:c'` lines.
+// `:a:b` and `a:b` both mean nested dir a/b.
+export function parseGradleSettings(rootDir) {
+    for (const fname of ["settings.gradle.kts", "settings.gradle"]) {
+        const p = path.join(rootDir, fname);
+        if (!fs.existsSync(p))
+            continue;
+        const text = fs.readFileSync(p, "utf8");
+        const names = [];
+        // include "a", 'b:c'  OR  include("a", "b:c")
+        const includeRe = /include\s*\(?([^)\n]+)\)?/g;
+        let m;
+        while ((m = includeRe.exec(text)) !== null) {
+            const parts = [...m[1].matchAll(/['"]([^'"]+)['"]/g)].map(x => x[1]);
+            names.push(...parts);
+        }
+        if (!names.length)
+            return null;
+        const abs = names.map(n => {
+            const rel = n.replace(/^:/, "").replace(/:/g, "/");
+            return path.resolve(rootDir, rel);
+        }).filter(d => fs.existsSync(d));
+        return dedupe(abs);
+    }
+    return null;
+}
+// Lerna packages — usable only if there's no underlying npm/pnpm workspaces.
+// (Modern lerna delegates to package manager workspaces; we prefer those.)
+export function parseLernaPackages(rootDir) {
+    const p = path.join(rootDir, "lerna.json");
+    if (!fs.existsSync(p))
+        return null;
+    let cfg;
+    try {
+        cfg = JSON.parse(fs.readFileSync(p, "utf8"));
+    }
+    catch {
+        return null;
+    }
+    if (!Array.isArray(cfg.packages))
+        return null;
+    const includes = cfg.packages.filter((p) => typeof p === "string" && !p.startsWith("!"));
+    const excludes = cfg.packages.filter((p) => typeof p === "string" && p.startsWith("!")).map((p) => p.slice(1));
+    const expanded = [];
+    for (const pat of includes)
+        expanded.push(...expandGlob(rootDir, pat));
+    const filtered = applyExcludes(expanded, excludes, rootDir);
+    return dedupe(filtered).filter(d => fs.existsSync(path.join(d, "package.json")));
+}
+// Try each parser in declaration-strength order; first non-empty result wins.
+// pnpm explicitly first because its file is unambiguous; npm/yarn second
+// because turborepo and lerna delegate to it; then language-native tools.
+export function detectWorkspaces(rootDir) {
+    const parsers = [
+        ["pnpm", parsePnpmWorkspace],
+        ["npm/yarn/bun", parseNpmYarnBunWorkspaces],
+        ["cargo", parseCargoWorkspace],
+        ["go", parseGoWork],
+        ["maven", parseMavenModules],
+        ["gradle", parseGradleSettings],
+        ["lerna", parseLernaPackages],
+    ];
+    for (const [name, fn] of parsers) {
+        try {
+            const children = fn(rootDir);
+            if (children && children.length > 0)
+                return { tool: name, children };
+        }
+        catch { /* try next */ }
+    }
+    return null;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",

--- a/src/discoverer.ts
+++ b/src/discoverer.ts
@@ -1,20 +1,23 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { vaultPath } from "./paths.js";
+import { vaultPath, dataDir } from "./paths.js";
 import { slug } from "./router.js";
 import { acquireLock, releaseLock } from "./lockfile.js";
 import { writeFailure } from "./sentinel.js";
 import { distillModel } from "./model.js";
+import { classifyPath, basenameSlug, hasStrongSignal, isBlockedPath, type Classification, type UmbrellaCtx } from "./projectDetect.js";
 
-// Discovery: on a session opening in a project we've never seen before,
-// produce ~/.superbrain/vault/projects/<slug>.md with a substantive code map
-// the next session can read. One Sonnet call per project, ever. After that
-// the note is "known" (its existence is the gate) and further distillation
-// only appends to it via the normal router path.
+// Discovery: synthesize a substantive `projects/<slug>.md` for a code repo
+// the user just opened a session in. The detection cascade lives in
+// projectDetect.ts; this module owns the walking, prompt construction,
+// claude -p call, file write, and umbrella fan-out.
 
-// Directories the walk always skips. Heavy, vendored, or build output —
-// adding them to the prompt context would just blow the token budget.
+const MAX_FILES = 600;
+const MAX_DEPTH = 5;
+const MAX_MANIFEST_BYTES = 8192;
+const MAX_SUBPROJECTS_PER_UMBRELLA = 8;
+
 const HEAVY_DIRS = new Set([
   "node_modules", ".git", "dist", "build", "out", "target", "vendor",
   "__pycache__", ".venv", "venv", ".next", ".nuxt", ".turbo",
@@ -22,12 +25,6 @@ const HEAVY_DIRS = new Set([
   ".gradle", ".mvn", "bin", "obj",
 ]);
 
-// Hard caps so a giant repo never spirals.
-const MAX_FILES = 600;
-const MAX_DEPTH = 5;
-const MAX_MANIFEST_BYTES = 8192;
-
-// Files read in full to anchor the discovery prompt context.
 const MANIFEST_FILES = [
   "README.md", "README.rst", "README", "README.txt",
   "package.json", "pyproject.toml", "Cargo.toml", "go.mod",
@@ -37,31 +34,50 @@ const MANIFEST_FILES = [
   "LICENSE", "LICENSE.md",
 ];
 
-export function projectSlug(projectDir: string): string {
-  return slug(path.basename(projectDir));
+export function projectSlug(projectDir: string, umbrella?: UmbrellaCtx): string {
+  const base = basenameSlug(projectDir);
+  return umbrella ? `${umbrella.slug}-${base}` : base;
 }
 
-export function projectNotePath(projectDir: string): string {
-  return path.join(vaultPath(), "projects", `${projectSlug(projectDir)}.md`);
+// Slug uniqueness for STANDALONE single-project discovery (no umbrella ctx).
+// If the bare basename slug is already taken by a different project_dir, fall
+// back to "<parent>-<basename>". Honors the existing note's project_dir
+// frontmatter to distinguish "same project re-discovered" from "name clash."
+function uniqueStandaloneSlug(projectDir: string): string {
+  const base = basenameSlug(projectDir);
+  const existing = path.join(vaultPath(), "projects", `${base}.md`);
+  if (!fs.existsSync(existing)) return base;
+  try {
+    const content = fs.readFileSync(existing, "utf8");
+    const m = content.match(/^project_dir:\s*"?(.+?)"?\s*$/m);
+    // No project_dir field at all → assume legacy/migrated note for the same
+    // project. Don't disambiguate; share the slug. Only disambiguate when
+    // there's an EXPLICIT, MISMATCHING project_dir — that's the unambiguous
+    // "two different real projects collided on basename" case.
+    if (!m) return base;
+    if (path.resolve(m[1].trim()) === path.resolve(projectDir)) return base;
+  } catch { /* ignore */ }
+  const parentBase = basenameSlug(path.dirname(projectDir));
+  return parentBase ? `${parentBase}-${base}` : base;
 }
 
-// "Unknown" = no project note exists yet. Once discovery (or any distillation)
-// has produced the file, we never re-discover — that protects user edits and
-// avoids ever burning tokens twice on the same project.
-export function isUnknownProject(projectDir: string): boolean {
-  try { return !fs.existsSync(projectNotePath(projectDir)); }
+export function projectNotePath(projectDir: string, umbrella?: UmbrellaCtx): string {
+  const s = umbrella ? projectSlug(projectDir, umbrella) : uniqueStandaloneSlug(projectDir);
+  return path.join(vaultPath(), "projects", `${s}.md`);
+}
+
+export function isUnknownProject(projectDir: string, umbrella?: UmbrellaCtx): boolean {
+  try { return !fs.existsSync(projectNotePath(projectDir, umbrella)); }
   catch { return false; }
 }
 
-// Heuristic gate: don't trigger discovery on directories that aren't actually
-// code projects (the user's home, a random tmp dir, etc.).
+// Re-exported for sb-session-start's old import path (the integration there
+// only checks "should we even spawn?"). Both gates are subsumed by
+// classifyPath, but keeping these as thin shims minimizes drift.
 export function looksLikeCodeProject(projectDir: string): boolean {
   try {
-    if (fs.existsSync(path.join(projectDir, ".git"))) return true;
-    for (const name of MANIFEST_FILES) {
-      if (fs.existsSync(path.join(projectDir, name))) return true;
-    }
-    return false;
+    if (isBlockedPath(projectDir).blocked) return false;
+    return hasStrongSignal(projectDir);
   } catch { return false; }
 }
 
@@ -77,7 +93,6 @@ function walkBounded(root: string): WalkResult {
     let entries: fs.Dirent[] = [];
     try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
     for (const e of entries) {
-      // Skip hidden entries except .github (workflows are signal).
       if (e.name.startsWith(".") && e.name !== ".github") continue;
       if (HEAVY_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
@@ -153,15 +168,15 @@ interface BuildPromptInput {
   manifests: Manifest[];
   paths: string[];
   truncated: boolean;
+  umbrella?: UmbrellaCtx;
 }
 
 export function buildDiscoveryPrompt(input: BuildPromptInput): string {
   const parts: string[] = [DISCOVERY_PROMPT_PREFIX];
   parts.push(`# Project directory\n\n\`${input.projectDir}\`\n`);
+  if (input.umbrella) parts.push(`# Umbrella context\n\nThis project is one sub-project of \`${input.umbrella.dir}\`. Mention it as the parent umbrella in the note's intro paragraph; otherwise treat this sub-project on its own merits.\n`);
   parts.push(`# Manifest files\n`);
-  for (const m of input.manifests) {
-    parts.push(`## ${m.name}\n\n\`\`\`\n${m.content}\n\`\`\`\n`);
-  }
+  for (const m of input.manifests) parts.push(`## ${m.name}\n\n\`\`\`\n${m.content}\n\`\`\`\n`);
   parts.push(`# Source file paths (${input.paths.length}${input.truncated ? `, TRUNCATED at ${MAX_FILES}` : ""})\n`);
   parts.push("```\n" + input.paths.join("\n") + "\n```\n");
   return parts.join("\n");
@@ -174,52 +189,43 @@ function callClaudeForDiscovery(prompt: string): string {
   return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
 }
 
-// Auto-discovery: fires from sb-session-start the first time a session opens
-// in a project with no existing note. Never overwrites — `isUnknownProject`
-// gate skips any project that already has a `projects/<slug>.md`. To force
-// discovery on a project that already has a note (e.g. one migrated from a
-// legacy vault with no real content), use `runDiscoverForce` via the
-// /superbrain:discover slash command.
-export async function runDiscover(projectDir: string): Promise<void> {
-  if (!projectDir || !fs.existsSync(projectDir)) return;
-  if (!looksLikeCodeProject(projectDir)) return;
-  if (!isUnknownProject(projectDir)) return;
-  return runDiscoveryWrite(projectDir, "create");
+// Append a single trace line to ~/.superbrain/discovery.log so users (and we)
+// can diagnose why discovery did or did not fire for a given path. Never
+// fatal — the file is best-effort observability, not load-bearing.
+function logTrace(line: string): void {
+  try {
+    const p = path.join(dataDir(), "discovery.log");
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    const stamp = new Date().toISOString().replace("T", " ").slice(0, 19);
+    fs.appendFileSync(p, `[${stamp}] ${line}\n`);
+  } catch { /* never propagate */ }
 }
 
-// Forced discovery: runs even if a project note already exists. In that case
-// the synthesized body is appended under a `## SuperBrain discovery (date)`
-// heading rather than replacing the file, so user-authored content is never
-// clobbered. Used by `/superbrain:discover` for manual re-discovery on
-// migrated stubs and for explicit refreshes.
-export async function runDiscoverForce(projectDir: string): Promise<void> {
-  if (!projectDir || !fs.existsSync(projectDir)) return;
-  if (!looksLikeCodeProject(projectDir)) return;
-  const mode = isUnknownProject(projectDir) ? "create" : "append";
-  return runDiscoveryWrite(projectDir, mode);
-}
-
-async function runDiscoveryWrite(projectDir: string, mode: "create" | "append"): Promise<void> {
-  if (!acquireLock("discover")) return;
+interface WriteOptions { projectDir: string; umbrella?: UmbrellaCtx; mode: "create" | "append"; }
+async function runDiscoveryWrite(opts: WriteOptions): Promise<void> {
+  const { projectDir, umbrella, mode } = opts;
+  if (!acquireLock("discover")) { logTrace(`skip ${projectDir}: discover lock held`); return; }
   try {
     const { paths, truncated } = walkBounded(projectDir);
     const manifests = readManifests(projectDir);
-    const prompt = buildDiscoveryPrompt({ projectDir, manifests, paths, truncated });
+    const prompt = buildDiscoveryPrompt({ projectDir, manifests, paths, truncated, umbrella });
     const body = callClaudeForDiscovery(prompt).trim();
     if (!body) {
       writeFailure(`discovery returned empty body for ${projectDir}`);
+      logTrace(`fail ${projectDir}: empty body from claude -p`);
       return;
     }
     const date = new Date().toISOString().slice(0, 10);
-    const notePath = projectNotePath(projectDir);
+    const notePath = projectNotePath(projectDir, umbrella);
     fs.mkdirSync(path.dirname(notePath), { recursive: true });
     if (mode === "create") {
-      const frontmatter = [
+      const fm = [
         "---",
         "type: project",
         "status: active",
-        `project: ${projectSlug(projectDir)}`,
+        `project: ${projectSlug(projectDir, umbrella)}`,
         `project_dir: ${JSON.stringify(projectDir)}`,
+        ...(umbrella ? [`umbrella: ${umbrella.slug}`] : []),
         "discovered: true",
         `created: '${date}'`,
         `updated: '${date}'`,
@@ -227,16 +233,73 @@ async function runDiscoveryWrite(projectDir: string, mode: "create" | "append"):
         "---",
         "",
       ].join("\n");
-      fs.writeFileSync(notePath, frontmatter + body + "\n");
+      fs.writeFileSync(notePath, fm + body + "\n");
+      logTrace(`wrote ${notePath} (create${umbrella ? `, umbrella=${umbrella.slug}` : ""})`);
     } else {
-      // Append-only: never clobber user-authored content, never reorder
-      // existing sections, just stamp a fresh discovery block at the bottom.
       const section = `\n\n## SuperBrain discovery (${date})\n\n${body}\n`;
       fs.appendFileSync(notePath, section);
+      logTrace(`appended ${notePath} (force)`);
     }
   } catch (e: any) {
     try { writeFailure(`discovery failed for ${projectDir}: ${e?.message || e}`); } catch { /* noop */ }
+    logTrace(`fail ${projectDir}: ${e?.message || e}`);
   } finally {
     releaseLock("discover");
   }
 }
+
+// Auto-discovery: fires from sb-session-start on a fresh session opening in
+// an unknown project. Routes through the four-stage classifier; "blocked"
+// and "skip" outcomes silently write a trace line and return.
+export async function runDiscover(cwd: string): Promise<void> {
+  if (!cwd || !fs.existsSync(cwd)) { logTrace(`skip: cwd missing or empty`); return; }
+  const c = classifyPath(cwd);
+  if (c.kind === "blocked") { logTrace(`skip ${cwd}: ${c.reason}`); return; }
+  if (c.kind === "skip")    { logTrace(`skip ${cwd}: ${c.reason}`); return; }
+  if (c.kind === "single") {
+    if (!isUnknownProject(c.projectDir, c.umbrella)) { logTrace(`skip ${c.projectDir}: already has a project note`); return; }
+    await runDiscoveryWrite({ projectDir: c.projectDir, umbrella: c.umbrella, mode: "create" });
+    return;
+  }
+  // Umbrella: fan out, one Sonnet call per child, capped.
+  const slice = c.children.slice(0, MAX_SUBPROJECTS_PER_UMBRELLA);
+  const dropped = c.children.length - slice.length;
+  const umbrella: UmbrellaCtx = { dir: c.projectDir, slug: basenameSlug(c.projectDir) };
+  logTrace(`umbrella ${c.projectDir} (tool=${c.tool}): ${c.children.length} children, discovering ${slice.length}${dropped ? `, ${dropped} dropped (over cap)` : ""}`);
+  for (const child of slice) {
+    if (!isUnknownProject(child, umbrella)) { logTrace(`skip umbrella child ${child}: already has a project note`); continue; }
+    await runDiscoveryWrite({ projectDir: child, umbrella, mode: "create" });
+  }
+}
+
+// Force-mode (manual /superbrain:discover). Runs even when a project note
+// already exists, in append mode — appends a fresh "## SuperBrain discovery
+// (date)" section without clobbering user content. Honors umbrella detection:
+// at an umbrella root, fans out to children with the same append semantics.
+// `--all` overrides the "only missing children" default at umbrella roots
+// (without --all, force at an umbrella root only writes children that lack a
+// project note yet).
+export async function runDiscoverForce(cwd: string, opts: { all?: boolean } = {}): Promise<void> {
+  if (!cwd || !fs.existsSync(cwd)) return;
+  const c = classifyPath(cwd);
+  if (c.kind === "blocked") { logTrace(`force skip ${cwd}: ${c.reason}`); return; }
+  if (c.kind === "skip")    { logTrace(`force skip ${cwd}: ${c.reason}`); return; }
+  if (c.kind === "single") {
+    const mode = isUnknownProject(c.projectDir, c.umbrella) ? "create" : "append";
+    await runDiscoveryWrite({ projectDir: c.projectDir, umbrella: c.umbrella, mode });
+    return;
+  }
+  // Umbrella under force: same fan-out, but per-child mode depends on existence
+  // (append if note exists, create if not) — unless --all, which forces append
+  // for every child whose note already exists too.
+  const slice = c.children.slice(0, MAX_SUBPROJECTS_PER_UMBRELLA);
+  const umbrella: UmbrellaCtx = { dir: c.projectDir, slug: basenameSlug(c.projectDir) };
+  for (const child of slice) {
+    const exists = !isUnknownProject(child, umbrella);
+    if (exists && !opts.all) { logTrace(`force skip umbrella child ${child}: note exists (use --all to append)`); continue; }
+    const mode = exists ? "append" : "create";
+    await runDiscoveryWrite({ projectDir: child, umbrella, mode });
+  }
+}
+
+export { classifyPath, isBlockedPath };

--- a/src/projectDetect.ts
+++ b/src/projectDetect.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { detectWorkspaces } from "./workspaces.js";
+
+// Project classification: a four-stage cascade that decides what (if
+// anything) discovery should do for a given session cwd. Pure file-system
+// inspection — no LLM calls, no network. Designed to return in <50ms.
+//
+//   Stage 1: path blocklist (HOME, Documents, /tmp, /Library, …)
+//   Stage 2: strong-signal check (real manifests, not just README/LICENSE)
+//   Stage 3: explicit workspace declaration (pnpm-workspace.yaml, etc.)
+//   Stage 4: implicit umbrella (≥2 sibling subdirs each strong-signal)
+//
+// Each stage is a hard gate. Failure = stop, no discovery, no Sonnet call.
+
+const STRONG_FILES = [
+  ".git", "package.json", "pyproject.toml", "setup.py", "setup.cfg", "Pipfile",
+  "go.mod", "go.work", "Cargo.toml", "pom.xml",
+  "settings.gradle", "settings.gradle.kts", "build.gradle", "build.gradle.kts",
+  "Gemfile", "composer.json", "mix.exs", "pubspec.yaml", "Package.swift",
+  "Project.toml", "stack.yaml", "cabal.project",
+  "flake.nix", "deno.json", "deno.jsonc", "bun.lock", "bun.lockb",
+  "pnpm-workspace.yaml", "MODULE.bazel", "WORKSPACE", "WORKSPACE.bazel",
+  "CLAUDE.md", ".claude", ".mcp.json", "AGENTS.md",
+];
+
+// Suffix-matched strong signals (Xcode bundles, .NET projects, Haskell cabal).
+const STRONG_SUFFIXES = [".xcodeproj", ".xcworkspace", ".sln", ".csproj", ".fsproj", ".vbproj", ".cabal"];
+
+export function hasStrongSignal(dir: string): boolean {
+  try {
+    for (const m of STRONG_FILES) {
+      if (fs.existsSync(path.join(dir, m))) return true;
+    }
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return false; }
+    for (const e of entries) {
+      for (const sfx of STRONG_SUFFIXES) if (e.name.endsWith(sfx)) return true;
+    }
+    return false;
+  } catch { return false; }
+}
+
+// Directories the implicit-umbrella scan skips. They're never themselves a
+// "sub-project" and walking into them costs us nothing useful.
+const HEAVY_DIRS = new Set([
+  "node_modules", ".git", "dist", "build", "out", "target", "vendor",
+  "__pycache__", ".venv", "venv", ".next", ".nuxt", ".turbo",
+  ".cache", ".idea", ".vscode", "coverage", ".pytest_cache",
+  ".gradle", ".mvn", "bin", "obj",
+]);
+
+function homedir(): string { return process.env.HOME || os.homedir(); }
+
+// Path classification. Exposed for tests and for the "why was this skipped?"
+// trace written to ~/.superbrain/discovery.log. SUPERBRAIN_TEST_BYPASS_BLOCKLIST
+// is an internal seam — tests using /tmp paths set it; Claude Code never does.
+export function isBlockedPath(p: string): { blocked: boolean; reason?: string } {
+  if (process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST === "1") return { blocked: false };
+  const HOME = homedir();
+  const abs = path.resolve(p);
+
+  // Exact-match blocklist. The literal home dir and standard user folders
+  // are never project roots even when they coincidentally contain a stray
+  // manifest from an extracted archive.
+  const exactBlocked = new Set<string>([
+    "/", HOME,
+    path.join(HOME, "Desktop"), path.join(HOME, "Documents"),
+    path.join(HOME, "Downloads"), path.join(HOME, "Music"),
+    path.join(HOME, "Movies"), path.join(HOME, "Videos"),
+    path.join(HOME, "Pictures"), path.join(HOME, "Public"),
+    path.join(HOME, "Templates"),
+    path.join(HOME, "Dropbox"), path.join(HOME, "OneDrive"),
+    path.join(HOME, "Google Drive"),
+  ]);
+  if (exactBlocked.has(abs)) return { blocked: true, reason: `exact-match blocklist: ${abs}` };
+
+  // Cloud-sync providers: block the root, allow nested projects.
+  const cloudParent = path.join(HOME, "Library", "CloudStorage");
+  if (path.dirname(abs) === cloudParent) return { blocked: true, reason: `cloud-sync root: ${abs}` };
+
+  // Prefix-match blocklist. Anything inside a cache / config / credential /
+  // package-manager state tree is system data, not a user project.
+  const prefixes: string[] = [
+    "/tmp/", "/var/tmp/", "/private/tmp/", "/private/var/folders/",
+    "/usr/", "/opt/", "/etc/", "/proc/", "/sys/", "/dev/", "/run/", "/boot/", "/snap/",
+    "/Applications/", "/Library/", "/System/", "/Volumes/", "/Network/",
+    path.join(HOME, ".cache") + "/",
+    path.join(HOME, ".config") + "/",
+    path.join(HOME, ".local", "share") + "/",
+    path.join(HOME, ".local", "state") + "/",
+    path.join(HOME, "Library") + "/",
+    path.join(HOME, ".npm") + "/", path.join(HOME, ".yarn") + "/",
+    path.join(HOME, ".pnpm-store") + "/", path.join(HOME, ".bun") + "/",
+    path.join(HOME, ".deno") + "/", path.join(HOME, ".cargo") + "/",
+    path.join(HOME, ".rustup") + "/", path.join(HOME, ".gradle") + "/",
+    path.join(HOME, ".m2") + "/", path.join(HOME, ".gem") + "/",
+    path.join(HOME, ".bundle") + "/", path.join(HOME, ".pyenv") + "/",
+    path.join(HOME, ".virtualenvs") + "/", path.join(HOME, ".nvm") + "/",
+    path.join(HOME, ".asdf") + "/", path.join(HOME, ".mise") + "/",
+    path.join(HOME, ".claude") + "/",
+    path.join(HOME, ".ssh") + "/", path.join(HOME, ".gnupg") + "/",
+    path.join(HOME, ".aws") + "/", path.join(HOME, ".kube") + "/",
+    path.join(HOME, ".docker") + "/",
+  ];
+  const TMPDIR = process.env.TMPDIR;
+  if (TMPDIR) prefixes.push(TMPDIR.endsWith("/") ? TMPDIR : TMPDIR + "/");
+
+  for (const pref of prefixes) {
+    if (abs + "/" === pref) return { blocked: true, reason: `prefix-blocklist root: ${pref}` };
+    if (abs.startsWith(pref)) return { blocked: true, reason: `prefix-blocklist: ${pref}` };
+  }
+  return { blocked: false };
+}
+
+export interface UmbrellaCtx { dir: string; slug: string; }
+
+export type Classification =
+  | { kind: "blocked"; reason: string }
+  | { kind: "skip"; reason: string }
+  | { kind: "single"; projectDir: string; umbrella?: UmbrellaCtx }
+  | { kind: "umbrella"; projectDir: string; tool: string; children: string[] };
+
+function basenameSlug(p: string): string {
+  return path.basename(p).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "untitled";
+}
+
+function findImplicitSubprojects(dir: string): string[] {
+  const out: string[] = [];
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    if (e.name.startsWith(".")) continue;
+    if (HEAVY_DIRS.has(e.name)) continue;
+    const sub = path.join(dir, e.name);
+    if (hasStrongSignal(sub)) out.push(sub);
+  }
+  return out;
+}
+
+// Does `parent` qualify as an umbrella that includes `child`?
+// Used when the user opens directly inside a sub-project — we need to detect
+// that the parent is an umbrella so we can prefix the slug correctly.
+function isUmbrellaParentOf(parent: string, child: string): { is: boolean; tool: string } {
+  if (!hasStrongSignal(parent)) return { is: false, tool: "" };
+  const ws = detectWorkspaces(parent);
+  if (ws) {
+    if (ws.children.some(c => path.resolve(c) === path.resolve(child))) return { is: true, tool: ws.tool };
+  }
+  const implicit = findImplicitSubprojects(parent);
+  if (implicit.length >= 2 && implicit.some(c => path.resolve(c) === path.resolve(child))) {
+    return { is: true, tool: "implicit" };
+  }
+  return { is: false, tool: "" };
+}
+
+export function classifyPath(cwd: string): Classification {
+  const abs = path.resolve(cwd);
+  const block = isBlockedPath(abs);
+  if (block.blocked) return { kind: "blocked", reason: block.reason || "blocked" };
+  if (!hasStrongSignal(abs)) return { kind: "skip", reason: `no strong project signal at ${abs}` };
+
+  // We have a strong signal. Two questions: am I a child of an umbrella, or
+  // am I myself an umbrella? Walk up one level to check the first.
+  const parent = path.dirname(abs);
+  if (parent !== abs && !isBlockedPath(parent).blocked) {
+    const ub = isUmbrellaParentOf(parent, abs);
+    if (ub.is) {
+      return { kind: "single", projectDir: abs, umbrella: { dir: parent, slug: basenameSlug(parent) } };
+    }
+  }
+
+  // Am I an umbrella? Explicit workspace declaration wins over heuristic.
+  const ws = detectWorkspaces(abs);
+  if (ws && ws.children.length >= 2) {
+    return { kind: "umbrella", projectDir: abs, tool: ws.tool, children: ws.children };
+  }
+  const implicit = findImplicitSubprojects(abs);
+  if (implicit.length >= 2) {
+    return { kind: "umbrella", projectDir: abs, tool: "implicit", children: implicit };
+  }
+
+  return { kind: "single", projectDir: abs };
+}
+
+export { basenameSlug };

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -1,0 +1,232 @@
+import fs from "node:fs";
+import path from "node:path";
+
+// Workspace / monorepo manifest parsers. Each parser inspects a single
+// declaration file at a given root and returns the absolute paths of declared
+// children, or null if no declaration is present. No external dependencies —
+// the module must stay import-safe so the discoverer can load it from
+// sb-session-start before bootstrap completes.
+
+// Minimal glob expansion supporting only the patterns actually used by
+// workspace manifests: literal paths, single-segment `*`, and double-star
+// `**`. Patterns are split on `/`; each `*` segment matches a single
+// directory entry; `**` matches any depth. Returns absolute directory paths
+// that exist on disk.
+function expandGlob(root: string, pattern: string): string[] {
+  if (!pattern.includes("*")) {
+    const abs = path.resolve(root, pattern);
+    return fs.existsSync(abs) && fs.statSync(abs).isDirectory() ? [abs] : [];
+  }
+  const segments = pattern.split("/").filter(Boolean);
+  let frontier: string[] = [path.resolve(root)];
+  for (const seg of segments) {
+    const next: string[] = [];
+    for (const dir of frontier) {
+      let entries: fs.Dirent[];
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+      if (seg === "**") {
+        // Match any depth — include dir itself and recurse into every child.
+        next.push(dir);
+        const stack = entries.filter(e => e.isDirectory() && !e.name.startsWith("."));
+        for (const sub of stack) next.push(path.join(dir, sub.name));
+      } else if (seg === "*") {
+        for (const e of entries) {
+          if (e.isDirectory() && !e.name.startsWith(".")) next.push(path.join(dir, e.name));
+        }
+      } else if (seg.includes("*")) {
+        const re = new RegExp("^" + seg.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$");
+        for (const e of entries) {
+          if (e.isDirectory() && re.test(e.name)) next.push(path.join(dir, e.name));
+        }
+      } else {
+        const candidate = path.join(dir, seg);
+        if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) next.push(candidate);
+      }
+    }
+    frontier = next;
+  }
+  return Array.from(new Set(frontier));
+}
+
+function applyExcludes(included: string[], excludePatterns: string[], root: string): string[] {
+  if (!excludePatterns.length) return included;
+  const excluded = new Set<string>();
+  for (const e of excludePatterns) for (const p of expandGlob(root, e)) excluded.add(p);
+  return included.filter(p => !excluded.has(p));
+}
+
+function dedupe(paths: string[]): string[] {
+  return Array.from(new Set(paths.map(p => path.resolve(p))));
+}
+
+// npm / yarn classic / yarn berry / bun all read `workspaces` from the root
+// package.json. yarn classic also accepts `{ packages: [...] }`.
+export function parseNpmYarnBunWorkspaces(rootDir: string): string[] | null {
+  const pj = path.join(rootDir, "package.json");
+  if (!fs.existsSync(pj)) return null;
+  let parsed: any;
+  try { parsed = JSON.parse(fs.readFileSync(pj, "utf8")); } catch { return null; }
+  let patterns: string[] | undefined;
+  if (Array.isArray(parsed.workspaces)) patterns = parsed.workspaces;
+  else if (parsed.workspaces && Array.isArray(parsed.workspaces.packages)) patterns = parsed.workspaces.packages;
+  if (!patterns || !patterns.length) return null;
+  const includes = patterns.filter(p => typeof p === "string" && !p.startsWith("!"));
+  const excludes = patterns.filter(p => typeof p === "string" && p.startsWith("!")).map(p => p.slice(1));
+  const expanded: string[] = [];
+  for (const p of includes) expanded.push(...expandGlob(rootDir, p));
+  const filtered = applyExcludes(expanded, excludes, rootDir);
+  // Each declared workspace MUST itself have a package.json to count.
+  return dedupe(filtered).filter(d => fs.existsSync(path.join(d, "package.json")));
+}
+
+// pnpm-workspace.yaml at root. We parse just `packages:` + `- ...` lines —
+// no general YAML support needed, the file is always this shape.
+export function parsePnpmWorkspace(rootDir: string): string[] | null {
+  const p = path.join(rootDir, "pnpm-workspace.yaml");
+  if (!fs.existsSync(p)) return null;
+  const text = fs.readFileSync(p, "utf8");
+  const lines = text.split("\n");
+  let inPackages = false;
+  const patterns: string[] = [];
+  for (const raw of lines) {
+    const line = raw.replace(/#.*$/, "");
+    if (/^packages\s*:/.test(line)) { inPackages = true; continue; }
+    if (inPackages) {
+      // Next top-level key terminates the packages list.
+      if (/^[a-zA-Z_-]/.test(line)) { inPackages = false; continue; }
+      const m = line.match(/^\s+-\s+["']?([^"'\s]+)["']?\s*$/);
+      if (m) patterns.push(m[1]);
+    }
+  }
+  if (!patterns.length) return null;
+  const includes = patterns.filter(p => !p.startsWith("!"));
+  const excludes = patterns.filter(p => p.startsWith("!")).map(p => p.slice(1));
+  const expanded: string[] = [];
+  for (const pat of includes) expanded.push(...expandGlob(rootDir, pat));
+  const filtered = applyExcludes(expanded, excludes, rootDir);
+  return dedupe(filtered).filter(d => fs.existsSync(path.join(d, "package.json")));
+}
+
+// Cargo: `[workspace] members = [...]` + optional `exclude = [...]`.
+export function parseCargoWorkspace(rootDir: string): string[] | null {
+  const p = path.join(rootDir, "Cargo.toml");
+  if (!fs.existsSync(p)) return null;
+  const text = fs.readFileSync(p, "utf8");
+  // Find the [workspace] section. Crude but sufficient: scan until next [section].
+  const wsStart = text.search(/^\s*\[workspace\]/m);
+  if (wsStart < 0) return null;
+  let wsEnd = text.indexOf("\n[", wsStart + 1);
+  if (wsEnd < 0) wsEnd = text.length;
+  const section = text.slice(wsStart, wsEnd);
+  function readArray(name: string): string[] {
+    const m = section.match(new RegExp(name + "\\s*=\\s*\\[([\\s\\S]*?)\\]"));
+    if (!m) return [];
+    return [...m[1].matchAll(/["']([^"']+)["']/g)].map(x => x[1]);
+  }
+  const members = readArray("members");
+  if (!members.length) return null;
+  const excludes = readArray("exclude");
+  const expanded: string[] = [];
+  for (const pat of members) expanded.push(...expandGlob(rootDir, pat));
+  const filtered = applyExcludes(expanded, excludes, rootDir);
+  return dedupe(filtered).filter(d => fs.existsSync(path.join(d, "Cargo.toml")));
+}
+
+// go.work: `use ( ./a ./b )` or single `use ./a` lines.
+export function parseGoWork(rootDir: string): string[] | null {
+  const p = path.join(rootDir, "go.work");
+  if (!fs.existsSync(p)) return null;
+  const text = fs.readFileSync(p, "utf8");
+  const lines = text.split("\n").map(l => l.replace(/\/\/.*$/, "").trim()).filter(Boolean);
+  const paths: string[] = [];
+  let inBlock = false;
+  for (const ln of lines) {
+    if (/^use\s*\(/.test(ln)) { inBlock = true; const rest = ln.replace(/^use\s*\(/, "").trim(); if (rest && rest !== ")") paths.push(rest); continue; }
+    if (inBlock) {
+      if (ln === ")") { inBlock = false; continue; }
+      paths.push(ln);
+    } else {
+      const m = ln.match(/^use\s+(.+)$/);
+      if (m) paths.push(m[1].trim());
+    }
+  }
+  if (!paths.length) return null;
+  const abs = paths.map(p => path.resolve(rootDir, p)).filter(d => fs.existsSync(path.join(d, "go.mod")));
+  return dedupe(abs);
+}
+
+// Maven multi-module: <modules><module>foo</module>...</modules>.
+export function parseMavenModules(rootDir: string): string[] | null {
+  const p = path.join(rootDir, "pom.xml");
+  if (!fs.existsSync(p)) return null;
+  const text = fs.readFileSync(p, "utf8");
+  const block = text.match(/<modules>([\s\S]*?)<\/modules>/);
+  if (!block) return null;
+  const mods = [...block[1].matchAll(/<module>\s*([^<\s][^<]*?)\s*<\/module>/g)].map(m => m[1].trim());
+  if (!mods.length) return null;
+  const abs = mods.map(m => path.resolve(rootDir, m)).filter(d => fs.existsSync(path.join(d, "pom.xml")));
+  return dedupe(abs);
+}
+
+// Gradle multi-module: settings.gradle(.kts) with `include 'a', 'b:c'` lines.
+// `:a:b` and `a:b` both mean nested dir a/b.
+export function parseGradleSettings(rootDir: string): string[] | null {
+  for (const fname of ["settings.gradle.kts", "settings.gradle"]) {
+    const p = path.join(rootDir, fname);
+    if (!fs.existsSync(p)) continue;
+    const text = fs.readFileSync(p, "utf8");
+    const names: string[] = [];
+    // include "a", 'b:c'  OR  include("a", "b:c")
+    const includeRe = /include\s*\(?([^)\n]+)\)?/g;
+    let m: RegExpExecArray | null;
+    while ((m = includeRe.exec(text)) !== null) {
+      const parts = [...m[1].matchAll(/['"]([^'"]+)['"]/g)].map(x => x[1]);
+      names.push(...parts);
+    }
+    if (!names.length) return null;
+    const abs = names.map(n => {
+      const rel = n.replace(/^:/, "").replace(/:/g, "/");
+      return path.resolve(rootDir, rel);
+    }).filter(d => fs.existsSync(d));
+    return dedupe(abs);
+  }
+  return null;
+}
+
+// Lerna packages — usable only if there's no underlying npm/pnpm workspaces.
+// (Modern lerna delegates to package manager workspaces; we prefer those.)
+export function parseLernaPackages(rootDir: string): string[] | null {
+  const p = path.join(rootDir, "lerna.json");
+  if (!fs.existsSync(p)) return null;
+  let cfg: any;
+  try { cfg = JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; }
+  if (!Array.isArray(cfg.packages)) return null;
+  const includes = cfg.packages.filter((p: any) => typeof p === "string" && !p.startsWith("!"));
+  const excludes = cfg.packages.filter((p: any) => typeof p === "string" && p.startsWith("!")).map((p: string) => p.slice(1));
+  const expanded: string[] = [];
+  for (const pat of includes) expanded.push(...expandGlob(rootDir, pat));
+  const filtered = applyExcludes(expanded, excludes, rootDir);
+  return dedupe(filtered).filter(d => fs.existsSync(path.join(d, "package.json")));
+}
+
+// Try each parser in declaration-strength order; first non-empty result wins.
+// pnpm explicitly first because its file is unambiguous; npm/yarn second
+// because turborepo and lerna delegate to it; then language-native tools.
+export function detectWorkspaces(rootDir: string): { tool: string; children: string[] } | null {
+  const parsers: Array<[string, (r: string) => string[] | null]> = [
+    ["pnpm", parsePnpmWorkspace],
+    ["npm/yarn/bun", parseNpmYarnBunWorkspaces],
+    ["cargo", parseCargoWorkspace],
+    ["go", parseGoWork],
+    ["maven", parseMavenModules],
+    ["gradle", parseGradleSettings],
+    ["lerna", parseLernaPackages],
+  ];
+  for (const [name, fn] of parsers) {
+    try {
+      const children = fn(rootDir);
+      if (children && children.length > 0) return { tool: name, children };
+    } catch { /* try next */ }
+  }
+  return null;
+}

--- a/tests/discoverer.test.ts
+++ b/tests/discoverer.test.ts
@@ -14,6 +14,9 @@ beforeEach(() => {
   fs.mkdirSync(TMP, { recursive: true });
   process.env.SUPERBRAIN_DATA_DIR = path.join(TMP, "data");
   process.env.SUPERBRAIN_VAULT_DIR = path.join(TMP, "vault");
+  // Tests below use /tmp paths as fake projects; bypass the blocklist gate so
+  // classifyPath doesn't reject them just for living under /tmp.
+  process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
 });
 
 describe("discoverer — gates", () => {
@@ -144,6 +147,77 @@ describe("discoverer — runDiscover (stubbed)", () => {
       expect(fs.existsSync(projectNotePath(proj))).toBe(false);
     } finally {
       delete process.env.SUPERBRAIN_DISCOVER_STUB;
+    }
+  });
+});
+
+describe("discoverer — umbrella fan-out", () => {
+  it("fans out into one note per sub-project, prefixing each slug with the umbrella name, NO umbrella note", async () => {
+    const root = path.join(TMP, "the-we-project");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, "CLAUDE.md"), "umbrella\n");
+    for (const name of ["backend", "app", "frontend"]) {
+      const sub = path.join(root, name);
+      fs.mkdirSync(sub, { recursive: true });
+      fs.writeFileSync(path.join(sub, "go.mod"), `module ${name}\n`);
+    }
+    const stubPath = path.join(TMP, "discover-umbrella-stub.md");
+    fs.writeFileSync(stubPath, "# child\n\n> a sub-project\n\n## Stack\n- Go\n");
+    process.env.SUPERBRAIN_DISCOVER_STUB = stubPath;
+    try {
+      await runDiscover(root);
+      const vault = process.env.SUPERBRAIN_VAULT_DIR!;
+      // Three child notes — prefixed by umbrella basename slug.
+      for (const child of ["backend", "app", "frontend"]) {
+        const note = path.join(vault, "projects", `the-we-project-${child}.md`);
+        expect(fs.existsSync(note)).toBe(true);
+        const content = fs.readFileSync(note, "utf8");
+        expect(content).toContain("umbrella: the-we-project");
+      }
+      // NO umbrella note for the root itself.
+      expect(fs.existsSync(path.join(vault, "projects", "the-we-project.md"))).toBe(false);
+    } finally {
+      delete process.env.SUPERBRAIN_DISCOVER_STUB;
+    }
+  });
+
+  it("when opened directly inside a sub-project, prefixes the slug with the umbrella's name", async () => {
+    const root = path.join(TMP, "umbrella2");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, "CLAUDE.md"), "u\n");
+    for (const name of ["a", "b", "c"]) {
+      fs.mkdirSync(path.join(root, name), { recursive: true });
+      fs.writeFileSync(path.join(root, name, "package.json"), `{"name":"${name}"}`);
+    }
+    const stubPath = path.join(TMP, "discover-direct-stub.md");
+    fs.writeFileSync(stubPath, "# a\n");
+    process.env.SUPERBRAIN_DISCOVER_STUB = stubPath;
+    try {
+      // User opens Claude inside the sub-project a/ directly.
+      await runDiscover(path.join(root, "a"));
+      const vault = process.env.SUPERBRAIN_VAULT_DIR!;
+      expect(fs.existsSync(path.join(vault, "projects", "umbrella2-a.md"))).toBe(true);
+      // No bare "a.md" — the umbrella prefix prevents the slug collision.
+      expect(fs.existsSync(path.join(vault, "projects", "a.md"))).toBe(false);
+    } finally {
+      delete process.env.SUPERBRAIN_DISCOVER_STUB;
+    }
+  });
+
+  it("hard-passes (no note, no spawn) on a blocked path", async () => {
+    delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+    const stubPath = path.join(TMP, "blocked-stub.md");
+    fs.writeFileSync(stubPath, "# x\n");
+    process.env.SUPERBRAIN_DISCOVER_STUB = stubPath;
+    try {
+      // /tmp is on the prefix blocklist when bypass is off.
+      await runDiscover("/tmp");
+      const vault = process.env.SUPERBRAIN_VAULT_DIR!;
+      // No projects/ directory should have been created.
+      expect(fs.existsSync(path.join(vault, "projects"))).toBe(false);
+    } finally {
+      delete process.env.SUPERBRAIN_DISCOVER_STUB;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
     }
   });
 });

--- a/tests/projectDetect.test.ts
+++ b/tests/projectDetect.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { classifyPath, isBlockedPath, hasStrongSignal } from "../src/projectDetect";
+
+const TMP = path.join(os.tmpdir(), `sb-pd-${process.pid}`);
+const HOME = process.env.HOME || os.homedir();
+
+beforeEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  // Most tests want to use /tmp paths without the blocklist firing.
+  process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+});
+
+describe("strong-signal detection", () => {
+  it("recognizes .git as a strong signal (directory)", () => {
+    const p = path.join(TMP, "a");
+    fs.mkdirSync(path.join(p, ".git"), { recursive: true });
+    expect(hasStrongSignal(p)).toBe(true);
+  });
+  it("recognizes .git as a strong signal (submodule gitlink file)", () => {
+    const p = path.join(TMP, "submodule");
+    fs.mkdirSync(p, { recursive: true });
+    fs.writeFileSync(path.join(p, ".git"), "gitdir: ../.git/modules/sub\n");
+    expect(hasStrongSignal(p)).toBe(true);
+  });
+  it.each([
+    ["package.json", "{}"],
+    ["pyproject.toml", "[tool.poetry]\nname=\"x\"\n"],
+    ["go.mod", "module x\n"],
+    ["Cargo.toml", "[package]\nname=\"x\"\n"],
+    ["pom.xml", "<project/>"],
+    ["Gemfile", "source 'x'\n"],
+    ["CLAUDE.md", "# project\n"],
+    [".mcp.json", "{}"],
+  ])("recognizes %s as a strong signal", (file, content) => {
+    const p = path.join(TMP, "x");
+    fs.mkdirSync(p, { recursive: true });
+    fs.writeFileSync(path.join(p, file), content);
+    expect(hasStrongSignal(p)).toBe(true);
+  });
+  it("rejects README + LICENSE + Makefile (weak signals only, no manifest)", () => {
+    const p = path.join(TMP, "weak");
+    fs.mkdirSync(p, { recursive: true });
+    fs.writeFileSync(path.join(p, "README.md"), "# notes\n");
+    fs.writeFileSync(path.join(p, "LICENSE"), "MIT\n");
+    fs.writeFileSync(path.join(p, "Makefile"), "all:\n");
+    expect(hasStrongSignal(p)).toBe(false);
+  });
+  it("recognizes a .xcodeproj bundle (suffix match)", () => {
+    const p = path.join(TMP, "ios-proj");
+    fs.mkdirSync(path.join(p, "MyApp.xcodeproj"), { recursive: true });
+    expect(hasStrongSignal(p)).toBe(true);
+  });
+});
+
+describe("blocklist (no bypass)", () => {
+  beforeEach(() => { delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST; });
+
+  it.each([
+    "/",
+    HOME,
+    path.join(HOME, "Documents"),
+    path.join(HOME, "Downloads"),
+    path.join(HOME, "Desktop"),
+    path.join(HOME, "Music"),
+  ])("blocks exact path %s", (p) => {
+    expect(isBlockedPath(p).blocked).toBe(true);
+  });
+
+  it("blocks /tmp prefix children", () => {
+    expect(isBlockedPath("/tmp/anything").blocked).toBe(true);
+  });
+
+  it("blocks ~/.cache prefix children", () => {
+    expect(isBlockedPath(path.join(HOME, ".cache", "anything")).blocked).toBe(true);
+  });
+
+  it("blocks ~/.ssh and ~/.aws (credential roots)", () => {
+    expect(isBlockedPath(path.join(HOME, ".ssh", "stuff")).blocked).toBe(true);
+    expect(isBlockedPath(path.join(HOME, ".aws", "credentials")).blocked).toBe(true);
+  });
+
+  it("blocks the cloud-sync provider roots but ALLOWS nested projects", () => {
+    expect(isBlockedPath(path.join(HOME, "Library", "CloudStorage", "iCloudDrive")).blocked).toBe(true);
+    // Anything under /Library is blocked by the prefix rule, so the subdir
+    // case really applies to ~/Dropbox/projects/foo style — see next test.
+  });
+
+  it("allows ~/Dropbox subdir (cloud sync at $HOME root)", () => {
+    expect(isBlockedPath(path.join(HOME, "Dropbox", "projects", "foo")).blocked).toBe(false);
+    // But blocks ~/Dropbox itself.
+    expect(isBlockedPath(path.join(HOME, "Dropbox")).blocked).toBe(true);
+  });
+
+  it("allows a normal Projects directory", () => {
+    expect(isBlockedPath(path.join(HOME, "Projects", "anything")).blocked).toBe(false);
+  });
+});
+
+describe("classifyPath cascade", () => {
+  it("returns blocked when path is on the blocklist", () => {
+    delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+    const c = classifyPath(HOME);
+    expect(c.kind).toBe("blocked");
+  });
+
+  it("returns skip when no strong signal present (just README)", () => {
+    const p = path.join(TMP, "no-signal");
+    fs.mkdirSync(p, { recursive: true });
+    fs.writeFileSync(path.join(p, "README.md"), "# hi\n");
+    const c = classifyPath(p);
+    expect(c.kind).toBe("skip");
+  });
+
+  it("returns single when strong signal present and no umbrella", () => {
+    const p = path.join(TMP, "solo");
+    fs.mkdirSync(p, { recursive: true });
+    fs.writeFileSync(path.join(p, "package.json"), '{"name":"solo"}');
+    const c = classifyPath(p);
+    expect(c.kind).toBe("single");
+    if (c.kind !== "single") return;
+    expect(c.projectDir).toBe(path.resolve(p));
+    expect(c.umbrella).toBeUndefined();
+  });
+
+  it("returns umbrella when ≥2 sub-projects are detected by heuristic", () => {
+    const root = path.join(TMP, "the-we-project");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, "CLAUDE.md"), "umbrella\n");  // root signal
+    for (const name of ["backend", "app", "frontend"]) {
+      const sub = path.join(root, name);
+      fs.mkdirSync(sub, { recursive: true });
+      fs.writeFileSync(path.join(sub, "package.json"), `{"name":"${name}"}`);
+    }
+    const c = classifyPath(root);
+    expect(c.kind).toBe("umbrella");
+    if (c.kind !== "umbrella") return;
+    expect(c.children.length).toBe(3);
+    expect(c.children.map(p => path.basename(p)).sort()).toEqual(["app", "backend", "frontend"]);
+    expect(c.tool).toBe("implicit");
+  });
+
+  it("returns umbrella when an explicit pnpm workspace declaration exists", () => {
+    const root = path.join(TMP, "pnpm-mono");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, "package.json"), '{"name":"root"}');
+    fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), 'packages:\n  - "packages/*"\n');
+    for (const name of ["a", "b", "c"]) {
+      const sub = path.join(root, "packages", name);
+      fs.mkdirSync(sub, { recursive: true });
+      fs.writeFileSync(path.join(sub, "package.json"), `{"name":"${name}"}`);
+    }
+    const c = classifyPath(root);
+    expect(c.kind).toBe("umbrella");
+    if (c.kind !== "umbrella") return;
+    expect(c.tool).toBe("pnpm");
+    expect(c.children.length).toBe(3);
+  });
+
+  it("treats a single subdir with a manifest as a single project, not an umbrella", () => {
+    const root = path.join(TMP, "almost-umbrella");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, "package.json"), '{"name":"r"}');
+    // Just one sub-project — should NOT trigger umbrella mode.
+    const onlyChild = path.join(root, "tools");
+    fs.mkdirSync(onlyChild, { recursive: true });
+    fs.writeFileSync(path.join(onlyChild, "package.json"), '{"name":"tools"}');
+    const c = classifyPath(root);
+    expect(c.kind).toBe("single");
+  });
+
+  it("when opened directly inside an umbrella's sub-project, encodes umbrella context", () => {
+    const root = path.join(TMP, "the-we-project-2");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, "CLAUDE.md"), "umbrella\n");
+    for (const name of ["backend", "app", "frontend"]) {
+      const sub = path.join(root, name);
+      fs.mkdirSync(sub, { recursive: true });
+      fs.writeFileSync(path.join(sub, "go.mod"), `module ${name}\n`);
+    }
+    // User opens Claude directly in backend/ — we should still know the umbrella.
+    const c = classifyPath(path.join(root, "backend"));
+    expect(c.kind).toBe("single");
+    if (c.kind !== "single") return;
+    expect(c.umbrella).toBeDefined();
+    expect(c.umbrella!.slug).toBe("the-we-project-2");
+  });
+});

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  parseNpmYarnBunWorkspaces, parsePnpmWorkspace, parseCargoWorkspace,
+  parseGoWork, parseMavenModules, parseGradleSettings, parseLernaPackages,
+  detectWorkspaces,
+} from "../src/workspaces";
+
+const TMP = path.join(os.tmpdir(), `sb-ws-${process.pid}`);
+
+beforeEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+});
+
+function mkdir(p: string) { fs.mkdirSync(p, { recursive: true }); }
+function write(p: string, content: string) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+}
+
+describe("npm / yarn / bun workspaces", () => {
+  it("parses the array form and expands packages/* glob", () => {
+    const root = path.join(TMP, "npm-ws");
+    write(path.join(root, "package.json"), JSON.stringify({ workspaces: ["packages/*"] }));
+    for (const n of ["a", "b"]) write(path.join(root, "packages", n, "package.json"), `{"name":"${n}"}`);
+    const c = parseNpmYarnBunWorkspaces(root);
+    expect(c!.length).toBe(2);
+    expect(c!.map(p => path.basename(p)).sort()).toEqual(["a", "b"]);
+  });
+
+  it("parses the yarn-classic { packages: [...] } form", () => {
+    const root = path.join(TMP, "yarn-classic");
+    write(path.join(root, "package.json"), JSON.stringify({ workspaces: { packages: ["apps/*"] } }));
+    write(path.join(root, "apps", "web", "package.json"), '{"name":"web"}');
+    const c = parseNpmYarnBunWorkspaces(root);
+    expect(c!.map(p => path.basename(p))).toEqual(["web"]);
+  });
+
+  it("filters out children that lack a package.json", () => {
+    const root = path.join(TMP, "npm-filter");
+    write(path.join(root, "package.json"), JSON.stringify({ workspaces: ["packages/*"] }));
+    mkdir(path.join(root, "packages", "empty-dir"));
+    write(path.join(root, "packages", "real", "package.json"), '{"name":"real"}');
+    const c = parseNpmYarnBunWorkspaces(root);
+    expect(c!.length).toBe(1);
+    expect(path.basename(c![0])).toBe("real");
+  });
+
+  it("honors negation patterns", () => {
+    const root = path.join(TMP, "npm-negate");
+    write(path.join(root, "package.json"), JSON.stringify({ workspaces: ["packages/*", "!packages/legacy"] }));
+    for (const n of ["a", "legacy"]) write(path.join(root, "packages", n, "package.json"), `{"name":"${n}"}`);
+    const c = parseNpmYarnBunWorkspaces(root);
+    expect(c!.length).toBe(1);
+    expect(path.basename(c![0])).toBe("a");
+  });
+
+  it("returns null when no workspaces field exists", () => {
+    const root = path.join(TMP, "npm-none");
+    write(path.join(root, "package.json"), '{"name":"x"}');
+    expect(parseNpmYarnBunWorkspaces(root)).toBeNull();
+  });
+});
+
+describe("pnpm-workspace.yaml", () => {
+  it("parses the packages list", () => {
+    const root = path.join(TMP, "pnpm-ws");
+    write(path.join(root, "pnpm-workspace.yaml"), `packages:\n  - "packages/*"\n  - "apps/*"\n`);
+    for (const p of ["packages/a", "packages/b", "apps/web"]) {
+      write(path.join(root, p, "package.json"), `{"name":"${path.basename(p)}"}`);
+    }
+    const c = parsePnpmWorkspace(root);
+    expect(c!.length).toBe(3);
+  });
+
+  it("honors negation entries", () => {
+    const root = path.join(TMP, "pnpm-negate");
+    write(path.join(root, "pnpm-workspace.yaml"), `packages:\n  - "packages/*"\n  - "!packages/old"\n`);
+    for (const n of ["new", "old"]) write(path.join(root, "packages", n, "package.json"), `{"name":"${n}"}`);
+    const c = parsePnpmWorkspace(root);
+    expect(c!.length).toBe(1);
+    expect(path.basename(c![0])).toBe("new");
+  });
+});
+
+describe("Cargo workspaces", () => {
+  it("parses [workspace] members with globs", () => {
+    const root = path.join(TMP, "cargo-ws");
+    write(path.join(root, "Cargo.toml"), `[workspace]\nmembers = ["crates/*", "tools/foo"]\n`);
+    for (const p of ["crates/a", "crates/b", "tools/foo"]) {
+      write(path.join(root, p, "Cargo.toml"), `[package]\nname="${path.basename(p)}"\n`);
+    }
+    const c = parseCargoWorkspace(root);
+    expect(c!.length).toBe(3);
+  });
+
+  it("returns null on a single-crate Cargo.toml (no [workspace])", () => {
+    const root = path.join(TMP, "cargo-single");
+    write(path.join(root, "Cargo.toml"), '[package]\nname="solo"\n');
+    expect(parseCargoWorkspace(root)).toBeNull();
+  });
+});
+
+describe("Go workspaces (go.work)", () => {
+  it("parses the use ( ... ) block form", () => {
+    const root = path.join(TMP, "go-ws");
+    write(path.join(root, "go.work"), `go 1.22\n\nuse (\n  ./svc-a\n  ./libs/foo\n)\n`);
+    for (const p of ["svc-a", "libs/foo"]) write(path.join(root, p, "go.mod"), `module ${p}\n`);
+    const c = parseGoWork(root);
+    expect(c!.length).toBe(2);
+    expect(c!.map(p => path.relative(root, p)).sort()).toEqual(["libs/foo", "svc-a"]);
+  });
+
+  it("parses single-line `use ./path` form", () => {
+    const root = path.join(TMP, "go-single");
+    write(path.join(root, "go.work"), `go 1.22\nuse ./api\n`);
+    write(path.join(root, "api", "go.mod"), "module api\n");
+    const c = parseGoWork(root);
+    expect(c!.length).toBe(1);
+  });
+});
+
+describe("Maven modules", () => {
+  it("parses <modules><module>...</module></modules>", () => {
+    const root = path.join(TMP, "maven");
+    write(path.join(root, "pom.xml"), `<project>\n<modules>\n<module>service-a</module>\n<module>service-b</module>\n</modules>\n</project>\n`);
+    for (const n of ["service-a", "service-b"]) write(path.join(root, n, "pom.xml"), "<project/>\n");
+    const c = parseMavenModules(root);
+    expect(c!.length).toBe(2);
+  });
+});
+
+describe("Gradle multi-module", () => {
+  it("parses include 'a', 'b:c' from settings.gradle", () => {
+    const root = path.join(TMP, "gradle");
+    write(path.join(root, "settings.gradle"), `rootProject.name = 'r'\ninclude 'app', 'lib:core'\n`);
+    mkdir(path.join(root, "app"));
+    mkdir(path.join(root, "lib", "core"));
+    const c = parseGradleSettings(root);
+    expect(c!.length).toBe(2);
+    expect(c!.some(p => p.endsWith("app"))).toBe(true);
+    expect(c!.some(p => p.endsWith(path.join("lib", "core")))).toBe(true);
+  });
+
+  it("parses include(...) call form from settings.gradle.kts", () => {
+    const root = path.join(TMP, "gradle-kts");
+    write(path.join(root, "settings.gradle.kts"), `include("a", "b")\n`);
+    mkdir(path.join(root, "a"));
+    mkdir(path.join(root, "b"));
+    const c = parseGradleSettings(root);
+    expect(c!.length).toBe(2);
+  });
+});
+
+describe("Lerna packages", () => {
+  it("parses lerna.json packages", () => {
+    const root = path.join(TMP, "lerna");
+    write(path.join(root, "lerna.json"), JSON.stringify({ packages: ["packages/*"] }));
+    for (const n of ["a", "b"]) write(path.join(root, "packages", n, "package.json"), `{"name":"${n}"}`);
+    const c = parseLernaPackages(root);
+    expect(c!.length).toBe(2);
+  });
+});
+
+describe("detectWorkspaces (top-level dispatch)", () => {
+  it("prefers pnpm-workspace.yaml when both pnpm and npm workspaces are declared", () => {
+    const root = path.join(TMP, "dual");
+    write(path.join(root, "package.json"), JSON.stringify({ workspaces: ["apps/*"] }));
+    write(path.join(root, "pnpm-workspace.yaml"), `packages:\n  - "packages/*"\n`);
+    write(path.join(root, "packages", "p1", "package.json"), '{}');
+    write(path.join(root, "apps", "a1", "package.json"), '{}');
+    const r = detectWorkspaces(root);
+    expect(r!.tool).toBe("pnpm");
+  });
+
+  it("returns null when no workspace declaration exists", () => {
+    const root = path.join(TMP, "none");
+    write(path.join(root, "package.json"), '{"name":"x"}');
+    expect(detectWorkspaces(root)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the loose `looksLikeCodeProject` heuristic with a deterministic four-stage cascade that decides whether (and how) discovery should fire. Pure file-system inspection, no LLM call until the decision is final.

Closes the false-positive class (opening a PDF, a Documents folder, a random extracted zip) and adds correct fan-out for monorepos / umbrella folders.

## The four-stage cascade

1. **Path blocklist** — `$HOME`, Documents/Downloads/Desktop/Music/Movies/Pictures/Public, `/tmp`, `/Library`, `~/.cache`/`~/.config`/`~/.local/share`/`~/Library`, all package-manager state dirs (`.npm`, `.yarn`, `.cargo`, `.gradle`, `.pyenv`, `.nvm`, …), credential roots (`.ssh`, `.aws`, `.gnupg`, `.kube`, `.docker`), cloud-sync provider roots (Dropbox / OneDrive / Google Drive / iCloudDrive). **Subdirs of cloud-sync providers are allowed** so `~/Dropbox/projects/foo` still discovers correctly.

2. **Strong-signal check** — at least one of a curated 30-entry manifest list. Includes `.git`, `package.json`, `go.mod`, `Cargo.toml`, `pyproject.toml`, `pom.xml`, `settings.gradle(.kts)`, `Gemfile`, `composer.json`, `mix.exs`, `pubspec.yaml`, `Package.swift`, `flake.nix`, `deno.json`, `bun.lock`, `pnpm-workspace.yaml`, `MODULE.bazel`, `WORKSPACE`, `CLAUDE.md`, `.claude/`, `.mcp.json`, `AGENTS.md`, plus suffix matches for `*.xcodeproj`, `*.xcworkspace`, `*.sln`, `*.csproj`, `*.cabal`. **`README.md` and `LICENSE` alone are explicitly NOT strong signals** — those produce false positives on every extracted archive.

3. **Explicit workspace declaration** — new `src/workspaces.ts` parses npm/yarn/bun `workspaces`, `pnpm-workspace.yaml`, Cargo `[workspace] members`, `go.work` `use` blocks, Maven `<modules>`, Gradle `settings.gradle(.kts) include`, and `lerna.json` `packages`. pnpm wins over npm when both are declared. Each parser is pure-string-manipulation with no external dependencies — keeps the discoverer import-safe.

4. **Implicit umbrella detection** — if no explicit workspace declaration, walk depth=1 and check each subdir against the strong-signal rule. ≥2 sub-projects → treat as umbrella.

## Behavior matrix

| Detection outcome | What happens |
|---|---|
| Blocked path | No note, no spawn, silent. Trace line in `~/.superbrain/discovery.log`. |
| No strong signal | No note, no spawn, silent. |
| Single project | One Sonnet call → `projects/<slug>.md`. |
| Umbrella (explicit or implicit) | One Sonnet call per child, capped at **8**. **No umbrella note is auto-written** — relationship lives in each child's `umbrella:` frontmatter. Children get umbrella-prefixed slugs (`the-we-project-backend.md`) to avoid collisions across umbrellas. |
| User opens directly inside a sub-project | Walk-up detects the umbrella, applies the prefix slug. |
| `/superbrain:discover` at an umbrella root | Same fan-out, append-on-existing semantics. `--all` flag forces re-discovery of every child. |

## Files

**New:**
- `src/projectDetect.ts` — the cascade.
- `src/workspaces.ts` — seven workspace-manifest parsers + minimal glob expander.
- `tests/projectDetect.test.ts` — 21 tests covering each stage.
- `tests/workspaces.test.ts` — 15 tests, one positive per parser plus negation + dispatch precedence.

**Modified:**
- `src/discoverer.ts` — uses `classifyPath`, handles umbrella fan-out, writes `~/.superbrain/discovery.log` traces.
- `bin/sb-discover.ts` — `--all` flag.
- `commands/discover.md` — updated to reflect the cascade and the umbrella semantics.
- `tests/discoverer.test.ts` — extended with umbrella + direct-subdir + blocked-path tests.

## Decisions (per the plan you signed off on)

| Decision | Outcome |
|---|---|
| Drop the auto-written umbrella note | Yes — encoded via `umbrella:` frontmatter on children |
| Slug naming | Umbrella-prefixed (`<umbrella>-<child>.md`) |
| Sub-project cap | 8 |
| Defer Nx / Rush / Bazel parsing | Yes — implicit umbrella catches them |
| Slug dedup when standalone collision | `<parent>-<basename>` only on EXPLICIT mismatching `project_dir`; legacy notes without that field share the slug |
| `/superbrain:discover --all` flag | Yes |
| Discovery trace log | `~/.superbrain/discovery.log` |

## Test plan

- [x] typecheck clean
- [x] build clean
- [x] **217/217 tests pass** (was 166; +51 new across projectDetect, workspaces, and discoverer umbrella extensions)
- [x] freshCloneE2E still green (import-safety preserved — new modules pull only from `paths`, `router`, `lockfile`, `sentinel`, `model`)
- [x] dist/ regenerated and committed
- [x] live install cache patched for in-session testing

## Version

`0.3.1` → `0.4.0` — meaningful behavior change in what gets auto-discovered.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>