### PR TITLE
feat: /superbrain:inject — manual freeform note ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,25 @@ flowchart LR
 
 - Auto-generated Maps-of-Content (`maps/`) + a lint pass.
 
+## Manual capture with `/superbrain:inject`
+
+Auto-capture handles everything SuperBrain can observe inside a Claude session. When you want to record something it didn't see — a random side thought, a meeting summary from elsewhere, a note imported from another system — use the inject command:
+
+```
+/superbrain:inject I just realized the auth-config endpoint probably needs a TTL field
+/superbrain:inject --from-file ~/Downloads/meeting-summary.md
+/superbrain:inject --project wcloud "transport is HTTP, not gRPC"
+```
+
+What it does:
+
+- **Short single-blob input** lands verbatim in `capture/`. No LLM call.
+- **Longer or multi-topic input** is split via SuperBrain's inject distiller into the right files: decisions to `decisions/`, project facts to the matching `projects/<slug>.md`, references to people to `people/`, everything else to `capture/`.
+- Today's daily note is updated either way.
+- Every injected note carries `source: inject` provenance so it's trivially auditable.
+
+Safety rails: inject never creates new project notes (use `/superbrain:discover` for that), never reshapes preferences, and never silently loses your input — if the distiller returns nothing, your text is written verbatim to `capture/`.
+
 ## Vault structure
 
 ```

--- a/bin/sb-inject.ts
+++ b/bin/sb-inject.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import { depsPresent } from "../src/bootstrap.js";
+import { pluginRoot } from "../src/paths.js";
+import { writeFailure } from "../src/sentinel.js";
+
+interface ParsedArgs {
+  text: string;
+  opts: { verbatim?: boolean; distill?: boolean; project?: string };
+  errors: string[];
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const opts: ParsedArgs["opts"] = {};
+  const errors: string[] = [];
+  const positional: string[] = [];
+  let fromFile: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--verbatim") opts.verbatim = true;
+    else if (a === "--distill") opts.distill = true;
+    else if (a === "--project") {
+      const next = argv[++i];
+      if (!next) errors.push("--project requires a slug");
+      else opts.project = next;
+    } else if (a === "--from-file") {
+      const next = argv[++i];
+      if (!next) errors.push("--from-file requires a path");
+      else fromFile = next;
+    } else if (a.startsWith("--")) {
+      errors.push(`unknown flag: ${a}`);
+    } else {
+      positional.push(a);
+    }
+  }
+  let text = "";
+  if (fromFile) {
+    try {
+      const st = fs.statSync(fromFile);
+      if (st.isDirectory()) errors.push(`--from-file is a directory: ${fromFile}`);
+      else text = fs.readFileSync(fromFile, "utf8");
+    } catch { errors.push(`--from-file not found: ${fromFile}`); }
+  } else if (positional.length > 0) {
+    text = positional.join(" ");
+  } else {
+    try {
+      if (!process.stdin.isTTY) text = fs.readFileSync(0, "utf8");
+    } catch { /* no stdin */ }
+  }
+  return { text, opts, errors };
+}
+
+async function main() {
+  if (!depsPresent(pluginRoot())) {
+    process.stderr.write("inject: dependencies not yet installed (bootstrap pending)\n");
+    process.exit(3);
+  }
+  const { text, opts, errors } = parseArgs(process.argv.slice(2));
+  if (errors.length > 0) {
+    process.stderr.write(errors.join("\n") + "\n");
+    process.exit(2);
+  }
+  if (text.length === 0) {
+    process.stderr.write("inject: no text provided. Pass text as argument, --from-file <path>, or pipe via stdin.\n");
+    process.exit(2);
+  }
+  try {
+    const mod = await import("../src/injectRun.js");
+    const result = await mod.runInject(text, opts);
+    if (!result.ok) {
+      process.stderr.write(`inject: ${result.message || "failed"}\n`);
+      process.exit(2);
+    }
+    const noteCount = result.notes.length;
+    const fallbackNote = result.fallback ? " (LLM returned no items — wrote verbatim)" : "";
+    process.stdout.write(`Wrote ${noteCount} note${noteCount === 1 ? "" : "s"} in ${result.mode} mode${fallbackNote}:\n`);
+    for (const rel of result.notes) process.stdout.write(`  - ${rel}\n`);
+    process.exit(0);
+  } catch (e: any) {
+    try { writeFailure(`inject crashed: ${e?.message || e}`); } catch { /* noop */ }
+    process.stderr.write(`inject: ${e?.message || e}\n`);
+    process.exit(3);
+  }
+}
+
+if ((process.argv[1] && process.argv[1].endsWith("sb-inject.ts")) || process.argv[1]?.endsWith("sb-inject.js")) main();

--- a/commands/inject.md
+++ b/commands/inject.md
@@ -1,0 +1,54 @@
+---
+name: inject
+description: Inject freeform text into the SuperBrain vault. SuperBrain splits multi-topic input, places each item in the right scope (project / decision / capture / etc.), links related notes, and updates today's daily note. Short single-blob input is preserved verbatim; longer or multi-paragraph input is split via the inject distiller. Provenance (`source: inject`) is recorded on every written note. Use whenever you want to record something the auto-capture hooks didn't observe — side thoughts, meeting summaries (e.g. piped from a mem.ai MCP), ad-hoc notes from any session.
+---
+
+# /superbrain:inject
+
+Manual ingestion path. Auto-capture remains the default — this is for content SuperBrain can't observe.
+
+## What it does
+
+1. Validates input (non-empty, alphanumeric, ≤32 KB).
+2. Auto-detects mode: **verbatim** for ≤200 chars with no blank-line separator; **distill** otherwise. Flags `--verbatim` / `--distill` override.
+3. **Verbatim**: writes a single `capture/<date>-<slug>.md` (or `projects/<slug>.md` append if `--project` is passed). No LLM call.
+4. **Distill**: pulls top-5 related vault notes via recall, lists existing project slugs, calls Sonnet 4.6 with the inject-specific prompt, parses the envelope, routes each item via the same `route()` the session distiller uses.
+5. Updates today's daily note. Logs to `~/.superbrain/inject.log`.
+6. On LLM failure or empty envelope, **falls back to verbatim capture** — input is never lost.
+
+## Safety rails
+
+- Inject NEVER creates a new project note. Unknown project slugs are downgraded to `capture/`. (Project notes are created only by `/superbrain:discover`.)
+- Inject NEVER reshapes preferences. Preference items emitted by the model are dropped.
+- `--project <slug>` always wins over anything the model emits.
+- Concurrent with an active session checkpoint? Inject takes the same lock and waits up to 5 s.
+
+## How to invoke
+
+Step 1 — gather the user's text. The slash command argument string is in `$ARGUMENTS`. If `$ARGUMENTS` is empty, ask the user what they'd like to inject before running the command.
+
+Step 2 — invoke the CLI. Pass the argument string straight through; the CLI parses flags itself.
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/dist/bin/sb-inject.js" $ARGUMENTS
+```
+
+If the user wants to inject the contents of a file (e.g. a meeting summary they pasted into `~/Downloads/meeting.md`), use `--from-file`:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/dist/bin/sb-inject.js" --from-file "<path>"
+```
+
+Step 3 — when the call returns, surface the output verbatim (it lists the rel paths of every note written) so the user knows where each piece landed.
+
+If exit code is non-zero, surface the stderr message. Common reasons:
+
+- `empty input` / `no alphanumeric content` / `input exceeds 32 KB` — user fixable.
+- `checkpoint in progress` — tell the user to retry in a moment.
+- `vault write failed` / other — check `~/.superbrain/last-failure.txt`.
+
+## What this is NOT
+
+- Not a replacement for `/superbrain:discover` — discovery synthesizes a project note from a code repo; inject ingests freeform user content.
+- Not a way to edit or delete existing notes — for that, edit the vault directly.
+- Not connected to any external system (mem.ai, etc.). The cross-MCP flow is: the user's other MCP server fetches content, the user pipes it into `inject --from-file` or pastes it as the argument.

--- a/dist/bin/sb-inject.js
+++ b/dist/bin/sb-inject.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import { depsPresent } from "../src/bootstrap.js";
+import { pluginRoot } from "../src/paths.js";
+import { writeFailure } from "../src/sentinel.js";
+function parseArgs(argv) {
+    const opts = {};
+    const errors = [];
+    const positional = [];
+    let fromFile;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === "--verbatim")
+            opts.verbatim = true;
+        else if (a === "--distill")
+            opts.distill = true;
+        else if (a === "--project") {
+            const next = argv[++i];
+            if (!next)
+                errors.push("--project requires a slug");
+            else
+                opts.project = next;
+        }
+        else if (a === "--from-file") {
+            const next = argv[++i];
+            if (!next)
+                errors.push("--from-file requires a path");
+            else
+                fromFile = next;
+        }
+        else if (a.startsWith("--")) {
+            errors.push(`unknown flag: ${a}`);
+        }
+        else {
+            positional.push(a);
+        }
+    }
+    let text = "";
+    if (fromFile) {
+        try {
+            const st = fs.statSync(fromFile);
+            if (st.isDirectory())
+                errors.push(`--from-file is a directory: ${fromFile}`);
+            else
+                text = fs.readFileSync(fromFile, "utf8");
+        }
+        catch {
+            errors.push(`--from-file not found: ${fromFile}`);
+        }
+    }
+    else if (positional.length > 0) {
+        text = positional.join(" ");
+    }
+    else {
+        try {
+            if (!process.stdin.isTTY)
+                text = fs.readFileSync(0, "utf8");
+        }
+        catch { /* no stdin */ }
+    }
+    return { text, opts, errors };
+}
+async function main() {
+    if (!depsPresent(pluginRoot())) {
+        process.stderr.write("inject: dependencies not yet installed (bootstrap pending)\n");
+        process.exit(3);
+    }
+    const { text, opts, errors } = parseArgs(process.argv.slice(2));
+    if (errors.length > 0) {
+        process.stderr.write(errors.join("\n") + "\n");
+        process.exit(2);
+    }
+    if (text.length === 0) {
+        process.stderr.write("inject: no text provided. Pass text as argument, --from-file <path>, or pipe via stdin.\n");
+        process.exit(2);
+    }
+    try {
+        const mod = await import("../src/injectRun.js");
+        const result = await mod.runInject(text, opts);
+        if (!result.ok) {
+            process.stderr.write(`inject: ${result.message || "failed"}\n`);
+            process.exit(2);
+        }
+        const noteCount = result.notes.length;
+        const fallbackNote = result.fallback ? " (LLM returned no items — wrote verbatim)" : "";
+        process.stdout.write(`Wrote ${noteCount} note${noteCount === 1 ? "" : "s"} in ${result.mode} mode${fallbackNote}:\n`);
+        for (const rel of result.notes)
+            process.stdout.write(`  - ${rel}\n`);
+        process.exit(0);
+    }
+    catch (e) {
+        try {
+            writeFailure(`inject crashed: ${e?.message || e}`);
+        }
+        catch { /* noop */ }
+        process.stderr.write(`inject: ${e?.message || e}\n`);
+        process.exit(3);
+    }
+}
+if ((process.argv[1] && process.argv[1].endsWith("sb-inject.ts")) || process.argv[1]?.endsWith("sb-inject.js"))
+    main();

--- a/dist/src/injectPrompt.js
+++ b/dist/src/injectPrompt.js
@@ -4,7 +4,7 @@ const PREFIX = `You are SuperBrain's manual-injection processor. The user has ex
 
 1. Output ONLY a JSON envelope of the form {"items":[...]}. No prose, no backticks.
 2. NEVER invent claims not present in the user's text. Every item's fields must be grounded in the input.
-3. You MUST NOT emit a "preference" item — preferences are reserved for session-pushback distillation, never injection.
+3. You MUST NOT emit a "preference" item — preferences capture session pushback only, never vault capture. Even if the user's text says "I prefer X", treat it as a capture or lesson, not a preference.
 4. You MUST NOT invent a new project slug. Only use a project slug that appears in the "Existing project slugs" list or in the recall hits below. If the user's text references a project not in those lists, emit it as a "capture" item with a tag instead.
 5. Splitting into multiple items is encouraged when the input covers multiple distinct topics (e.g. a meeting summary). Each item must stand on its own.
 6. For each per-kind section (Context, Rationale, Symptom, Why, etc.) fill ONLY if supported by explicit user text. Otherwise OMIT the section entirely.
@@ -19,6 +19,8 @@ const PREFIX = `You are SuperBrain's manual-injection processor. The user has ex
 - capture — default for anything substantive that doesn't fit above.
 
 # Required fields per kind (same shape as session distillation)
+
+For each field below, fill ONLY when the user's text directly provides or strongly implies that value. Optional fields (marked with ?) MUST be omitted if not supported by the input — do NOT invent plausible values to fill them.
 
 decision: { kind, title, date, context?, decision?, rationale?, consequences?, implementation?, project?, links }
 gotcha: { kind, title, date, project, symptom?, rootCause?, fix?, prevention?, links }

--- a/dist/src/injectPrompt.js
+++ b/dist/src/injectPrompt.js
@@ -1,0 +1,60 @@
+const PREFIX = `You are SuperBrain's manual-injection processor. The user has explicitly typed (or pasted) a block of text and run /superbrain:inject — they want this content captured in their second-brain vault. Your job is to split it into structured note items, place each one in the right scope, and link to related vault notes.
+
+# Hard rules — never violate
+
+1. Output ONLY a JSON envelope of the form {"items":[...]}. No prose, no backticks.
+2. NEVER invent claims not present in the user's text. Every item's fields must be grounded in the input.
+3. You MUST NOT emit a "preference" item — preferences are reserved for session-pushback distillation, never injection.
+4. You MUST NOT invent a new project slug. Only use a project slug that appears in the "Existing project slugs" list or in the recall hits below. If the user's text references a project not in those lists, emit it as a "capture" item with a tag instead.
+5. Splitting into multiple items is encouraged when the input covers multiple distinct topics (e.g. a meeting summary). Each item must stand on its own.
+6. For each per-kind section (Context, Rationale, Symptom, Why, etc.) fill ONLY if supported by explicit user text. Otherwise OMIT the section entirely.
+
+# Allowed kinds
+
+- decision — only when the user's text explicitly weighs a tradeoff or records a choice with reasoning.
+- gotcha — only when the user describes a reproduced bug + cause + fix. Requires a project slug; if absent, emit as capture.
+- project_fact — for durable facts about an existing project (architecture, scope, ownership). Requires a project slug from the allowed list.
+- person — for a person reference with role/context.
+- lesson — for a generalizable rule. Rare from injection; allowed.
+- capture — default for anything substantive that doesn't fit above.
+
+# Required fields per kind (same shape as session distillation)
+
+decision: { kind, title, date, context?, decision?, rationale?, consequences?, implementation?, project?, links }
+gotcha: { kind, title, date, project, symptom?, rootCause?, fix?, prevention?, links }
+project_fact: { kind, title, date, project, body, links }
+person: { kind, title, date, person, body, links }
+lesson: { kind, title, date, rule, why?, whenApplies?, links }
+capture: { kind, title, date, body, links }
+
+Use today's date for every item unless the user's text says otherwise.
+
+# Output schema
+
+{"items":[ <items> ]}
+
+# User text
+
+`;
+const RECALL_HEADER = "\n\n# Related vault notes (use as placement context, link via slug in links[] when appropriate)\n\n";
+const PROJECTS_HEADER = "\n\n# Existing project slugs (the only slugs you may use in project: fields)\n\n";
+function formatRecall(hits) {
+    if (hits.length === 0)
+        return "(no related vault notes found)";
+    return hits
+        .map((h) => `- ${h.relPath} — ${h.excerpt}`)
+        .join("\n");
+}
+function formatProjects(slugs) {
+    if (slugs.length === 0)
+        return "(no existing project slugs)";
+    return slugs.map((s) => `- ${s}`).join("\n");
+}
+export function buildInjectPrompt(text, recallHits, projectSlugs) {
+    return (PREFIX +
+        text +
+        RECALL_HEADER +
+        formatRecall(recallHits) +
+        PROJECTS_HEADER +
+        formatProjects(projectSlugs));
+}

--- a/dist/src/injectRun.js
+++ b/dist/src/injectRun.js
@@ -217,7 +217,14 @@ export async function runInject(raw, opts = {}) {
         const knownProjects = new Set(projectSlugs);
         const safeItems = applyInjectSafety(envelope.items, knownProjects, opts.project);
         if (safeItems.length === 0) {
-            return { ok: false, mode: "distill", notes: [], message: "LLM returned no usable items (fallback in Task 7)" };
+            // Fallback: never lose user input. Write the text verbatim to capture/.
+            const item = buildVerbatimItem(sane.text, opts);
+            const rel = await writeOne(item, "verbatim");
+            if (!rel)
+                return { ok: false, mode: "distill", notes: [], message: "vault write failed" };
+            await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+            appendInjectLog("verbatim", 1, sane.text);
+            return { ok: true, mode: "distill", notes: [rel], fallback: true };
         }
         const written = [];
         for (const item of safeItems) {

--- a/dist/src/injectRun.js
+++ b/dist/src/injectRun.js
@@ -12,6 +12,7 @@ import { hybridRecall } from "./recall.js";
 import { parseEnvelope } from "./distillRun.js";
 import { distillModel } from "./model.js";
 import { buildInjectPrompt } from "./injectPrompt.js";
+import { acquireLock, releaseLock } from "./lockfile.js";
 const MAX_INPUT_BYTES = 32 * 1024;
 export function sanityCheck(raw) {
     const stripped = raw.replace(/\0/g, "");
@@ -171,44 +172,64 @@ function applyInjectSafety(items, knownProjects, forcedProject) {
     }
     return out;
 }
+async function acquireDistillLockWithWait(maxWaitMs) {
+    const start = Date.now();
+    const intervalMs = 250;
+    while (Date.now() - start < maxWaitMs) {
+        if (acquireLock("distill"))
+            return true;
+        await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    return false;
+}
 export async function runInject(raw, opts = {}) {
     const sane = sanityCheck(raw);
     if (!sane.ok)
         return { ok: false, mode: "verbatim", notes: [], message: sane.reason };
-    const mode = detectMode(sane.text, opts);
-    if (mode === "verbatim") {
-        const item = buildVerbatimItem(sane.text, opts);
-        const rel = await writeOne(item, "verbatim");
-        if (!rel)
-            return { ok: false, mode, notes: [], message: "vault write failed" };
-        await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
-        appendInjectLog("verbatim", 1, sane.text);
-        return { ok: true, mode, notes: [rel] };
+    const waitMs = Number(process.env.SUPERBRAIN_INJECT_LOCK_WAIT_MS || 5000);
+    const got = await acquireDistillLockWithWait(waitMs);
+    if (!got) {
+        return { ok: false, mode: "verbatim", notes: [], message: "checkpoint in progress — try again in a moment" };
     }
-    // distill mode
-    const recallHits = await gatherRecall(sane.text);
-    const projectSlugs = listProjectSlugs();
-    const prompt = buildInjectPrompt(sane.text, recallHits, projectSlugs);
-    let envelope;
     try {
-        envelope = parseEnvelope(callClaudeInject(prompt));
+        const mode = detectMode(sane.text, opts);
+        if (mode === "verbatim") {
+            const item = buildVerbatimItem(sane.text, opts);
+            const rel = await writeOne(item, "verbatim");
+            if (!rel)
+                return { ok: false, mode, notes: [], message: "vault write failed" };
+            await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+            appendInjectLog("verbatim", 1, sane.text);
+            return { ok: true, mode, notes: [rel] };
+        }
+        // distill mode
+        const recallHits = await gatherRecall(sane.text);
+        const projectSlugs = listProjectSlugs();
+        const prompt = buildInjectPrompt(sane.text, recallHits, projectSlugs);
+        let envelope;
+        try {
+            envelope = parseEnvelope(callClaudeInject(prompt));
+        }
+        catch (e) {
+            writeFailure(`inject LLM call failed: ${e?.message || e}`);
+            envelope = { items: [], openThreads: [], alsoDid: [] };
+        }
+        const knownProjects = new Set(projectSlugs);
+        const safeItems = applyInjectSafety(envelope.items, knownProjects, opts.project);
+        if (safeItems.length === 0) {
+            return { ok: false, mode: "distill", notes: [], message: "LLM returned no usable items (fallback in Task 7)" };
+        }
+        const written = [];
+        for (const item of safeItems) {
+            const rel = await writeOne(item, "distill");
+            if (rel)
+                written.push(rel);
+        }
+        await updateDaily(todayIso(), `inject-${Date.now()}`, written);
+        appendInjectLog("distill", written.length, sane.text);
+        return { ok: written.length > 0, mode: "distill", notes: written };
     }
-    catch (e) {
-        writeFailure(`inject LLM call failed: ${e?.message || e}`);
-        envelope = { items: [], openThreads: [], alsoDid: [] };
+    finally {
+        releaseLock("distill");
     }
-    const knownProjects = new Set(projectSlugs);
-    const safeItems = applyInjectSafety(envelope.items, knownProjects, opts.project);
-    if (safeItems.length === 0) {
-        return { ok: false, mode: "distill", notes: [], message: "LLM returned no usable items (fallback in Task 7)" };
-    }
-    const written = [];
-    for (const item of safeItems) {
-        const rel = await writeOne(item, "distill");
-        if (rel)
-            written.push(rel);
-    }
-    await updateDaily(todayIso(), `inject-${Date.now()}`, written);
-    appendInjectLog("distill", written.length, sane.text);
-    return { ok: written.length > 0, mode: "distill", notes: written };
 }

--- a/dist/src/injectRun.js
+++ b/dist/src/injectRun.js
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import path from "node:path";
+import { route, slug } from "./router.js";
+import { writeNote } from "./vaultWriter.js";
+import { indexNote } from "./indexer.js";
+import { upsertDay } from "./dailyState.js";
+import { buildDailyNote } from "./dailyNote.js";
+import { dataDir } from "./paths.js";
+import { writeFailure } from "./sentinel.js";
+const MAX_INPUT_BYTES = 32 * 1024;
+export function sanityCheck(raw) {
+    const stripped = raw.replace(/\0/g, "");
+    const trimmed = stripped.trim();
+    if (trimmed.length === 0) {
+        return { ok: false, code: 2, reason: "empty input" };
+    }
+    if (Buffer.byteLength(stripped, "utf8") > MAX_INPUT_BYTES) {
+        return { ok: false, code: 2, reason: "input exceeds 32 KB" };
+    }
+    if (!/[a-z0-9]/i.test(trimmed)) {
+        return { ok: false, code: 2, reason: "no alphanumeric content" };
+    }
+    return { ok: true, text: stripped };
+}
+export function detectMode(text, opts) {
+    if (opts.verbatim)
+        return "verbatim";
+    if (opts.distill)
+        return "distill";
+    if (text.length > 200)
+        return "distill";
+    if (/\n\s*\n/.test(text))
+        return "distill";
+    return "verbatim";
+}
+const INJECT_MARKER = "<!-- superbrain:inject ";
+function todayIso() { return new Date().toISOString().slice(0, 10); }
+function nowIso() { return new Date().toISOString(); }
+function injectMarker() {
+    return `${INJECT_MARKER}${todayIso()} -->`;
+}
+function applyInjectProvenance(res, mode) {
+    const fm = {
+        ...res.frontmatter,
+        source: "inject",
+        injected_at: nowIso(),
+        inject_mode: mode,
+    };
+    const body = `${injectMarker()}\n${res.body}`;
+    return { ...res, frontmatter: fm, body };
+}
+function appendInjectLog(mode, count, preview) {
+    try {
+        const stamp = nowIso().replace("T", " ").slice(0, 19);
+        const safePreview = preview.replace(/\s+/g, " ").slice(0, 80);
+        const line = `[${stamp}] ${mode} | ${count} notes | ${safePreview}\n`;
+        fs.appendFileSync(path.join(dataDir(), "inject.log"), line);
+    }
+    catch { /* best-effort */ }
+}
+async function writeOne(item, mode) {
+    const routed = applyInjectProvenance(route(item), mode);
+    const res = writeNote(routed.relPath, {
+        frontmatter: routed.frontmatter,
+        body: routed.body,
+        mode: routed.mode,
+    });
+    if (!res.ok)
+        return null;
+    try {
+        await indexNote(routed.relPath);
+    }
+    catch (e) {
+        writeFailure(`inject index failed: ${e?.message || e}`);
+    }
+    return routed.relPath;
+}
+async function updateDaily(date, sid, routedRel) {
+    try {
+        upsertDay(date, sid, {
+            digestLine: "",
+            routedRelPaths: routedRel,
+            alsoDid: [],
+            openThreads: [],
+        });
+        const dn = buildDailyNote(date);
+        writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });
+        try {
+            await indexNote(dn.relPath);
+        }
+        catch (e) {
+            writeFailure(`inject daily index failed: ${e?.message || e}`);
+        }
+    }
+    catch (e) {
+        writeFailure(`inject daily upsert failed: ${e?.message || e}`);
+    }
+}
+function buildVerbatimItem(text, opts) {
+    const date = todayIso();
+    const firstLine = text.split(/\n/, 1)[0].trim();
+    const title = firstLine.slice(0, 80) || "Injected note";
+    if (opts.project) {
+        return {
+            kind: "project_fact",
+            title,
+            date,
+            project: slug(opts.project),
+            body: text.trim(),
+            links: [],
+        };
+    }
+    return { kind: "capture", title, date, body: text.trim(), links: [] };
+}
+export async function runInject(raw, opts = {}) {
+    const sane = sanityCheck(raw);
+    if (!sane.ok)
+        return { ok: false, mode: "verbatim", notes: [], message: sane.reason };
+    const mode = detectMode(sane.text, opts);
+    if (mode === "verbatim") {
+        const item = buildVerbatimItem(sane.text, opts);
+        const rel = await writeOne(item, "verbatim");
+        if (!rel)
+            return { ok: false, mode, notes: [], message: "vault write failed" };
+        await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+        appendInjectLog("verbatim", 1, sane.text);
+        return { ok: true, mode, notes: [rel] };
+    }
+    // distill path lands in Task 4 (will be replaced then)
+    return { ok: false, mode, notes: [], message: "distill mode not yet implemented" };
+}

--- a/dist/src/injectRun.js
+++ b/dist/src/injectRun.js
@@ -1,12 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { route, slug } from "./router.js";
 import { writeNote } from "./vaultWriter.js";
 import { indexNote } from "./indexer.js";
 import { upsertDay } from "./dailyState.js";
 import { buildDailyNote } from "./dailyNote.js";
-import { dataDir } from "./paths.js";
+import { dataDir, vaultPath } from "./paths.js";
 import { writeFailure } from "./sentinel.js";
+import { hybridRecall } from "./recall.js";
+import { parseEnvelope } from "./distillRun.js";
+import { distillModel } from "./model.js";
+import { buildInjectPrompt } from "./injectPrompt.js";
 const MAX_INPUT_BYTES = 32 * 1024;
 export function sanityCheck(raw) {
     const stripped = raw.replace(/\0/g, "");
@@ -96,6 +101,33 @@ async function updateDaily(date, sid, routedRel) {
         writeFailure(`inject daily upsert failed: ${e?.message || e}`);
     }
 }
+function listProjectSlugs() {
+    try {
+        const dir = path.join(vaultPath(), "projects");
+        if (!fs.existsSync(dir))
+            return [];
+        return fs.readdirSync(dir)
+            .filter((f) => f.endsWith(".md"))
+            .map((f) => f.replace(/\.md$/, ""));
+    }
+    catch {
+        return [];
+    }
+}
+function callClaudeInject(prompt) {
+    const stub = process.env.SUPERBRAIN_DISTILL_STUB;
+    if (stub)
+        return fs.readFileSync(stub, "utf8");
+    return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
+}
+async function gatherRecall(text) {
+    try {
+        return await hybridRecall(text, 5);
+    }
+    catch {
+        return [];
+    }
+}
 function buildVerbatimItem(text, opts) {
     const date = todayIso();
     const firstLine = text.split(/\n/, 1)[0].trim();
@@ -126,6 +158,29 @@ export async function runInject(raw, opts = {}) {
         appendInjectLog("verbatim", 1, sane.text);
         return { ok: true, mode, notes: [rel] };
     }
-    // distill path lands in Task 4 (will be replaced then)
-    return { ok: false, mode, notes: [], message: "distill mode not yet implemented" };
+    // distill mode
+    const recallHits = await gatherRecall(sane.text);
+    const projectSlugs = listProjectSlugs();
+    const prompt = buildInjectPrompt(sane.text, recallHits, projectSlugs);
+    let envelope;
+    try {
+        envelope = parseEnvelope(callClaudeInject(prompt));
+    }
+    catch (e) {
+        writeFailure(`inject LLM call failed: ${e?.message || e}`);
+        envelope = { items: [], openThreads: [], alsoDid: [] };
+    }
+    if (envelope.items.length === 0) {
+        // Task 7 will replace this with verbatim fallback. For now: fail-soft.
+        return { ok: false, mode: "distill", notes: [], message: "LLM returned no items (fallback in Task 7)" };
+    }
+    const written = [];
+    for (const item of envelope.items) {
+        const rel = await writeOne(item, "distill");
+        if (rel)
+            written.push(rel);
+    }
+    await updateDaily(todayIso(), `inject-${Date.now()}`, written);
+    appendInjectLog("distill", written.length, sane.text);
+    return { ok: written.length > 0, mode: "distill", notes: written };
 }

--- a/dist/src/injectRun.js
+++ b/dist/src/injectRun.js
@@ -144,6 +144,32 @@ function buildVerbatimItem(text, opts) {
     }
     return { kind: "capture", title, date, body: text.trim(), links: [] };
 }
+function applyInjectSafety(items, knownProjects, forcedProject) {
+    const out = [];
+    for (const it of items) {
+        if (it.kind === "preference")
+            continue;
+        let project = it.project;
+        if (forcedProject)
+            project = slug(forcedProject);
+        if (it.kind === "project_fact" || it.kind === "gotcha") {
+            const p = project ? slug(project) : undefined;
+            if (!p || !knownProjects.has(p)) {
+                const tag = p ? ` (project: ${p})` : "";
+                out.push({
+                    kind: "capture",
+                    title: it.title,
+                    date: it.date,
+                    body: ((it.body || "") + tag).trim(),
+                    links: it.links,
+                });
+                continue;
+            }
+        }
+        out.push({ ...it, project });
+    }
+    return out;
+}
 export async function runInject(raw, opts = {}) {
     const sane = sanityCheck(raw);
     if (!sane.ok)
@@ -170,12 +196,13 @@ export async function runInject(raw, opts = {}) {
         writeFailure(`inject LLM call failed: ${e?.message || e}`);
         envelope = { items: [], openThreads: [], alsoDid: [] };
     }
-    if (envelope.items.length === 0) {
-        // Task 7 will replace this with verbatim fallback. For now: fail-soft.
-        return { ok: false, mode: "distill", notes: [], message: "LLM returned no items (fallback in Task 7)" };
+    const knownProjects = new Set(projectSlugs);
+    const safeItems = applyInjectSafety(envelope.items, knownProjects, opts.project);
+    if (safeItems.length === 0) {
+        return { ok: false, mode: "distill", notes: [], message: "LLM returned no usable items (fallback in Task 7)" };
     }
     const written = [];
-    for (const item of envelope.items) {
+    for (const item of safeItems) {
         const rel = await writeOne(item, "distill");
         if (rel)
             written.push(rel);

--- a/dist/src/injectRun.js
+++ b/dist/src/injectRun.js
@@ -152,6 +152,7 @@ function applyInjectSafety(items, knownProjects, forcedProject) {
         let project = it.project;
         if (forcedProject)
             project = slug(forcedProject);
+        // Inject must never create new project notes — that's reserved for /superbrain:discover.
         if (it.kind === "project_fact" || it.kind === "gotcha") {
             const p = project ? slug(project) : undefined;
             if (!p || !knownProjects.has(p)) {

--- a/src/injectPrompt.ts
+++ b/src/injectPrompt.ts
@@ -6,7 +6,7 @@ const PREFIX = `You are SuperBrain's manual-injection processor. The user has ex
 
 1. Output ONLY a JSON envelope of the form {"items":[...]}. No prose, no backticks.
 2. NEVER invent claims not present in the user's text. Every item's fields must be grounded in the input.
-3. You MUST NOT emit a "preference" item — preferences are reserved for session-pushback distillation, never injection.
+3. You MUST NOT emit a "preference" item — preferences capture session pushback only, never vault capture. Even if the user's text says "I prefer X", treat it as a capture or lesson, not a preference.
 4. You MUST NOT invent a new project slug. Only use a project slug that appears in the "Existing project slugs" list or in the recall hits below. If the user's text references a project not in those lists, emit it as a "capture" item with a tag instead.
 5. Splitting into multiple items is encouraged when the input covers multiple distinct topics (e.g. a meeting summary). Each item must stand on its own.
 6. For each per-kind section (Context, Rationale, Symptom, Why, etc.) fill ONLY if supported by explicit user text. Otherwise OMIT the section entirely.
@@ -21,6 +21,8 @@ const PREFIX = `You are SuperBrain's manual-injection processor. The user has ex
 - capture — default for anything substantive that doesn't fit above.
 
 # Required fields per kind (same shape as session distillation)
+
+For each field below, fill ONLY when the user's text directly provides or strongly implies that value. Optional fields (marked with ?) MUST be omitted if not supported by the input — do NOT invent plausible values to fill them.
 
 decision: { kind, title, date, context?, decision?, rationale?, consequences?, implementation?, project?, links }
 gotcha: { kind, title, date, project, symptom?, rootCause?, fix?, prevention?, links }

--- a/src/injectPrompt.ts
+++ b/src/injectPrompt.ts
@@ -1,0 +1,70 @@
+import type { Pointer } from "./recall.js";
+
+const PREFIX = `You are SuperBrain's manual-injection processor. The user has explicitly typed (or pasted) a block of text and run /superbrain:inject — they want this content captured in their second-brain vault. Your job is to split it into structured note items, place each one in the right scope, and link to related vault notes.
+
+# Hard rules — never violate
+
+1. Output ONLY a JSON envelope of the form {"items":[...]}. No prose, no backticks.
+2. NEVER invent claims not present in the user's text. Every item's fields must be grounded in the input.
+3. You MUST NOT emit a "preference" item — preferences are reserved for session-pushback distillation, never injection.
+4. You MUST NOT invent a new project slug. Only use a project slug that appears in the "Existing project slugs" list or in the recall hits below. If the user's text references a project not in those lists, emit it as a "capture" item with a tag instead.
+5. Splitting into multiple items is encouraged when the input covers multiple distinct topics (e.g. a meeting summary). Each item must stand on its own.
+6. For each per-kind section (Context, Rationale, Symptom, Why, etc.) fill ONLY if supported by explicit user text. Otherwise OMIT the section entirely.
+
+# Allowed kinds
+
+- decision — only when the user's text explicitly weighs a tradeoff or records a choice with reasoning.
+- gotcha — only when the user describes a reproduced bug + cause + fix. Requires a project slug; if absent, emit as capture.
+- project_fact — for durable facts about an existing project (architecture, scope, ownership). Requires a project slug from the allowed list.
+- person — for a person reference with role/context.
+- lesson — for a generalizable rule. Rare from injection; allowed.
+- capture — default for anything substantive that doesn't fit above.
+
+# Required fields per kind (same shape as session distillation)
+
+decision: { kind, title, date, context?, decision?, rationale?, consequences?, implementation?, project?, links }
+gotcha: { kind, title, date, project, symptom?, rootCause?, fix?, prevention?, links }
+project_fact: { kind, title, date, project, body, links }
+person: { kind, title, date, person, body, links }
+lesson: { kind, title, date, rule, why?, whenApplies?, links }
+capture: { kind, title, date, body, links }
+
+Use today's date for every item unless the user's text says otherwise.
+
+# Output schema
+
+{"items":[ <items> ]}
+
+# User text
+
+`;
+
+const RECALL_HEADER = "\n\n# Related vault notes (use as placement context, link via slug in links[] when appropriate)\n\n";
+const PROJECTS_HEADER = "\n\n# Existing project slugs (the only slugs you may use in project: fields)\n\n";
+
+function formatRecall(hits: Pointer[]): string {
+  if (hits.length === 0) return "(no related vault notes found)";
+  return hits
+    .map((h) => `- ${h.relPath} — ${h.excerpt}`)
+    .join("\n");
+}
+
+function formatProjects(slugs: string[]): string {
+  if (slugs.length === 0) return "(no existing project slugs)";
+  return slugs.map((s) => `- ${s}`).join("\n");
+}
+
+export function buildInjectPrompt(
+  text: string,
+  recallHits: Pointer[],
+  projectSlugs: string[],
+): string {
+  return (
+    PREFIX +
+    text +
+    RECALL_HEADER +
+    formatRecall(recallHits) +
+    PROJECTS_HEADER +
+    formatProjects(projectSlugs)
+  );
+}

--- a/src/injectRun.ts
+++ b/src/injectRun.ts
@@ -239,7 +239,13 @@ export async function runInject(raw: string, opts: InjectOpts = {}): Promise<Inj
     const knownProjects = new Set(projectSlugs);
     const safeItems = applyInjectSafety(envelope.items, knownProjects, opts.project);
     if (safeItems.length === 0) {
-      return { ok: false, mode: "distill", notes: [], message: "LLM returned no usable items (fallback in Task 7)" };
+      // Fallback: never lose user input. Write the text verbatim to capture/.
+      const item = buildVerbatimItem(sane.text, opts);
+      const rel = await writeOne(item, "verbatim");
+      if (!rel) return { ok: false, mode: "distill", notes: [], message: "vault write failed" };
+      await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+      appendInjectLog("verbatim", 1, sane.text);
+      return { ok: true, mode: "distill", notes: [rel], fallback: true };
     }
     const written: string[] = [];
     for (const item of safeItems) {

--- a/src/injectRun.ts
+++ b/src/injectRun.ts
@@ -12,6 +12,7 @@ import { hybridRecall, type Pointer } from "./recall.js";
 import { parseEnvelope } from "./distillRun.js";
 import { distillModel } from "./model.js";
 import { buildInjectPrompt } from "./injectPrompt.js";
+import { acquireLock, releaseLock } from "./lockfile.js";
 
 export interface InjectOpts {
   verbatim?: boolean;
@@ -194,43 +195,61 @@ function applyInjectSafety(
   return out;
 }
 
+async function acquireDistillLockWithWait(maxWaitMs: number): Promise<boolean> {
+  const start = Date.now();
+  const intervalMs = 250;
+  while (Date.now() - start < maxWaitMs) {
+    if (acquireLock("distill")) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return false;
+}
+
 export async function runInject(raw: string, opts: InjectOpts = {}): Promise<InjectResult> {
   const sane = sanityCheck(raw);
   if (!sane.ok) return { ok: false, mode: "verbatim", notes: [], message: sane.reason };
 
-  const mode = detectMode(sane.text, opts);
-  if (mode === "verbatim") {
-    const item = buildVerbatimItem(sane.text, opts);
-    const rel = await writeOne(item, "verbatim");
-    if (!rel) return { ok: false, mode, notes: [], message: "vault write failed" };
-    await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
-    appendInjectLog("verbatim", 1, sane.text);
-    return { ok: true, mode, notes: [rel] };
-  }
-  // distill mode
-  const recallHits = await gatherRecall(sane.text);
-  const projectSlugs = listProjectSlugs();
-  const prompt = buildInjectPrompt(sane.text, recallHits, projectSlugs);
-  let envelope;
-  try { envelope = parseEnvelope(callClaudeInject(prompt)); }
-  catch (e: any) {
-    writeFailure(`inject LLM call failed: ${e?.message || e}`);
-    envelope = { items: [], openThreads: [], alsoDid: [] };
+  const waitMs = Number(process.env.SUPERBRAIN_INJECT_LOCK_WAIT_MS || 5000);
+  const got = await acquireDistillLockWithWait(waitMs);
+  if (!got) {
+    return { ok: false, mode: "verbatim", notes: [], message: "checkpoint in progress — try again in a moment" };
   }
 
-  const knownProjects = new Set(projectSlugs);
-  const safeItems = applyInjectSafety(envelope.items, knownProjects, opts.project);
+  try {
+    const mode = detectMode(sane.text, opts);
+    if (mode === "verbatim") {
+      const item = buildVerbatimItem(sane.text, opts);
+      const rel = await writeOne(item, "verbatim");
+      if (!rel) return { ok: false, mode, notes: [], message: "vault write failed" };
+      await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+      appendInjectLog("verbatim", 1, sane.text);
+      return { ok: true, mode, notes: [rel] };
+    }
 
-  if (safeItems.length === 0) {
-    return { ok: false, mode: "distill", notes: [], message: "LLM returned no usable items (fallback in Task 7)" };
+    // distill mode
+    const recallHits = await gatherRecall(sane.text);
+    const projectSlugs = listProjectSlugs();
+    const prompt = buildInjectPrompt(sane.text, recallHits, projectSlugs);
+    let envelope;
+    try { envelope = parseEnvelope(callClaudeInject(prompt)); }
+    catch (e: any) {
+      writeFailure(`inject LLM call failed: ${e?.message || e}`);
+      envelope = { items: [], openThreads: [], alsoDid: [] };
+    }
+    const knownProjects = new Set(projectSlugs);
+    const safeItems = applyInjectSafety(envelope.items, knownProjects, opts.project);
+    if (safeItems.length === 0) {
+      return { ok: false, mode: "distill", notes: [], message: "LLM returned no usable items (fallback in Task 7)" };
+    }
+    const written: string[] = [];
+    for (const item of safeItems) {
+      const rel = await writeOne(item, "distill");
+      if (rel) written.push(rel);
+    }
+    await updateDaily(todayIso(), `inject-${Date.now()}`, written);
+    appendInjectLog("distill", written.length, sane.text);
+    return { ok: written.length > 0, mode: "distill", notes: written };
+  } finally {
+    releaseLock("distill");
   }
-
-  const written: string[] = [];
-  for (const item of safeItems) {
-    const rel = await writeOne(item, "distill");
-    if (rel) written.push(rel);
-  }
-  await updateDaily(todayIso(), `inject-${Date.now()}`, written);
-  appendInjectLog("distill", written.length, sane.text);
-  return { ok: written.length > 0, mode: "distill", notes: written };
 }

--- a/src/injectRun.ts
+++ b/src/injectRun.ts
@@ -1,12 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { route, type DistilledItem, slug } from "./router.js";
 import { writeNote } from "./vaultWriter.js";
 import { indexNote } from "./indexer.js";
 import { upsertDay } from "./dailyState.js";
 import { buildDailyNote } from "./dailyNote.js";
-import { dataDir } from "./paths.js";
+import { dataDir, vaultPath } from "./paths.js";
 import { writeFailure } from "./sentinel.js";
+import { hybridRecall, type Pointer } from "./recall.js";
+import { parseEnvelope } from "./distillRun.js";
+import { distillModel } from "./model.js";
+import { buildInjectPrompt } from "./injectPrompt.js";
 
 export interface InjectOpts {
   verbatim?: boolean;
@@ -120,6 +125,26 @@ async function updateDaily(date: string, sid: string, routedRel: string[]): Prom
   }
 }
 
+function listProjectSlugs(): string[] {
+  try {
+    const dir = path.join(vaultPath(), "projects");
+    if (!fs.existsSync(dir)) return [];
+    return fs.readdirSync(dir)
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => f.replace(/\.md$/, ""));
+  } catch { return []; }
+}
+
+function callClaudeInject(prompt: string): string {
+  const stub = process.env.SUPERBRAIN_DISTILL_STUB;
+  if (stub) return fs.readFileSync(stub, "utf8");
+  return execFileSync("claude", ["--model", distillModel(), "-p", prompt], { encoding: "utf8" });
+}
+
+async function gatherRecall(text: string): Promise<Pointer[]> {
+  try { return await hybridRecall(text, 5); } catch { return []; }
+}
+
 function buildVerbatimItem(text: string, opts: InjectOpts): DistilledItem {
   const date = todayIso();
   const firstLine = text.split(/\n/, 1)[0].trim();
@@ -150,6 +175,28 @@ export async function runInject(raw: string, opts: InjectOpts = {}): Promise<Inj
     appendInjectLog("verbatim", 1, sane.text);
     return { ok: true, mode, notes: [rel] };
   }
-  // distill path lands in Task 4 (will be replaced then)
-  return { ok: false, mode, notes: [], message: "distill mode not yet implemented" };
+  // distill mode
+  const recallHits = await gatherRecall(sane.text);
+  const projectSlugs = listProjectSlugs();
+  const prompt = buildInjectPrompt(sane.text, recallHits, projectSlugs);
+  let envelope;
+  try { envelope = parseEnvelope(callClaudeInject(prompt)); }
+  catch (e: any) {
+    writeFailure(`inject LLM call failed: ${e?.message || e}`);
+    envelope = { items: [], openThreads: [], alsoDid: [] };
+  }
+
+  if (envelope.items.length === 0) {
+    // Task 7 will replace this with verbatim fallback. For now: fail-soft.
+    return { ok: false, mode: "distill", notes: [], message: "LLM returned no items (fallback in Task 7)" };
+  }
+
+  const written: string[] = [];
+  for (const item of envelope.items) {
+    const rel = await writeOne(item, "distill");
+    if (rel) written.push(rel);
+  }
+  await updateDaily(todayIso(), `inject-${Date.now()}`, written);
+  appendInjectLog("distill", written.length, sane.text);
+  return { ok: written.length > 0, mode: "distill", notes: written };
 }

--- a/src/injectRun.ts
+++ b/src/injectRun.ts
@@ -162,6 +162,37 @@ function buildVerbatimItem(text: string, opts: InjectOpts): DistilledItem {
   return { kind: "capture", title, date, body: text.trim(), links: [] };
 }
 
+function applyInjectSafety(
+  items: DistilledItem[],
+  knownProjects: Set<string>,
+  forcedProject: string | undefined,
+): DistilledItem[] {
+  const out: DistilledItem[] = [];
+  for (const it of items) {
+    if (it.kind === "preference") continue;
+
+    let project = it.project;
+    if (forcedProject) project = slug(forcedProject);
+
+    if (it.kind === "project_fact" || it.kind === "gotcha") {
+      const p = project ? slug(project) : undefined;
+      if (!p || !knownProjects.has(p)) {
+        const tag = p ? ` (project: ${p})` : "";
+        out.push({
+          kind: "capture",
+          title: it.title,
+          date: it.date,
+          body: ((it.body || "") + tag).trim(),
+          links: it.links,
+        });
+        continue;
+      }
+    }
+    out.push({ ...it, project });
+  }
+  return out;
+}
+
 export async function runInject(raw: string, opts: InjectOpts = {}): Promise<InjectResult> {
   const sane = sanityCheck(raw);
   if (!sane.ok) return { ok: false, mode: "verbatim", notes: [], message: sane.reason };
@@ -186,13 +217,15 @@ export async function runInject(raw: string, opts: InjectOpts = {}): Promise<Inj
     envelope = { items: [], openThreads: [], alsoDid: [] };
   }
 
-  if (envelope.items.length === 0) {
-    // Task 7 will replace this with verbatim fallback. For now: fail-soft.
-    return { ok: false, mode: "distill", notes: [], message: "LLM returned no items (fallback in Task 7)" };
+  const knownProjects = new Set(projectSlugs);
+  const safeItems = applyInjectSafety(envelope.items, knownProjects, opts.project);
+
+  if (safeItems.length === 0) {
+    return { ok: false, mode: "distill", notes: [], message: "LLM returned no usable items (fallback in Task 7)" };
   }
 
   const written: string[] = [];
-  for (const item of envelope.items) {
+  for (const item of safeItems) {
     const rel = await writeOne(item, "distill");
     if (rel) written.push(rel);
   }

--- a/src/injectRun.ts
+++ b/src/injectRun.ts
@@ -1,0 +1,36 @@
+export interface InjectOpts {
+  verbatim?: boolean;
+  distill?: boolean;
+  project?: string;
+}
+
+export type SanityResult =
+  | { ok: true; text: string }
+  | { ok: false; code: 2 | 3; reason: string };
+
+const MAX_INPUT_BYTES = 32 * 1024;
+
+export function sanityCheck(raw: string): SanityResult {
+  const stripped = raw.replace(/\0/g, "");
+  const trimmed = stripped.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, code: 2, reason: "empty input" };
+  }
+  if (Buffer.byteLength(stripped, "utf8") > MAX_INPUT_BYTES) {
+    return { ok: false, code: 2, reason: "input exceeds 32 KB" };
+  }
+  if (!/[a-z0-9]/i.test(trimmed)) {
+    return { ok: false, code: 2, reason: "no alphanumeric content" };
+  }
+  return { ok: true, text: stripped };
+}
+
+export type Mode = "verbatim" | "distill";
+
+export function detectMode(text: string, opts: InjectOpts): Mode {
+  if (opts.verbatim) return "verbatim";
+  if (opts.distill) return "distill";
+  if (text.length > 200) return "distill";
+  if (/\n\s*\n/.test(text)) return "distill";
+  return "verbatim";
+}

--- a/src/injectRun.ts
+++ b/src/injectRun.ts
@@ -174,6 +174,7 @@ function applyInjectSafety(
     let project = it.project;
     if (forcedProject) project = slug(forcedProject);
 
+    // Inject must never create new project notes — that's reserved for /superbrain:discover.
     if (it.kind === "project_fact" || it.kind === "gotcha") {
       const p = project ? slug(project) : undefined;
       if (!p || !knownProjects.has(p)) {

--- a/src/injectRun.ts
+++ b/src/injectRun.ts
@@ -1,3 +1,13 @@
+import fs from "node:fs";
+import path from "node:path";
+import { route, type DistilledItem, slug } from "./router.js";
+import { writeNote } from "./vaultWriter.js";
+import { indexNote } from "./indexer.js";
+import { upsertDay } from "./dailyState.js";
+import { buildDailyNote } from "./dailyNote.js";
+import { dataDir } from "./paths.js";
+import { writeFailure } from "./sentinel.js";
+
 export interface InjectOpts {
   verbatim?: boolean;
   distill?: boolean;
@@ -33,4 +43,113 @@ export function detectMode(text: string, opts: InjectOpts): Mode {
   if (text.length > 200) return "distill";
   if (/\n\s*\n/.test(text)) return "distill";
   return "verbatim";
+}
+
+export interface InjectResult {
+  ok: boolean;
+  mode: Mode;
+  notes: string[];
+  fallback?: boolean;
+  message?: string;
+}
+
+const INJECT_MARKER = "<!-- superbrain:inject ";
+
+function todayIso(): string { return new Date().toISOString().slice(0, 10); }
+function nowIso(): string { return new Date().toISOString(); }
+
+function injectMarker(): string {
+  return `${INJECT_MARKER}${todayIso()} -->`;
+}
+
+function applyInjectProvenance(
+  res: ReturnType<typeof route>,
+  mode: Mode,
+): ReturnType<typeof route> {
+  const fm = {
+    ...res.frontmatter,
+    source: "inject",
+    injected_at: nowIso(),
+    inject_mode: mode,
+  };
+  const body = `${injectMarker()}\n${res.body}`;
+  return { ...res, frontmatter: fm, body };
+}
+
+function appendInjectLog(mode: Mode, count: number, preview: string): void {
+  try {
+    const stamp = nowIso().replace("T", " ").slice(0, 19);
+    const safePreview = preview.replace(/\s+/g, " ").slice(0, 80);
+    const line = `[${stamp}] ${mode} | ${count} notes | ${safePreview}\n`;
+    fs.appendFileSync(path.join(dataDir(), "inject.log"), line);
+  } catch { /* best-effort */ }
+}
+
+async function writeOne(
+  item: DistilledItem,
+  mode: Mode,
+): Promise<string | null> {
+  const routed = applyInjectProvenance(route(item), mode);
+  const res = writeNote(routed.relPath, {
+    frontmatter: routed.frontmatter,
+    body: routed.body,
+    mode: routed.mode,
+  });
+  if (!res.ok) return null;
+  try { await indexNote(routed.relPath); } catch (e: any) {
+    writeFailure(`inject index failed: ${e?.message || e}`);
+  }
+  return routed.relPath;
+}
+
+async function updateDaily(date: string, sid: string, routedRel: string[]): Promise<void> {
+  try {
+    upsertDay(date, sid, {
+      digestLine: "",
+      routedRelPaths: routedRel,
+      alsoDid: [],
+      openThreads: [],
+    });
+    const dn = buildDailyNote(date);
+    writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });
+    try { await indexNote(dn.relPath); } catch (e: any) {
+      writeFailure(`inject daily index failed: ${e?.message || e}`);
+    }
+  } catch (e: any) {
+    writeFailure(`inject daily upsert failed: ${e?.message || e}`);
+  }
+}
+
+function buildVerbatimItem(text: string, opts: InjectOpts): DistilledItem {
+  const date = todayIso();
+  const firstLine = text.split(/\n/, 1)[0].trim();
+  const title = firstLine.slice(0, 80) || "Injected note";
+  if (opts.project) {
+    return {
+      kind: "project_fact",
+      title,
+      date,
+      project: slug(opts.project),
+      body: text.trim(),
+      links: [],
+    };
+  }
+  return { kind: "capture", title, date, body: text.trim(), links: [] };
+}
+
+export async function runInject(raw: string, opts: InjectOpts = {}): Promise<InjectResult> {
+  const sane = sanityCheck(raw);
+  if (!sane.ok) return { ok: false, mode: "verbatim", notes: [], message: sane.reason };
+
+  const mode = detectMode(sane.text, opts);
+  if (mode === "verbatim") {
+    const item = buildVerbatimItem(sane.text, opts);
+    const rel = await writeOne(item, "verbatim");
+    if (!rel) return { ok: false, mode, notes: [], message: "vault write failed" };
+    await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+    appendInjectLog("verbatim", 1, sane.text);
+    return { ok: true, mode, notes: [rel] };
+  }
+  // distill path lands in Task 4 (will be replaced then)
+  return { ok: false, mode, notes: [], message: "distill mode not yet implemented" };
 }

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -216,6 +216,30 @@ describe("inject safety filter", () => {
     expect(captureBody).toContain("(project: totally-invented)");
   });
 
+  it("downgrades gotcha with unknown project slug to capture", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("safety-gotcha");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    const stub = path.join(dataDir, "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({
+      items: [
+        { kind: "gotcha", title: "Hidden bug", date: "2026-05-20",
+          project: "unknown-svc", symptom: "thing crashes", fix: "do X", links: [] },
+      ],
+    }));
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const { runInject } = await import("../src/injectRun.js");
+    const result = await runInject("text that forces distill " + "g".repeat(250), {});
+
+    expect(result.ok).toBe(true);
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes[0]).toMatch(/^capture\//);
+    expect(fs.existsSync(path.join(vaultDir, "projects/unknown-svc.md"))).toBe(false);
+  });
+
   it("--project flag overrides model's project field", async () => {
     const { dataDir, vaultDir } = makeTmpEnv("safety-override");
     process.env.SUPERBRAIN_DATA_DIR = dataDir;
@@ -369,5 +393,21 @@ describe("sb-inject CLI", () => {
       encoding: "utf8",
     });
     expect(out).toMatch(/Wrote 1 note/);
+  });
+
+  it("reads text from stdin when no argv text and no --from-file", () => {
+    const { dataDir, vaultDir } = makeTmpEnv("cli-stdin");
+    const out = execFileSync("npx", ["tsx", "bin/sb-inject.ts"], {
+      env: {
+        ...process.env,
+        SUPERBRAIN_DATA_DIR: dataDir,
+        SUPERBRAIN_VAULT_DIR: vaultDir,
+        SUPERBRAIN_EMBED_STUB: "1",
+      },
+      input: "a side thought piped via stdin",
+      encoding: "utf8",
+    });
+    expect(out).toMatch(/Wrote 1 note/);
+    expect(out).toMatch(/capture\//);
   });
 });

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -163,3 +163,80 @@ describe("runInject — distill mode", () => {
     }
   });
 });
+
+describe("inject safety filter", () => {
+  it("drops preference items emitted by the model", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("safety-pref");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    const stub = path.join(dataDir, "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({
+      items: [
+        { kind: "preference", title: "Preferences", date: "2026-05-20", body: "fake pref reshape", links: [] },
+        { kind: "capture", title: "real note", date: "2026-05-20", body: "real content", links: [] },
+      ],
+    }));
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const { runInject } = await import("../src/injectRun.js");
+    const result = await runInject("long input that triggers distill mode " + "x".repeat(250), {});
+
+    expect(result.ok).toBe(true);
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes[0]).toMatch(/^capture\//);
+    expect(fs.existsSync(path.join(vaultDir, "meta/preferences.md"))).toBe(false);
+  });
+
+  it("downgrades project_fact with unknown project slug to capture", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("safety-unknown");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    const stub = path.join(dataDir, "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({
+      items: [
+        { kind: "project_fact", title: "Made-up", date: "2026-05-20",
+          project: "totally-invented", body: "claim", links: [] },
+      ],
+    }));
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const { runInject } = await import("../src/injectRun.js");
+    const result = await runInject("text that forces distill " + "x".repeat(250), {});
+
+    expect(result.ok).toBe(true);
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes[0]).toMatch(/^capture\//);
+    expect(fs.existsSync(path.join(vaultDir, "projects/totally-invented.md"))).toBe(false);
+  });
+
+  it("--project flag overrides model's project field", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("safety-override");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    fs.mkdirSync(path.join(vaultDir, "projects"), { recursive: true });
+    fs.writeFileSync(path.join(vaultDir, "projects/wcloud.md"), "---\n---\n# wcloud\n");
+    fs.writeFileSync(path.join(vaultDir, "projects/other.md"), "---\n---\n# other\n");
+
+    const stub = path.join(dataDir, "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({
+      items: [
+        { kind: "project_fact", title: "thing", date: "2026-05-20",
+          project: "other", body: "claim", links: [] },
+      ],
+    }));
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const { runInject } = await import("../src/injectRun.js");
+    const result = await runInject("text that forces distill " + "x".repeat(250), { project: "wcloud" });
+
+    expect(result.ok).toBe(true);
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes[0]).toBe("projects/wcloud.md");
+  });
+});

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { sanityCheck, detectMode } from "../src/injectRun.js";
+
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  delete process.env.SUPERBRAIN_EMBED_STUB;
+  delete process.env.SUPERBRAIN_DISTILL_STUB;
+  delete process.env.SUPERBRAIN_INJECT_LOCK_WAIT_MS;
+});
 
 describe("sanityCheck", () => {
   it("rejects empty string", () => {
@@ -153,7 +161,5 @@ describe("runInject — distill mode", () => {
       expect(body).toMatch(/source: inject/);
       expect(body).toMatch(/inject_mode: distill/);
     }
-
-    delete process.env.SUPERBRAIN_DISTILL_STUB;
   });
 });

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
 import { sanityCheck, detectMode } from "../src/injectRun.js";
 
 afterEach(() => {
@@ -316,5 +317,57 @@ describe("inject LLM-failure fallback", () => {
     expect(result.fallback).toBe(true);
     expect(result.notes).toHaveLength(1);
     expect(result.notes[0]).toMatch(/^capture\//);
+  });
+});
+
+describe("sb-inject CLI", () => {
+  it("writes a verbatim capture when given text on argv", () => {
+    const { dataDir, vaultDir } = makeTmpEnv("cli-text");
+    const out = execFileSync("npx", ["tsx", "bin/sb-inject.ts", "a brief side thought from CLI"], {
+      env: {
+        ...process.env,
+        SUPERBRAIN_DATA_DIR: dataDir,
+        SUPERBRAIN_VAULT_DIR: vaultDir,
+        SUPERBRAIN_EMBED_STUB: "1",
+      },
+      encoding: "utf8",
+    });
+    expect(out).toMatch(/Wrote 1 note/);
+    expect(out).toMatch(/capture\//);
+  });
+
+  it("exits 2 on empty input", () => {
+    const { dataDir, vaultDir } = makeTmpEnv("cli-empty");
+    let exitCode = 0;
+    try {
+      execFileSync("npx", ["tsx", "bin/sb-inject.ts", ""], {
+        env: {
+          ...process.env,
+          SUPERBRAIN_DATA_DIR: dataDir,
+          SUPERBRAIN_VAULT_DIR: vaultDir,
+          SUPERBRAIN_EMBED_STUB: "1",
+        },
+        encoding: "utf8",
+      });
+    } catch (e: any) {
+      exitCode = e.status;
+    }
+    expect(exitCode).toBe(2);
+  });
+
+  it("reads text from --from-file", () => {
+    const { dataDir, vaultDir } = makeTmpEnv("cli-file");
+    const inputFile = path.join(dataDir, "input.txt");
+    fs.writeFileSync(inputFile, "hello from a file");
+    const out = execFileSync("npx", ["tsx", "bin/sb-inject.ts", "--from-file", inputFile], {
+      env: {
+        ...process.env,
+        SUPERBRAIN_DATA_DIR: dataDir,
+        SUPERBRAIN_VAULT_DIR: vaultDir,
+        SUPERBRAIN_EMBED_STUB: "1",
+      },
+      encoding: "utf8",
+    });
+    expect(out).toMatch(/Wrote 1 note/);
   });
 });

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -211,6 +211,8 @@ describe("inject safety filter", () => {
     expect(result.notes).toHaveLength(1);
     expect(result.notes[0]).toMatch(/^capture\//);
     expect(fs.existsSync(path.join(vaultDir, "projects/totally-invented.md"))).toBe(false);
+    const captureBody = fs.readFileSync(path.join(vaultDir, result.notes[0]), "utf8");
+    expect(captureBody).toContain("(project: totally-invented)");
   });
 
   it("--project flag overrides model's project field", async () => {

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -242,3 +242,37 @@ describe("inject safety filter", () => {
     expect(result.notes[0]).toBe("projects/wcloud.md");
   });
 });
+
+describe("inject lock serialization", () => {
+  it("acquires the distill lock and releases it on success", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("lock-success");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    const { runInject } = await import("../src/injectRun.js");
+    await runInject("a brief inject", { verbatim: true });
+
+    expect(fs.existsSync(path.join(dataDir, "locks/distill.lock"))).toBe(false);
+  });
+
+  it("waits-then-fails when distill lock is held by another process", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("lock-held");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    fs.mkdirSync(path.join(dataDir, "locks/distill.lock"), { recursive: true });
+    fs.writeFileSync(path.join(dataDir, "locks/distill.lock/pid"), "99999");
+
+    process.env.SUPERBRAIN_INJECT_LOCK_WAIT_MS = "300";
+
+    const { runInject } = await import("../src/injectRun.js");
+    const result = await runInject("a brief inject", { verbatim: true });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/checkpoint in progress/i);
+
+    fs.rmSync(path.join(dataDir, "locks/distill.lock"), { recursive: true, force: true });
+  });
+});

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -276,3 +276,45 @@ describe("inject lock serialization", () => {
     fs.rmSync(path.join(dataDir, "locks/distill.lock"), { recursive: true, force: true });
   });
 });
+
+describe("inject LLM-failure fallback", () => {
+  it("falls back to verbatim capture when envelope has no items", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("fallback-empty");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    const stub = path.join(dataDir, "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({ items: [] }));
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const { runInject } = await import("../src/injectRun.js");
+    const result = await runInject("long input forcing distill " + "y".repeat(250), {});
+
+    expect(result.ok).toBe(true);
+    expect(result.fallback).toBe(true);
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes[0]).toMatch(/^capture\//);
+    const body = fs.readFileSync(path.join(vaultDir, result.notes[0]), "utf8");
+    expect(body).toMatch(/inject_mode: verbatim/);
+  });
+
+  it("falls back to verbatim when LLM returns non-JSON garbage", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("fallback-garbage");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    const stub = path.join(dataDir, "stub.json");
+    fs.writeFileSync(stub, "not valid json at all");
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const { runInject } = await import("../src/injectRun.js");
+    const result = await runInject("long input forcing distill " + "z".repeat(250), {});
+
+    expect(result.ok).toBe(true);
+    expect(result.fallback).toBe(true);
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes[0]).toMatch(/^capture\//);
+  });
+});

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -93,3 +93,30 @@ describe("runInject — verbatim mode", () => {
     expect(fs.readFileSync(injectLog, "utf8")).toMatch(/verbatim \| 1 notes/);
   });
 });
+
+describe("buildInjectPrompt", () => {
+  it("includes text, recall hits, project slugs, and the inject hard rules", async () => {
+    const { buildInjectPrompt } = await import("../src/injectPrompt.js");
+    const prompt = buildInjectPrompt(
+      "user typed this",
+      [{ relPath: "projects/wcloud.md", headingPath: "", anchor: "", excerpt: "wcloud project notes" }],
+      ["wcloud", "superbrain"],
+    );
+    expect(prompt).toContain("user typed this");
+    expect(prompt).toContain("projects/wcloud.md");
+    expect(prompt).toContain("wcloud project notes");
+    expect(prompt).toContain("wcloud");
+    expect(prompt).toContain("superbrain");
+    expect(prompt).toMatch(/never invent claims/i);
+    expect(prompt).toMatch(/MUST NOT emit.*preference/i);
+    expect(prompt).toMatch(/MUST NOT invent.*project/i);
+  });
+
+  it("handles empty recall + project list cleanly", async () => {
+    const { buildInjectPrompt } = await import("../src/injectPrompt.js");
+    const prompt = buildInjectPrompt("text", [], []);
+    expect(prompt).toContain("text");
+    expect(prompt).toMatch(/no related vault notes/i);
+    expect(prompt).toMatch(/no existing project slugs/i);
+  });
+});

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -120,3 +120,40 @@ describe("buildInjectPrompt", () => {
     expect(prompt).toMatch(/no existing project slugs/i);
   });
 });
+
+describe("runInject — distill mode", () => {
+  it("processes a multi-topic dump into multiple routed notes", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("distill");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    const stub = path.join(dataDir, "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({
+      items: [
+        { kind: "decision", title: "Pick option A", date: "2026-05-20",
+          context: "two options", decision: "go with A", rationale: "simpler", links: [] },
+        { kind: "capture", title: "Side thought", date: "2026-05-20",
+          body: "remember to check Y", links: [] },
+      ],
+    }));
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const longInput = "long multi-topic dump\n\n" + "x".repeat(250);
+    const { runInject } = await import("../src/injectRun.js");
+    const result = await runInject(longInput, {});
+
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("distill");
+    expect(result.notes).toHaveLength(2);
+    expect(result.notes.some((p) => p.startsWith("decisions/"))).toBe(true);
+    expect(result.notes.some((p) => p.startsWith("capture/"))).toBe(true);
+    for (const rel of result.notes) {
+      const body = fs.readFileSync(path.join(vaultDir, rel), "utf8");
+      expect(body).toMatch(/source: inject/);
+      expect(body).toMatch(/inject_mode: distill/);
+    }
+
+    delete process.env.SUPERBRAIN_DISTILL_STUB;
+  });
+});

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -50,3 +50,46 @@ describe("detectMode", () => {
     expect(detectMode("hi", { distill: true })).toBe("distill");
   });
 });
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+function makeTmpEnv(name: string) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `sb-inject-${name}-`));
+  const dataDir = path.join(root, "data");
+  const vaultDir = path.join(root, "vault");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(vaultDir, { recursive: true });
+  return { root, dataDir, vaultDir };
+}
+
+describe("runInject — verbatim mode", () => {
+  it("writes a capture note with inject provenance and updates daily note", async () => {
+    const { dataDir, vaultDir } = makeTmpEnv("verbatim");
+    process.env.SUPERBRAIN_DATA_DIR = dataDir;
+    process.env.SUPERBRAIN_VAULT_DIR = vaultDir;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    const { runInject } = await import("../src/injectRun.js");
+    const result = await runInject("a brief side thought about wcloud", { verbatim: true });
+
+    expect(result.ok).toBe(true);
+    expect(result.notes).toHaveLength(1);
+    const captureRel = result.notes[0];
+    expect(captureRel).toMatch(/^capture\/\d{4}-\d{2}-\d{2}-/);
+    const captureBody = fs.readFileSync(path.join(vaultDir, captureRel), "utf8");
+    expect(captureBody).toMatch(/source: inject/);
+    expect(captureBody).toMatch(/inject_mode: verbatim/);
+    expect(captureBody).toMatch(/<!-- superbrain:inject /);
+    expect(captureBody).toMatch(/a brief side thought about wcloud/);
+
+    const today = new Date().toISOString().slice(0, 10);
+    const dailyRel = `daily/${today}.md`;
+    expect(fs.existsSync(path.join(vaultDir, dailyRel))).toBe(true);
+
+    const injectLog = path.join(dataDir, "inject.log");
+    expect(fs.existsSync(injectLog)).toBe(true);
+    expect(fs.readFileSync(injectLog, "utf8")).toMatch(/verbatim \| 1 notes/);
+  });
+});

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { sanityCheck, detectMode } from "../src/injectRun.js";
+
+describe("sanityCheck", () => {
+  it("rejects empty string", () => {
+    expect(sanityCheck("")).toEqual({ ok: false, code: 2, reason: "empty input" });
+  });
+  it("rejects whitespace-only", () => {
+    expect(sanityCheck("   \n\t\n  ")).toEqual({ ok: false, code: 2, reason: "empty input" });
+  });
+  it("rejects pure punctuation", () => {
+    expect(sanityCheck("!!!")).toEqual({ ok: false, code: 2, reason: "no alphanumeric content" });
+  });
+  it("rejects single emoji", () => {
+    expect(sanityCheck("🎉")).toEqual({ ok: false, code: 2, reason: "no alphanumeric content" });
+  });
+  it("rejects input over 32 KB", () => {
+    const big = "a".repeat(32 * 1024 + 1);
+    expect(sanityCheck(big)).toEqual({ ok: false, code: 2, reason: "input exceeds 32 KB" });
+  });
+  it("strips null bytes and accepts the remainder if non-empty", () => {
+    const r = sanityCheck("hello\0\0 world");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.text).toBe("hello world");
+  });
+  it("rejects after null-byte strip if empty", () => {
+    expect(sanityCheck("\0\0 \0 ").ok).toBe(false);
+  });
+  it("accepts normal short text", () => {
+    const r = sanityCheck("hello world");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.text).toBe("hello world");
+  });
+});
+
+describe("detectMode", () => {
+  it("picks verbatim for short single-blob input", () => {
+    expect(detectMode("a short thought", {})).toBe("verbatim");
+  });
+  it("picks distill for input over 200 chars", () => {
+    expect(detectMode("a".repeat(201), {})).toBe("distill");
+  });
+  it("picks distill when input contains a blank-line separator", () => {
+    expect(detectMode("para one\n\npara two", {})).toBe("distill");
+  });
+  it("respects explicit --verbatim flag even on long input", () => {
+    expect(detectMode("a".repeat(500), { verbatim: true })).toBe("verbatim");
+  });
+  it("respects explicit --distill flag even on short input", () => {
+    expect(detectMode("hi", { distill: true })).toBe("distill");
+  });
+});

--- a/tests/injectE2E.test.ts
+++ b/tests/injectE2E.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { execFileSync } from "node:child_process";
+
+function mkenv(name: string) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `sb-injectE2E-${name}-`));
+  const dataDir = path.join(root, "data");
+  const vaultDir = path.join(root, "vault");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(vaultDir, { recursive: true });
+  return { dataDir, vaultDir };
+}
+
+function run(args: string[], env: Record<string, string>) {
+  return execFileSync("npx", ["tsx", "bin/sb-inject.ts", ...args], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+describe("inject E2E", () => {
+  const today = new Date().toISOString().slice(0, 10);
+
+  it("scenario 1 — short input → verbatim capture, daily note, index", () => {
+    const { dataDir, vaultDir } = mkenv("s1");
+    const env = {
+      SUPERBRAIN_DATA_DIR: dataDir,
+      SUPERBRAIN_VAULT_DIR: vaultDir,
+      SUPERBRAIN_EMBED_STUB: "1",
+    };
+
+    const out = run(["a short freeform thought about provisioning"], env);
+    expect(out).toMatch(/Wrote 1 note in verbatim mode/);
+
+    const captureFiles = fs.readdirSync(path.join(vaultDir, "capture"));
+    expect(captureFiles).toHaveLength(1);
+    const captureBody = fs.readFileSync(path.join(vaultDir, "capture", captureFiles[0]), "utf8");
+    expect(captureBody).toMatch(/source: inject/);
+    expect(captureBody).toMatch(/inject_mode: verbatim/);
+    expect(captureBody).toMatch(/<!-- superbrain:inject /);
+    expect(captureBody).toMatch(/a short freeform thought about provisioning/);
+
+    const dailyPath = path.join(vaultDir, "daily", `${today}.md`);
+    expect(fs.existsSync(dailyPath)).toBe(true);
+    expect(fs.readFileSync(dailyPath, "utf8")).toContain(captureFiles[0].replace(/\.md$/, ""));
+
+    expect(fs.existsSync(path.join(dataDir, "index.db"))).toBe(true);
+  });
+
+  it("scenario 2 — long multi-topic input + stubbed multi-item envelope → all routed", () => {
+    const { dataDir, vaultDir } = mkenv("s2");
+    fs.mkdirSync(path.join(vaultDir, "projects"), { recursive: true });
+    fs.writeFileSync(path.join(vaultDir, "projects/wcloud.md"), "---\ntype: project\nproject: wcloud\n---\n# wcloud\n");
+
+    const stub = path.join(dataDir, "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({
+      items: [
+        { kind: "decision", title: "Use Sonnet for inject", date: today,
+          context: "options weighed", decision: "Sonnet 4.6", rationale: "cost/quality", links: [] },
+        { kind: "project_fact", title: "wcloud uses HTTP transport", date: today,
+          project: "wcloud", body: "Transport choice", links: [] },
+        { kind: "capture", title: "Reminder", date: today, body: "ask Pierre about TwinGate", links: [] },
+      ],
+    }));
+
+    const env = {
+      SUPERBRAIN_DATA_DIR: dataDir,
+      SUPERBRAIN_VAULT_DIR: vaultDir,
+      SUPERBRAIN_EMBED_STUB: "1",
+      SUPERBRAIN_DISTILL_STUB: stub,
+    };
+
+    const longInput = "Meeting summary:\n\n" + "details ".repeat(40);
+    const out = run([longInput], env);
+    expect(out).toMatch(/Wrote 3 notes in distill mode/);
+
+    expect(fs.existsSync(path.join(vaultDir, "decisions", `${today}-use-sonnet-for-inject.md`))).toBe(true);
+    const wcloudBody = fs.readFileSync(path.join(vaultDir, "projects/wcloud.md"), "utf8");
+    expect(wcloudBody).toMatch(/wcloud uses HTTP transport/);
+    expect(fs.readdirSync(path.join(vaultDir, "capture")).length).toBe(1);
+
+    const dailyBody = fs.readFileSync(path.join(vaultDir, "daily", `${today}.md`), "utf8");
+    expect(dailyBody).toMatch(/use-sonnet-for-inject/);
+  });
+
+  it("scenario 3 — long input + empty envelope → verbatim fallback", () => {
+    const { dataDir, vaultDir } = mkenv("s3");
+    const stub = path.join(dataDir, "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({ items: [] }));
+
+    const env = {
+      SUPERBRAIN_DATA_DIR: dataDir,
+      SUPERBRAIN_VAULT_DIR: vaultDir,
+      SUPERBRAIN_EMBED_STUB: "1",
+      SUPERBRAIN_DISTILL_STUB: stub,
+    };
+
+    const longInput = "x".repeat(400);
+    const out = run([longInput], env);
+    expect(out).toMatch(/wrote verbatim/);
+    expect(fs.readdirSync(path.join(vaultDir, "capture")).length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `/superbrain:inject <text>` (plus `--from-file <path>` / stdin) — the manual escape hatch for content auto-capture can't observe (side thoughts, meeting summaries, ad-hoc notes). Auto-capture remains the default and is untouched.

## What's new

- **Sanity gate + mode detection.** Empty / whitespace-only / >32 KB / no-alphanumeric input → exit 2. Auto-detect: verbatim for ≤200 chars with no blank-line separator, distill otherwise. `--verbatim` / `--distill` override.
- **Verbatim path.** Wraps text as a `capture/<date>-<slug>.md` (or `projects/<slug>.md` append with `--project`). No LLM call. Provenance applied.
- **Distill path.** Pulls top-5 related vault notes via `hybridRecall`, lists existing project slugs, calls Sonnet 4.6 with an inject-specific prompt (`src/injectPrompt.ts`), routes each emitted item via the existing `route() → writeNote() → indexNote() → upsertDay() → buildDailyNote()` pipeline. Multi-item splits supported.
- **Safety filter.** Drops preference items (defense in depth — prompt forbids them but router enforces). Downgrades `project_fact` / `gotcha` items with unknown project slugs to `capture/` (only `/superbrain:discover` creates project notes). `--project <slug>` overrides any project field the model emits.
- **Lock serialization.** Acquires the existing `acquireLock("distill")` with a poll-retry (configurable via `SUPERBRAIN_INJECT_LOCK_WAIT_MS`, default 5 s) so inject and session checkpoints can't interleave.
- **Verbatim fallback.** When the LLM returns empty or garbage, the user's text is written verbatim to `capture/` — input is never lost. `result.fallback === true` so the CLI can surface a clear message.
- **Provenance.** Every inject-written note carries `source: inject`, `injected_at`, `inject_mode` frontmatter + `<!-- superbrain:inject YYYY-MM-DD -->` body marker. Per-day trace at `~/.superbrain/inject.log`.
- **Import-safe CLI** (`bin/sb-inject.ts`). Only Node built-ins + paths/bootstrap/sentinel at top level; `runInject` reached via dynamic `import()` after `depsPresent()` check. Exit codes 0 / 2 / 3.
- **Slash command** (`commands/inject.md`).
- **README** has a new "Manual capture with /superbrain:inject" section.

## File changes

- **New:** `src/injectRun.ts`, `src/injectPrompt.ts`, `bin/sb-inject.ts`, `commands/inject.md`, `tests/inject.test.ts`, `tests/injectE2E.test.ts`
- **Modified:** `README.md`
- **Built:** `dist/src/injectRun.js`, `dist/src/injectPrompt.js`, `dist/bin/sb-inject.js`
- **Untouched:** existing src/ (no changes to router, vaultWriter, distillRun, recall, lockfile — every integration is additive)

## Test coverage

- 29 unit tests in `tests/inject.test.ts`: sanity gate, mode detection, prompt builder, verbatim path, distill path, preference drop, `project_fact` + `gotcha` downgrade, `--project` override, lock acquire/release, lock contention timeout, empty/garbage fallback, CLI argv / empty-input / --from-file / stdin
- 3 end-to-end CLI tests in `tests/injectE2E.test.ts`
- Full suite: 261/261 across 69 files (+16 from this branch)

## Non-goals (deferred)

- MCP transport (`superbrain_inject` over MCP) — Phase 2. `runInject(text, opts)` is the right boundary; Phase 2 is a transport lift only.
- Native mem.ai integration. Phase-1 flow is `cat ~/path | /superbrain:inject` or `--from-file`.

## Test plan

- [ ] CI green (typecheck, build, vitest, `git diff --exit-code dist`)
- [ ] Local smoke test: `/superbrain:inject "side thought"` → confirm note in `capture/`
- [ ] Local smoke test: `/superbrain:inject --from-file <meeting.md>` → confirm multi-item routing
- [ ] Local smoke test: `/superbrain:inject --project <known-slug> "fact"` → confirm append to `projects/<slug>.md`
- [ ] Local smoke test: `/superbrain:inject --project <unknown> "fact"` → confirm downgrade to capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)
