### PR TITLE
fix: cross-platform path handling and Obsidian discovery (Linux + Windows)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ behavior may change without notice.
 
 ## [Unreleased]
 
+## [0.4.2]
+
+### Added
+
+- `/superbrain:inject` — manual freeform note ingestion. Auto-detects
+  **verbatim** mode (short single-paragraph input) vs **distill** mode
+  (longer or multi-topic input); passes through the existing
+  route → write → index → daily-upsert pipeline with inject-specific
+  provenance (`source: inject`, `injected_at`, `inject_mode`).
+  Recall-augmented placement context for distill mode. Safety rails:
+  inject never creates new project notes (reserved for
+  `/superbrain:discover`), never reshapes preferences, and falls back
+  to verbatim capture on any LLM failure — user input is never lost.
+  Supports `--from-file <path>`, stdin, `--verbatim` / `--distill`
+  overrides, and `--project <slug>` (overrides whatever project the
+  model emits). See [PR #24](https://github.com/m3talux/superbrain/pull/24).
+
+### Fixed
+
+- **Distiller wikilink resolution** (#23). The distill prompt asked
+  for `links (related-note slugs)`, and the model would emit short
+  conceptual slugs like `[[jarvis-vision]]` that did not match any
+  on-disk filename — Obsidian renders these as broken links. The new
+  `resolveLinks` helper walks the vault once per call and matches each
+  emitted link by (1) exact relative-path, (2) exact basename
+  (preferring `projects/` → `decisions/` → ...), or (3) token-subset
+  against post-date-strip filenames for 2+ token links. Unresolved
+  links are dropped rather than rendered. `runDistill`, `runRollup`,
+  and `injectRun`'s distill branch all resolve links before routing.
+  The distill prompt also gained an explicit rule about emitting full
+  on-disk relative paths. See [PR #25](https://github.com/m3talux/superbrain/pull/25).
+- **`writeNote` append dedup** (#23). The distiller can re-emit the
+  same `project_fact` / `gotcha` across adjacent checkpoints because
+  the LLM has no memory of prior emissions; identical sections were
+  landing twice in project notes minutes apart. The append branch now
+  skips when the normalized new body already appears in the file
+  content. A 40-character floor avoids generic-phrase false positives.
+  Also benefits inject's distill path. See
+  [PR #25](https://github.com/m3talux/superbrain/pull/25).
+
+## [0.4.1]
+
 ### Changed
 
 - The detached `claude -p` distill and rollup spawns now **pin the model**
@@ -53,5 +95,7 @@ Initial development baseline.
   a one-time guarded dependency bootstrap so a marketplace install works from a
   bare clone.
 
-[Unreleased]: https://github.com/m3talux/superbrain/compare/main...HEAD
+[Unreleased]: https://github.com/m3talux/superbrain/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/m3talux/superbrain/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/m3talux/superbrain
 [0.1.0]: https://github.com/m3talux/superbrain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,15 @@ behavior may change without notice.
   `resolveLinks` helper walks the vault once per call and matches each
   emitted link by (1) exact relative-path, (2) exact basename
   (preferring `projects/` → `decisions/` → ...), or (3) token-subset
-  against post-date-strip filenames for 2+ token links. Unresolved
-  links are dropped rather than rendered. `runDistill`, `runRollup`,
-  and `injectRun`'s distill branch all resolve links before routing.
-  The distill prompt also gained an explicit rule about emitting full
-  on-disk relative paths. See [PR #25](https://github.com/m3talux/superbrain/pull/25).
+  against post-date-strip filenames for 2+ token links. Resolution is
+  **case-insensitive** (so `[[Weddy]]` matches `projects/weddy.md`)
+  and strips leading `./`, `../`, and pipe-aliases (`[[target|alias]]`)
+  before matching. Unresolved links are dropped rather than rendered.
+  `runDistill`, `runRollup`, and `injectRun`'s distill branch all
+  resolve links before routing. The distill prompt also gained an
+  explicit rule about emitting full on-disk relative paths.
+  See [PR #25](https://github.com/m3talux/superbrain/pull/25) and
+  [PR #26](https://github.com/m3talux/superbrain/pull/26).
 - **`writeNote` append dedup** (#23). The distiller can re-emit the
   same `project_fact` / `gotcha` across adjacent checkpoints because
   the LLM has no memory of prior emissions; identical sections were

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -13,7 +13,7 @@ async function main() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
-  const server = new McpServer({ name: "superbrain", version: "0.4.1" });
+  const server = new McpServer({ name: "superbrain", version: "0.4.2" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).",

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -27,12 +27,16 @@ Determine the source vault path in this priority order:
    - Otherwise: resolve it; if it's an existing directory containing an `.obsidian/` folder OR
      at least one `.md` file at depth ≤ 2, accept it as the source. If `--dry-run` is also in
      `$ARGUMENTS`, set `DRY_RUN=true`.
-2. Otherwise, auto-detect by reading Obsidian's vault registry (macOS):
-   - `~/Library/Application Support/obsidian/obsidian.json` → its `vaults` object lists
-     vaults the user has opened, each with a `path`. Filter to entries whose `path` exists.
+2. Otherwise, auto-detect by reading Obsidian's vault registry. The location depends on host OS:
+   - **macOS:** `~/Library/Application Support/obsidian/obsidian.json`
+   - **Linux:** `$XDG_CONFIG_HOME/obsidian/obsidian.json` if set, else `~/.config/obsidian/obsidian.json`
+   - **Windows:** `%APPDATA%\obsidian\obsidian.json` (typically `~/AppData/Roaming/obsidian/obsidian.json`)
+
+   The file's `vaults` object lists vaults the user has opened, each with a `path`.
+   Filter to entries whose `path` exists on disk.
 3. If the registry produces 0 candidates, scan these common defaults (existence check only):
-   - `~/Documents/Obsidian Vault`, `~/Documents/Obsidian/*`, `~/Obsidian`,
-   - `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/*` (iCloud).
+   - **All platforms:** `~/Obsidian`, `~/Documents/Obsidian`, `~/Documents/Obsidian Vault`
+   - **macOS only:** `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/*` (iCloud)
 4. Decision:
    - **0 candidates** → ask the user: *"I couldn't auto-detect an Obsidian vault. Could you give
      me the absolute path?"* Wait for a reply; validate it (directory, contains markdown).

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -12,7 +12,7 @@ async function main() {
     const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
-    const server = new McpServer({ name: "superbrain", version: "0.4.1" });
+    const server = new McpServer({ name: "superbrain", version: "0.4.2" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).", { query: z.string(), k: z.number().optional() }, async ({ query, k }) => (await handleSearch({ query, k })));
     const transport = new StdioServerTransport();
     server.connect(transport).catch(() => process.exit(1));

--- a/dist/src/projectDetect.js
+++ b/dist/src/projectDetect.js
@@ -56,7 +56,7 @@ const HEAVY_DIRS = new Set([
     ".cache", ".idea", ".vscode", "coverage", ".pytest_cache",
     ".gradle", ".mvn", "bin", "obj",
 ]);
-function homedir() { return process.env.HOME || os.homedir(); }
+function homedir() { return os.homedir(); }
 // Path classification. Exposed for tests and for the "why was this skipped?"
 // trace written to ~/.superbrain/discovery.log. SUPERBRAIN_TEST_BYPASS_BLOCKLIST
 // is an internal seam — tests using /tmp paths set it; Claude Code never does.

--- a/dist/src/vaultWriter.js
+++ b/dist/src/vaultWriter.js
@@ -12,7 +12,8 @@ function resolveSafe(rel) {
         return null;
     if (!ALLOWED_EXT.has(path.extname(abs)))
         return null;
-    if (EXCLUDED.some((e) => (abs + "/").includes(e)))
+    const normalized = abs.replace(/\\/g, "/");
+    if (EXCLUDED.some((e) => (normalized + "/").includes(e)))
         return null;
     return abs;
 }

--- a/dist/src/wikilink.js
+++ b/dist/src/wikilink.js
@@ -7,7 +7,7 @@ function tokenize(s) {
     return s.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
 }
 function buildIndex(vaultRoot) {
-    const ix = { byRelPath: new Set(), byBasename: new Map(), byTokens: [] };
+    const ix = { byRelPath: new Map(), byBasename: new Map(), byTokens: [] };
     for (const folder of VAULT_FOLDERS) {
         const dir = path.join(vaultRoot, folder);
         let entries;
@@ -22,15 +22,12 @@ function buildIndex(vaultRoot) {
                 continue;
             const stem = f.slice(0, -3);
             const rel = `${folder}/${stem}`;
-            ix.byRelPath.add(rel);
+            ix.byRelPath.set(rel.toLowerCase(), rel);
             const stripped = stem.replace(DATE_PREFIX, "");
-            const arr = ix.byBasename.get(stem) ?? [];
-            arr.push(rel);
-            ix.byBasename.set(stem, arr);
-            if (stripped !== stem) {
-                const arr2 = ix.byBasename.get(stripped) ?? [];
-                arr2.push(rel);
-                ix.byBasename.set(stripped, arr2);
+            for (const key of new Set([stem.toLowerCase(), stripped.toLowerCase()])) {
+                const arr = ix.byBasename.get(key) ?? [];
+                arr.push(rel);
+                ix.byBasename.set(key, arr);
             }
             ix.byTokens.push({ rel, tokens: new Set(tokenize(stripped)) });
         }
@@ -38,7 +35,19 @@ function buildIndex(vaultRoot) {
     return ix;
 }
 function normalize(raw) {
-    return raw.replace(/^\[\[/, "").replace(/\]\]$/, "").replace(/\.md$/i, "").trim();
+    // Strip [[ ]], pipe-alias (`[[target|alias]]` → `target`), .md suffix,
+    // leading `./` or `../` (Obsidian wikilinks sometimes carry path prefixes),
+    // and a leading slash.
+    let s = raw.replace(/^\[\[/, "").replace(/\]\]$/, "");
+    const pipe = s.indexOf("|");
+    if (pipe >= 0)
+        s = s.slice(0, pipe);
+    s = s.trim().replace(/\.md$/i, "");
+    while (s.startsWith("../") || s.startsWith("./"))
+        s = s.replace(/^\.\.?\//, "");
+    if (s.startsWith("/"))
+        s = s.slice(1);
+    return s.trim();
 }
 function pickPreferred(rels) {
     return [...rels].sort((a, b) => {
@@ -70,10 +79,11 @@ export function resolveLinks(links, vaultRoot) {
     return out;
 }
 function resolveOne(link, ix) {
+    const lower = link.toLowerCase();
     if (link.includes("/")) {
-        return ix.byRelPath.has(link) ? link : null;
+        return ix.byRelPath.get(lower) ?? null;
     }
-    const exact = ix.byBasename.get(link);
+    const exact = ix.byBasename.get(lower);
     if (exact && exact.length > 0)
         return pickPreferred(exact);
     const linkTokens = tokenize(link);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",

--- a/src/projectDetect.ts
+++ b/src/projectDetect.ts
@@ -51,7 +51,7 @@ const HEAVY_DIRS = new Set([
   ".gradle", ".mvn", "bin", "obj",
 ]);
 
-function homedir(): string { return process.env.HOME || os.homedir(); }
+function homedir(): string { return os.homedir(); }
 
 // Path classification. Exposed for tests and for the "why was this skipped?"
 // trace written to ~/.superbrain/discovery.log. SUPERBRAIN_TEST_BYPASS_BLOCKLIST

--- a/src/vaultWriter.ts
+++ b/src/vaultWriter.ts
@@ -19,7 +19,8 @@ function resolveSafe(rel: string): string | null {
   const abs = path.resolve(root, rel);
   if (abs !== root && !abs.startsWith(root + path.sep)) return null;
   if (!ALLOWED_EXT.has(path.extname(abs))) return null;
-  if (EXCLUDED.some((e) => (abs + "/").includes(e))) return null;
+  const normalized = abs.replace(/\\/g, "/");
+  if (EXCLUDED.some((e) => (normalized + "/").includes(e))) return null;
   return abs;
 }
 

--- a/src/wikilink.ts
+++ b/src/wikilink.ts
@@ -6,7 +6,9 @@ const FOLDER_PREFERENCE = new Map(VAULT_FOLDERS.map((f, i) => [f, i]));
 const DATE_PREFIX = /^\d{4}-\d{2}-\d{2}-/;
 
 interface Index {
-  byRelPath: Set<string>;
+  // Index keys are lowercased so lookup is case-insensitive — Obsidian
+  // treats `[[Weddy]]` and `[[weddy]]` as the same target.
+  byRelPath: Map<string, string>;
   byBasename: Map<string, string[]>;
   byTokens: Array<{ rel: string; tokens: Set<string>; }>;
 }
@@ -16,7 +18,7 @@ function tokenize(s: string): string[] {
 }
 
 function buildIndex(vaultRoot: string): Index {
-  const ix: Index = { byRelPath: new Set(), byBasename: new Map(), byTokens: [] };
+  const ix: Index = { byRelPath: new Map(), byBasename: new Map(), byTokens: [] };
   for (const folder of VAULT_FOLDERS) {
     const dir = path.join(vaultRoot, folder);
     let entries: string[];
@@ -25,15 +27,12 @@ function buildIndex(vaultRoot: string): Index {
       if (!f.endsWith(".md")) continue;
       const stem = f.slice(0, -3);
       const rel = `${folder}/${stem}`;
-      ix.byRelPath.add(rel);
+      ix.byRelPath.set(rel.toLowerCase(), rel);
       const stripped = stem.replace(DATE_PREFIX, "");
-      const arr = ix.byBasename.get(stem) ?? [];
-      arr.push(rel);
-      ix.byBasename.set(stem, arr);
-      if (stripped !== stem) {
-        const arr2 = ix.byBasename.get(stripped) ?? [];
-        arr2.push(rel);
-        ix.byBasename.set(stripped, arr2);
+      for (const key of new Set([stem.toLowerCase(), stripped.toLowerCase()])) {
+        const arr = ix.byBasename.get(key) ?? [];
+        arr.push(rel);
+        ix.byBasename.set(key, arr);
       }
       ix.byTokens.push({ rel, tokens: new Set(tokenize(stripped)) });
     }
@@ -42,7 +41,16 @@ function buildIndex(vaultRoot: string): Index {
 }
 
 function normalize(raw: string): string {
-  return raw.replace(/^\[\[/, "").replace(/\]\]$/, "").replace(/\.md$/i, "").trim();
+  // Strip [[ ]], pipe-alias (`[[target|alias]]` → `target`), .md suffix,
+  // leading `./` or `../` (Obsidian wikilinks sometimes carry path prefixes),
+  // and a leading slash.
+  let s = raw.replace(/^\[\[/, "").replace(/\]\]$/, "");
+  const pipe = s.indexOf("|");
+  if (pipe >= 0) s = s.slice(0, pipe);
+  s = s.trim().replace(/\.md$/i, "");
+  while (s.startsWith("../") || s.startsWith("./")) s = s.replace(/^\.\.?\//, "");
+  if (s.startsWith("/")) s = s.slice(1);
+  return s.trim();
 }
 
 function pickPreferred(rels: string[]): string {
@@ -74,10 +82,11 @@ export function resolveLinks(links: string[], vaultRoot: string): string[] {
 }
 
 function resolveOne(link: string, ix: Index): string | null {
+  const lower = link.toLowerCase();
   if (link.includes("/")) {
-    return ix.byRelPath.has(link) ? link : null;
+    return ix.byRelPath.get(lower) ?? null;
   }
-  const exact = ix.byBasename.get(link);
+  const exact = ix.byBasename.get(lower);
   if (exact && exact.length > 0) return pickPreferred(exact);
 
   const linkTokens = tokenize(link);

--- a/tests/vaultWriter.test.ts
+++ b/tests/vaultWriter.test.ts
@@ -74,4 +74,11 @@ describe("vaultWriter", () => {
     const r = writeNote("projects/jarvis.md", { frontmatter: fm, body: "short note", mode: "append" });
     expect(r.reason).toBeUndefined();
   });
+  it("rejects writes into excluded folders regardless of path separator style", () => {
+    // These already pass on Linux/macOS because path.resolve uses forward slashes.
+    // After the fix they also pass on Windows where path.resolve uses backslashes.
+    expect(writeNote(".obsidian/note.md", { frontmatter: { type: "project", status: "active" }, body: "", mode: "create" }).ok).toBe(false);
+    expect(writeNote(".git/HEAD.md", { frontmatter: { type: "project", status: "active" }, body: "", mode: "create" }).ok).toBe(false);
+    expect(writeNote("subdir/.trash/x.md", { frontmatter: { type: "project", status: "active" }, body: "", mode: "create" }).ok).toBe(false);
+  });
 });

--- a/tests/wikilink.test.ts
+++ b/tests/wikilink.test.ts
@@ -78,4 +78,29 @@ describe("resolveLinks", () => {
   it("returns empty on a non-existent vault root without crashing", () => {
     expect(resolveLinks(["anything"], path.join(vault, "does-not-exist"))).toEqual([]);
   });
+
+  it("resolves links case-insensitively (Weddy -> projects/weddy)", () => {
+    touch("projects/weddy.md");
+    expect(resolveLinks(["Weddy"], vault)).toEqual(["projects/weddy"]);
+    expect(resolveLinks(["WEDDY"], vault)).toEqual(["projects/weddy"]);
+    expect(resolveLinks(["[[Engram]]"], vault)).toEqual([]);
+  });
+
+  it("resolves case-insensitive full relative paths (Projects/Weddy -> projects/weddy)", () => {
+    touch("projects/weddy.md");
+    expect(resolveLinks(["Projects/Weddy"], vault)).toEqual(["projects/weddy"]);
+  });
+
+  it("strips leading ../ and ./ from links before resolving", () => {
+    touch("people/thomas.md");
+    expect(resolveLinks(["../people/thomas"], vault)).toEqual(["people/thomas"]);
+    expect(resolveLinks(["./people/thomas"], vault)).toEqual(["people/thomas"]);
+    expect(resolveLinks(["../../people/thomas"], vault)).toEqual(["people/thomas"]);
+  });
+
+  it("strips pipe alias before resolving (Obsidian [[target|alias]] form)", () => {
+    touch("projects/weddy.md");
+    expect(resolveLinks(["weddy|the weddy project"], vault)).toEqual(["projects/weddy"]);
+    expect(resolveLinks(["[[weddy|Weddy]]"], vault)).toEqual(["projects/weddy"]);
+  });
 });


### PR DESCRIPTION
## Summary

- **`src/vaultWriter.ts` EXCLUDED separator bug.** `resolveSafe` checked for excluded folders (`.obsidian`, `.git`, `node_modules`, `.trash`) via a hardcoded forward-slash substring match. On Windows `path.resolve` returns backslash-separated paths, so the check silently allowed writes into `.obsidian/`, etc. Fixed by normalizing separators before the match.
- **`src/projectDetect.ts` HOME shortcut.** Dropped the `process.env.HOME ||` shortcut; rely on `os.homedir()` directly. Removes a redundant code path; same behavior on every OS.
- **`commands/migrate.md`** — Obsidian vault auto-detect now lists registry locations for macOS, Linux, and Windows. Common-defaults list updated to cover non-macOS hosts.

## Test plan

- [ ] CI green (existing single-OS Linux job)
- [ ] Local: `npm run typecheck && npm run build && npx vitest run && git diff --exit-code dist`

## Not in this PR

- Test suite portability (`/tmp/` → `os.tmpdir()`) — PR B.
- Windows `execFile("claude", ...)` wrapper, bootstrap UX, CI matrix, README cross-platform claims — PR C.
