### PR TITLE
test: replace hardcoded /tmp/ paths with os.tmpdir()

### DIFF
--- a/tests/atomicWrite.test.ts
+++ b/tests/atomicWrite.test.ts
@@ -1,9 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { sha256, atomicWrite, readWithChecksum } from "../src/atomicWrite";
 
-const F = "/tmp/sb-aw/n.md";
-beforeEach(() => { fs.rmSync("/tmp/sb-aw", { recursive: true, force: true }); });
+let TMP: string;
+let F: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-aw-"));
+  F = path.join(TMP, "n.md");
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
 
 describe("atomicWrite", () => {
   it("writes then reads back with stable checksum", () => {
@@ -13,11 +24,11 @@ describe("atomicWrite", () => {
     expect(r?.checksum).toBe(sha256("hello"));
   });
   it("returns null for missing file", () => {
-    expect(readWithChecksum("/tmp/sb-aw/missing.md")).toBeNull();
+    expect(readWithChecksum(path.join(TMP, "missing.md"))).toBeNull();
   });
   it("overwrites atomically (no temp file left behind)", () => {
     atomicWrite(F, "a"); atomicWrite(F, "b");
     expect(readWithChecksum(F)?.content).toBe("b");
-    expect(fs.readdirSync("/tmp/sb-aw").filter((x) => x.includes("tmp"))).toEqual([]);
+    expect(fs.readdirSync(TMP).filter((x) => x.includes("tmp"))).toEqual([]);
   });
 });

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -1,61 +1,71 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { depsPresent, bootstrapDone, markBootstrapDone } from "../src/bootstrap";
 
+let TMP_PLUGIN: string;
+let TMP_DATA: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-bs", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-bs-data", { recursive: true, force: true });
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-bs-data";
+  TMP_PLUGIN = fs.mkdtempSync(path.join(os.tmpdir(), "sb-bs-plugin-"));
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-bs-data-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_PLUGIN, { recursive: true, force: true });
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
 });
 
 it("depsPresent is false without the better-sqlite3 native binding, true with it", () => {
-  fs.mkdirSync("/tmp/sb-bs", { recursive: true });
-  expect(depsPresent("/tmp/sb-bs")).toBe(false);
+  expect(depsPresent(TMP_PLUGIN)).toBe(false);
   // package directory alone is NOT enough — a source-only install (no compiled
   // .node) must read as not-ready, or entrypoints crash silently on require().
-  fs.mkdirSync("/tmp/sb-bs/node_modules/better-sqlite3", { recursive: true });
-  expect(depsPresent("/tmp/sb-bs")).toBe(false);
+  fs.mkdirSync(path.join(TMP_PLUGIN, "node_modules/better-sqlite3"), { recursive: true });
+  expect(depsPresent(TMP_PLUGIN)).toBe(false);
   // with the compiled native binding present → ready
-  fs.mkdirSync("/tmp/sb-bs/node_modules/better-sqlite3/build/Release", { recursive: true });
-  fs.writeFileSync("/tmp/sb-bs/node_modules/better-sqlite3/build/Release/better_sqlite3.node", "");
-  expect(depsPresent("/tmp/sb-bs")).toBe(true);
+  fs.mkdirSync(path.join(TMP_PLUGIN, "node_modules/better-sqlite3/build/Release"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_PLUGIN, "node_modules/better-sqlite3/build/Release/better_sqlite3.node"), "");
+  expect(depsPresent(TMP_PLUGIN)).toBe(true);
 });
 
 it("bootstrapDone reflects the per-install marker", () => {
-  fs.mkdirSync("/tmp/sb-bs", { recursive: true });
-  expect(bootstrapDone("/tmp/sb-bs")).toBe(false);
-  markBootstrapDone("/tmp/sb-bs");
-  expect(bootstrapDone("/tmp/sb-bs")).toBe(true);
+  expect(bootstrapDone(TMP_PLUGIN)).toBe(false);
+  markBootstrapDone(TMP_PLUGIN);
+  expect(bootstrapDone(TMP_PLUGIN)).toBe(true);
   // A different install dir must have its own independent sentinel — that's
   // the whole point of moving bootstrap-done per-install.
-  fs.mkdirSync("/tmp/sb-bs-other", { recursive: true });
-  expect(bootstrapDone("/tmp/sb-bs-other")).toBe(false);
+  const otherPlugin = fs.mkdtempSync(path.join(os.tmpdir(), "sb-bs-other-"));
+  try {
+    expect(bootstrapDone(otherPlugin)).toBe(false);
+  } finally {
+    fs.rmSync(otherPlugin, { recursive: true, force: true });
+  }
 });
 
 it("sb-bootstrap is idempotent only when BOTH sentinel exists AND deps present", () => {
-  fs.mkdirSync("/tmp/sb-bs", { recursive: true });
-  markBootstrapDone("/tmp/sb-bs");
+  markBootstrapDone(TMP_PLUGIN);
   // Without the native binding, sentinel alone is not enough — bootstrap must
   // still run to rebuild. Stage a fake binding so the conjoined check passes.
-  fs.mkdirSync("/tmp/sb-bs/node_modules/better-sqlite3/build/Release", { recursive: true });
-  fs.writeFileSync("/tmp/sb-bs/node_modules/better-sqlite3/build/Release/better_sqlite3.node", "");
+  fs.mkdirSync(path.join(TMP_PLUGIN, "node_modules/better-sqlite3/build/Release"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_PLUGIN, "node_modules/better-sqlite3/build/Release/better_sqlite3.node"), "");
   const out = execFileSync("npx", ["tsx", "bin/sb-bootstrap.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-bs-data",
-      SUPERBRAIN_PLUGIN_ROOT: "/tmp/sb-bs", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_PLUGIN_ROOT: TMP_PLUGIN, SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });
   expect(out).toMatch(/already done/);
 });
 
 it("sb-bootstrap (fake) writes per-install bootstrap-done on success", () => {
-  fs.mkdirSync("/tmp/sb-bs", { recursive: true });
   execFileSync("npx", ["tsx", "bin/sb-bootstrap.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-bs-data",
-      SUPERBRAIN_PLUGIN_ROOT: "/tmp/sb-bs", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_PLUGIN_ROOT: TMP_PLUGIN, SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });
-  expect(bootstrapDone("/tmp/sb-bs")).toBe(true);
+  expect(bootstrapDone(TMP_PLUGIN)).toBe(true);
 });
 
 it("sb-bootstrap re-runs when sentinel exists but native binding is missing (upgrade self-heal)", () => {
@@ -63,12 +73,11 @@ it("sb-bootstrap re-runs when sentinel exists but native binding is missing (upg
   // survives into a new plugin version dir that has no .node binary yet.
   // Old code would short-circuit on sentinel and leave deps broken forever.
   // New code re-runs because the conjoined check fails.
-  fs.mkdirSync("/tmp/sb-bs", { recursive: true });
-  markBootstrapDone("/tmp/sb-bs");
+  markBootstrapDone(TMP_PLUGIN);
   // No better-sqlite3 native binding staged — depsPresent is false.
   const out = execFileSync("npx", ["tsx", "bin/sb-bootstrap.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-bs-data",
-      SUPERBRAIN_PLUGIN_ROOT: "/tmp/sb-bs", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_PLUGIN_ROOT: TMP_PLUGIN, SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });
   expect(out).not.toMatch(/already done/);

--- a/tests/checkpoint.test.ts
+++ b/tests/checkpoint.test.ts
@@ -1,13 +1,23 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-beforeEach(() => fs.rmSync("/tmp/sb-ckpt", { recursive: true, force: true }));
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ckpt-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
 
 function run(hook: object, extraEnv: Record<string, string> = {}) {
   return execFileSync("npx", ["tsx", "bin/sb-checkpoint.ts"], {
     input: JSON.stringify(hook),
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ckpt",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP,
            SUPERBRAIN_FAKE_DISTILLER: "1", ...extraEnv },
     encoding: "utf8",
   });
@@ -16,21 +26,21 @@ function run(hook: object, extraEnv: Record<string, string> = {}) {
 describe("sb-checkpoint", () => {
   it("Stop with no pending marker is a no-op", () => {
     run({ session_id: "S", hook_event_name: "Stop", cwd: "/p", transcript_path: "/dev/null" });
-    expect(fs.existsSync("/tmp/sb-ckpt/distill-invoked")).toBe(false);
+    expect(fs.existsSync(path.join(TMP, "distill-invoked"))).toBe(false);
   });
   it("Stop with pending marker invokes the (faked) distiller and clears pending", () => {
-    fs.mkdirSync("/tmp/sb-ckpt/sessions", { recursive: true });
-    fs.writeFileSync("/tmp/sb-ckpt/sessions/S.pending", "1");
+    fs.mkdirSync(path.join(TMP, "sessions"), { recursive: true });
+    fs.writeFileSync(path.join(TMP, "sessions/S.pending"), "1");
     run({ session_id: "S", hook_event_name: "Stop", cwd: "/p", transcript_path: "/dev/null" });
-    expect(fs.existsSync("/tmp/sb-ckpt/distill-invoked")).toBe(true);
-    expect(fs.existsSync("/tmp/sb-ckpt/sessions/S.pending")).toBe(false);
+    expect(fs.existsSync(path.join(TMP, "distill-invoked"))).toBe(true);
+    expect(fs.existsSync(path.join(TMP, "sessions/S.pending"))).toBe(false);
   });
   it("PreCompact always invokes distiller (no pending needed) and never blocks (exit 0)", () => {
     run({ session_id: "S", hook_event_name: "PreCompact", cwd: "/p", transcript_path: "/dev/null" });
-    expect(fs.existsSync("/tmp/sb-ckpt/distill-invoked")).toBe(true);
+    expect(fs.existsSync(path.join(TMP, "distill-invoked"))).toBe(true);
   });
   it("recursion guard makes it a no-op", () => {
     run({ session_id: "S", hook_event_name: "PreCompact", cwd: "/p", transcript_path: "/dev/null" }, { SUPERBRAIN_CHILD: "1" });
-    expect(fs.existsSync("/tmp/sb-ckpt/distill-invoked")).toBe(false);
+    expect(fs.existsSync(path.join(TMP, "distill-invoked"))).toBe(false);
   });
 });

--- a/tests/cursor.test.ts
+++ b/tests/cursor.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { readCursor, writeCursor } from "../src/cursor";
 
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-cursor";
-  fs.rmSync("/tmp/sb-cursor", { recursive: true, force: true });
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-cursor-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 describe("cursor", () => {
@@ -14,9 +22,8 @@ describe("cursor", () => {
     expect(readCursor("s")).toBe(42);
   });
   it("treats corrupt cursor as 0", () => {
-    process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-cursor";
     writeCursor("s", 10);
-    fs.writeFileSync("/tmp/sb-cursor/sessions/s.cursor", "garbage");
+    fs.writeFileSync(path.join(TMP, "sessions/s.cursor"), "garbage");
     expect(readCursor("s")).toBe(0);
   });
 });

--- a/tests/dailyNote.test.ts
+++ b/tests/dailyNote.test.ts
@@ -1,11 +1,19 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { upsertDay } from "../src/dailyState";
 import { buildDailyNote } from "../src/dailyNote";
 
+let TMP: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-dn", { recursive: true, force: true });
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-dn";
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dn-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 it("merges sessions into a hybrid note (links, not bodies)", () => {

--- a/tests/dailyState.test.ts
+++ b/tests/dailyState.test.ts
@@ -1,10 +1,18 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { upsertDay, readDay, type DaySessionEntry } from "../src/dailyState";
 
+let TMP: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-ds", { recursive: true, force: true });
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-ds";
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ds-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 const entry = (over: Partial<DaySessionEntry> = {}): DaySessionEntry =>

--- a/tests/depsBinding.test.ts
+++ b/tests/depsBinding.test.ts
@@ -1,5 +1,6 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { depsPresent } from "../src/bootstrap.js";
 
@@ -9,19 +10,22 @@ import { depsPresent } from "../src/bootstrap.js";
 // binding was never compiled (e.g. Node ABI with no prebuild + bootstrap that
 // didn't rebuild). Treating that as "ready" causes silent require() crashes.
 
-const ROOT = "/tmp/sb-deps-binding";
-const BS = path.join(ROOT, "node_modules", "better-sqlite3");
+let ROOT: string;
 
 beforeEach(() => {
+  ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-deps-binding-"));
+});
+
+afterEach(() => {
   fs.rmSync(ROOT, { recursive: true, force: true });
 });
 
 it("false when better-sqlite3 is absent entirely", () => {
-  fs.mkdirSync(ROOT, { recursive: true });
   expect(depsPresent(ROOT)).toBe(false);
 });
 
 it("false when better-sqlite3 is present but the native binding was never built (source-only)", () => {
+  const BS = path.join(ROOT, "node_modules", "better-sqlite3");
   fs.mkdirSync(BS, { recursive: true });
   fs.writeFileSync(path.join(BS, "package.json"), '{"name":"better-sqlite3"}');
   // no build/Release/*.node, no prebuilds/ — this is the broken-install bug
@@ -29,6 +33,7 @@ it("false when better-sqlite3 is present but the native binding was never built 
 });
 
 it("true when the compiled binding exists at build/Release/better_sqlite3.node", () => {
+  const BS = path.join(ROOT, "node_modules", "better-sqlite3");
   const rel = path.join(BS, "build", "Release");
   fs.mkdirSync(rel, { recursive: true });
   fs.writeFileSync(path.join(rel, "better_sqlite3.node"), "");
@@ -36,6 +41,7 @@ it("true when the compiled binding exists at build/Release/better_sqlite3.node",
 });
 
 it("true when a prebuilt binding is shipped under prebuilds/ (must not false-negative prebuild installs)", () => {
+  const BS = path.join(ROOT, "node_modules", "better-sqlite3");
   const pre = path.join(BS, "prebuilds", "darwin-arm64");
   fs.mkdirSync(pre, { recursive: true });
   fs.writeFileSync(path.join(pre, "better-sqlite3.node"), "");

--- a/tests/distill.test.ts
+++ b/tests/distill.test.ts
@@ -1,35 +1,45 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-dist", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-dist-vault", { recursive: true, force: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dist-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dist-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 it("distills delta into routed notes, daily .log file, advances cursor, releases lock", () => {
-  fs.mkdirSync("/tmp/sb-dist/sessions", { recursive: true });
-  fs.writeFileSync("/tmp/sb-dist/sessions/S.ndjson",
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/S.ndjson"),
     JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n");
-  const stub = "/tmp/sb-dist/stub.json";
+  const stub = path.join(TMP_DATA, "stub.json");
   fs.writeFileSync(stub, JSON.stringify([
     { kind: "decision", title: "Pick X", body: "rationale", date: "2026-05-19", links: ["SuperBrain"] },
   ]));
-  fs.mkdirSync("/tmp/sb-dist/locks/distill.lock", { recursive: true });
-  fs.writeFileSync("/tmp/sb-dist/sessions/S.prompt.json", "{}");
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/S.prompt.json"), "{}");
 
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-dist",
-      SUPERBRAIN_VAULT_DIR: "/tmp/sb-dist-vault", SUPERBRAIN_DISTILL_STUB: stub,
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT, SUPERBRAIN_DISTILL_STUB: stub,
       SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });
 
-  expect(fs.existsSync("/tmp/sb-dist-vault/decisions/2026-05-19-pick-x.md")).toBe(true);
+  expect(fs.existsSync(path.join(TMP_VAULT, "decisions/2026-05-19-pick-x.md"))).toBe(true);
   // The daily .log file lives in dataDir/logs/<today>.log and is named with the
   // current date (not the item's date) since appendLog stamps it at write time.
   const today = new Date().toISOString().slice(0, 10);
-  expect(fs.readFileSync(`/tmp/sb-dist/logs/${today}.log`, "utf8")).toMatch(/Pick X/);
-  expect(Number(fs.readFileSync("/tmp/sb-dist/sessions/S.cursor", "utf8"))).toBeGreaterThan(0);
-  expect(fs.existsSync("/tmp/sb-dist/locks/distill.lock")).toBe(false);
+  expect(fs.readFileSync(path.join(TMP_DATA, `logs/${today}.log`), "utf8")).toMatch(/Pick X/);
+  expect(Number(fs.readFileSync(path.join(TMP_DATA, "sessions/S.cursor"), "utf8"))).toBeGreaterThan(0);
+  expect(fs.existsSync(path.join(TMP_DATA, "locks/distill.lock"))).toBe(false);
 });

--- a/tests/distillDaily.test.ts
+++ b/tests/distillDaily.test.ts
@@ -1,30 +1,40 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-dd", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-dd-vault", { recursive: true, force: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dd-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dd-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 it("writes a daily note aggregating the session's routed items + envelope fields", () => {
-  fs.mkdirSync("/tmp/sb-dd/sessions", { recursive: true });
-  fs.writeFileSync("/tmp/sb-dd/sessions/S.ndjson",
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/S.ndjson"),
     JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n");
-  const stub = "/tmp/sb-dd/stub.json";
+  const stub = path.join(TMP_DATA, "stub.json");
   fs.writeFileSync(stub, JSON.stringify({
     items: [{ kind: "decision", title: "Pick X", body: "why", date: "2026-05-19", links: [] }],
     digest: "Chose X for the pipeline", openThreads: ["wire Y"], alsoDid: ["cleaned logs"],
   }));
-  fs.mkdirSync("/tmp/sb-dd/locks/distill.lock", { recursive: true });
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
 
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-dd", SUPERBRAIN_VAULT_DIR: "/tmp/sb-dd-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });
 
-  const daily = fs.readFileSync("/tmp/sb-dd-vault/daily/2026-05-19.md", "utf8");
+  const daily = fs.readFileSync(path.join(TMP_VAULT, "daily/2026-05-19.md"), "utf8");
   expect(daily).toContain("# 2026-05-19");
   expect(daily).toContain("Chose X for the pipeline");
   expect(daily).toContain("[[decisions/2026-05-19-pick-x]]");

--- a/tests/distillIndex.test.ts
+++ b/tests/distillIndex.test.ts
@@ -1,26 +1,36 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { openIndex } from "../src/searchIndex";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-di";
-  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-di-vault";
-  fs.rmSync("/tmp/sb-di", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-di-vault", { recursive: true, force: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-di-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-di-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 it("a note written by the distiller is searchable in the index", () => {
-  fs.mkdirSync("/tmp/sb-di/sessions", { recursive: true });
-  fs.writeFileSync("/tmp/sb-di/sessions/S.ndjson",
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/S.ndjson"),
     JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n");
-  const stub = "/tmp/sb-di/stub.json";
+  const stub = path.join(TMP_DATA, "stub.json");
   fs.writeFileSync(stub, JSON.stringify([
     { kind: "decision", title: "Adopt sqlite-vec", body: "fast local KNN", date: "2026-05-19", links: [] },
   ]));
-  fs.mkdirSync("/tmp/sb-di/locks/distill.lock", { recursive: true });
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-di", SUPERBRAIN_VAULT_DIR: "/tmp/sb-di-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/distillRollup.test.ts
+++ b/tests/distillRollup.test.ts
@@ -1,27 +1,36 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-dr", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-dr-vault", { recursive: true, force: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dr-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dr-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 it("rollup mode writes a daily note and marks rollup state", () => {
-  fs.mkdirSync("/tmp/sb-dr-vault", { recursive: true });
-  const stub = "/tmp/sb-dr/stub.json";
-  fs.mkdirSync("/tmp/sb-dr/logs", { recursive: true });
-  fs.writeFileSync("/tmp/sb-dr/logs/2026-05-18.log", "[2026-05-18 10:00] write | did things | x\n");
+  const stub = path.join(TMP_DATA, "stub.json");
+  fs.mkdirSync(path.join(TMP_DATA, "logs"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "logs/2026-05-18.log"), "[2026-05-18 10:00] write | did things | x\n");
   fs.writeFileSync(stub, JSON.stringify([{ kind: "capture", title: "Daily 2026-05-18", body: "summary", date: "2026-05-18", links: [] }]));
-  fs.mkdirSync("/tmp/sb-dr/locks/distill.lock", { recursive: true });
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-dr", SUPERBRAIN_VAULT_DIR: "/tmp/sb-dr-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_ROLLUP: "daily:2026-05-18:42",
       SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });
-  expect(fs.existsSync("/tmp/sb-dr-vault/capture/2026-05-18-daily-2026-05-18.md")).toBe(true);
-  const state = JSON.parse(fs.readFileSync("/tmp/sb-dr/rollup-state.json", "utf8"));
+  expect(fs.existsSync(path.join(TMP_VAULT, "capture/2026-05-18-daily-2026-05-18.md"))).toBe(true);
+  const state = JSON.parse(fs.readFileSync(path.join(TMP_DATA, "rollup-state.json"), "utf8"));
   expect(state["daily:2026-05-18"]).toBe("42");
-  expect(fs.existsSync("/tmp/sb-dr/locks/distill.lock")).toBe(false);
+  expect(fs.existsSync(path.join(TMP_DATA, "locks/distill.lock"))).toBe(false);
 });

--- a/tests/distillRollupDaily.test.ts
+++ b/tests/distillRollupDaily.test.ts
@@ -1,31 +1,40 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-rd", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-rd-vault", { recursive: true, force: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rd-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rd-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 it("rollup path also regenerates the daily note for the rollup key", () => {
-  fs.mkdirSync("/tmp/sb-rd-vault", { recursive: true });
-  fs.mkdirSync("/tmp/sb-rd/logs", { recursive: true });
-  fs.writeFileSync("/tmp/sb-rd/logs/2026-05-18.log", "[2026-05-18 10:00] write | Did stuff | decisions/x\n");
-  const stub = "/tmp/sb-rd/stub.json";
+  fs.mkdirSync(path.join(TMP_DATA, "logs"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "logs/2026-05-18.log"), "[2026-05-18 10:00] write | Did stuff | decisions/x\n");
+  const stub = path.join(TMP_DATA, "stub.json");
   fs.writeFileSync(stub, JSON.stringify({
     items: [{ kind: "capture", title: "Daily 2026-05-18", body: "synthesis", date: "2026-05-18", links: [] }],
     digest: "Rollup synthesis for the day",
   }));
-  fs.mkdirSync("/tmp/sb-rd/locks/distill.lock", { recursive: true });
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
 
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-rd", SUPERBRAIN_VAULT_DIR: "/tmp/sb-rd-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "rollup-2026-05-18",
       SUPERBRAIN_ROLLUP: "daily:2026-05-18:v1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });
 
-  const daily = fs.readFileSync("/tmp/sb-rd-vault/daily/2026-05-18.md", "utf8");
+  const daily = fs.readFileSync(path.join(TMP_VAULT, "daily/2026-05-18.md"), "utf8");
   expect(daily).toContain("# 2026-05-18");
   expect(daily).toContain("Rollup synthesis for the day");
 });

--- a/tests/freshCloneE2E.test.ts
+++ b/tests/freshCloneE2E.test.ts
@@ -1,22 +1,28 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-const CLONE = "/tmp/sb-fresh";
+let CLONE: string;
+let TMP_DATA: string;
+
 beforeEach(() => {
-  fs.rmSync(CLONE, { recursive: true, force: true });
-  fs.mkdirSync(CLONE, { recursive: true });
+  CLONE = fs.mkdtempSync(path.join(os.tmpdir(), "sb-fresh-clone-"));
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-fresh-data-"));
   // Simulate a marketplace clone: committed dist/ + manifests, NO node_modules.
   for (const d of ["dist", ".claude-plugin", "hooks"])
     fs.cpSync(d, path.join(CLONE, d), { recursive: true });
   fs.copyFileSync("package.json", path.join(CLONE, "package.json"));
 });
 
+afterEach(() => {
+  fs.rmSync(CLONE, { recursive: true, force: true });
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+});
+
 it("every hook entrypoint loads + exits 0 with NO node_modules; SessionStart bootstraps", () => {
-  const dataDir = "/tmp/sb-fresh-data";
-  fs.rmSync(dataDir, { recursive: true, force: true });
-  const env = { ...process.env, CLAUDE_PLUGIN_ROOT: CLONE, SUPERBRAIN_DATA_DIR: dataDir,
+  const env = { ...process.env, CLAUDE_PLUGIN_ROOT: CLONE, SUPERBRAIN_DATA_DIR: TMP_DATA,
     SUPERBRAIN_BOOTSTRAP_FAKE: "1", SUPERBRAIN_FAKE_DISTILLER: "1" };
   for (const b of ["sb-observe", "sb-checkpoint", "sb-recall", "sb-distill"]) {
     const r = execFileSync(process.execPath, [path.join(CLONE, "dist/bin", `${b}.js`)], {

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -1,20 +1,30 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { indexNote, reconcile } from "../src/indexer";
 import { openIndex } from "../src/searchIndex";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-indexer";
-  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-indexer-vault";
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-indexer-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-indexer-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
   process.env.SUPERBRAIN_EMBED_STUB = "1";
-  fs.rmSync("/tmp/sb-indexer", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-indexer-vault", { recursive: true, force: true });
-  fs.mkdirSync("/tmp/sb-indexer-vault/decisions", { recursive: true });
+  fs.mkdirSync(path.join(TMP_VAULT, "decisions"), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 describe("indexer", () => {
   it("indexNote indexes a single file's chunks", async () => {
-    fs.writeFileSync("/tmp/sb-indexer-vault/decisions/a.md",
+    fs.writeFileSync(path.join(TMP_VAULT, "decisions/a.md"),
       "---\ntype: decision\nstatus: active\n---\n## D\npicked raft over paxos");
     await indexNote("decisions/a.md");
     const ix = openIndex();
@@ -22,7 +32,7 @@ describe("indexer", () => {
     ix.close();
   });
   it("reconcile adds new, updates changed, deletes removed, no-ops unchanged", async () => {
-    const f = "/tmp/sb-indexer-vault/decisions/b.md";
+    const f = path.join(TMP_VAULT, "decisions/b.md");
     fs.writeFileSync(f, "---\ntype: decision\nstatus: active\n---\noriginal alpha");
     let s = await reconcile();
     expect(s).toMatchObject({ added: 1 });
@@ -40,8 +50,8 @@ describe("indexer", () => {
     expect(s).toMatchObject({ deleted: 1 });
   });
   it("reconcile skips .trash and .obsidian", async () => {
-    fs.mkdirSync("/tmp/sb-indexer-vault/.trash", { recursive: true });
-    fs.writeFileSync("/tmp/sb-indexer-vault/.trash/old.md", "## x\ntrashed");
+    fs.mkdirSync(path.join(TMP_VAULT, ".trash"), { recursive: true });
+    fs.writeFileSync(path.join(TMP_VAULT, ".trash/old.md"), "## x\ntrashed");
     await reconcile();
     const ix = openIndex();
     expect(ix.bm25("trashed", 5).length).toBe(0);

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,39 +1,48 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
-import { execFileSync } from "node:child_process";
+import os from "node:os";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 
-const BIN = "/tmp/sb-int-bin";
 const DIST_CHECKPOINT = path.resolve("dist/bin/sb-checkpoint.js");
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+let TMP_BIN: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-int", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-int-vault", { recursive: true, force: true });
-  fs.rmSync(BIN, { recursive: true, force: true });
-  fs.mkdirSync(BIN, { recursive: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-int-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-int-vault-"));
+  TMP_BIN = fs.mkdtempSync(path.join(os.tmpdir(), "sb-int-bin-"));
   // fake `claude` that prints a JSON array (mimics distiller LLM output)
-  fs.writeFileSync(`${BIN}/claude`,
+  fs.writeFileSync(path.join(TMP_BIN, "claude"),
     '#!/usr/bin/env bash\necho \'[{"kind":"decision","title":"Use X","body":"why","date":"2026-05-19","links":["SuperBrain"]}]\'\n');
-  fs.chmodSync(`${BIN}/claude`, 0o755);
+  fs.chmodSync(path.join(TMP_BIN, "claude"), 0o755);
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  fs.rmSync(TMP_BIN, { recursive: true, force: true });
 });
 
 it("real checkpoint path (no fake seam) writes a vault note and releases the lock", () => {
-  fs.mkdirSync("/tmp/sb-int/sessions", { recursive: true });
-  fs.writeFileSync("/tmp/sb-int/sessions/S.ndjson",
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/S.ndjson"),
     JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n");
-  fs.writeFileSync("/tmp/sb-int/sessions/S.pending", "1");
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/S.pending"), "1");
   execFileSync("node", [DIST_CHECKPOINT], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "Stop", cwd: "/p", transcript_path: "/dev/null" }),
-    env: { ...process.env, PATH: `${BIN}:${process.env.PATH}`,
-      SUPERBRAIN_DATA_DIR: "/tmp/sb-int", SUPERBRAIN_VAULT_DIR: "/tmp/sb-int-vault" },
+    env: { ...process.env, PATH: `${TMP_BIN}:${process.env.PATH}`,
+      SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT },
     encoding: "utf8",
   });
   // checkpoint spawns the detached writer; give it a moment
   execFileSync("bash", ["-c", "sleep 2"]);
-  const vault = "/tmp/sb-int-vault";
-  const found = fs.existsSync(vault) && fs.readdirSync(vault, { recursive: true } as any)
+  const found = fs.existsSync(TMP_VAULT) && fs.readdirSync(TMP_VAULT, { recursive: true } as any)
     .some((f: any) => String(f).endsWith(".md"));
   expect(found).toBe(true);
   const today = new Date().toISOString().slice(0, 10);
-  expect(fs.readFileSync(`/tmp/sb-int/logs/${today}.log`, "utf8")).toMatch(/Use X/);
-  expect(fs.existsSync("/tmp/sb-int/locks/distill.lock")).toBe(false);
+  expect(fs.readFileSync(path.join(TMP_DATA, `logs/${today}.log`), "utf8")).toMatch(/Use X/);
+  expect(fs.existsSync(path.join(TMP_DATA, "locks/distill.lock"))).toBe(false);
 });

--- a/tests/lockfile.test.ts
+++ b/tests/lockfile.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { acquireLock, releaseLock } from "../src/lockfile";
 
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-lock";
-  fs.rmSync("/tmp/sb-lock", { recursive: true, force: true });
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-lock-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 describe("lockfile", () => {

--- a/tests/mcpSearch.test.ts
+++ b/tests/mcpSearch.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { openIndex } from "../src/searchIndex";
 import { handleSearch } from "../src/mcpSearch";
 
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-mcps";
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-mcps-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
   process.env.SUPERBRAIN_EMBED_STUB = "1";
-  fs.rmSync("/tmp/sb-mcps", { recursive: true, force: true });
   const ix = openIndex();
   ix.upsertNote("decisions/x.md", 1, "h",
     [{ headingPath: "", anchor: "", text: "adopted mcpvault then replaced it with an in-process writer" }],
     [Float32Array.from(Array(384).fill(0.2))]);
   ix.close();
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 describe("handleSearch", () => {

--- a/tests/ndjson.test.ts
+++ b/tests/ndjson.test.ts
@@ -1,11 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { appendEvent, readDelta } from "../src/ndjson";
 
 const SID = "sess1";
+
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-ndjson";
-  fs.rmSync("/tmp/sb-ndjson", { recursive: true, force: true });
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ndjson-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 describe("ndjson", () => {

--- a/tests/observe.test.ts
+++ b/tests/observe.test.ts
@@ -1,13 +1,23 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-beforeEach(() => fs.rmSync("/tmp/sb-obs", { recursive: true, force: true }));
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-obs-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
 
 function run(hookJson: object) {
   return execFileSync("npx", ["tsx", "bin/sb-observe.ts"], {
     input: JSON.stringify(hookJson),
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-obs" },
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP },
     encoding: "utf8",
   });
 }
@@ -16,16 +26,16 @@ describe("sb-observe", () => {
   it("appends a tool event and sets pending marker file on git commit", () => {
     run({ session_id: "S", hook_event_name: "PostToolUse", cwd: "/p",
           tool_name: "Bash", tool_input: { command: "git commit -m x" } });
-    const nd = fs.readFileSync("/tmp/sb-obs/sessions/S.ndjson", "utf8");
+    const nd = fs.readFileSync(path.join(TMP, "sessions/S.ndjson"), "utf8");
     expect(nd).toMatch(/"tool":"Bash"/);
     expect(nd).toMatch(/"type":"salient"/);
-    expect(fs.existsSync("/tmp/sb-obs/sessions/S.pending")).toBe(true);
+    expect(fs.existsSync(path.join(TMP, "sessions/S.pending"))).toBe(true);
   });
   it("no-ops when recursion guard is set", () => {
     execFileSync("npx", ["tsx", "bin/sb-observe.ts"], {
       input: JSON.stringify({ session_id: "S2", hook_event_name: "PostToolUse", cwd: "/p", tool_name: "Read" }),
-      env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-obs", SUPERBRAIN_CHILD: "1" }, encoding: "utf8",
+      env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP, SUPERBRAIN_CHILD: "1" }, encoding: "utf8",
     });
-    expect(fs.existsSync("/tmp/sb-obs/sessions/S2.ndjson")).toBe(false);
+    expect(fs.existsSync(path.join(TMP, "sessions/S2.ndjson"))).toBe(false);
   });
 });

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -1,19 +1,33 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import * as P from "../src/paths";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
 
 describe("paths", () => {
   beforeEach(() => {
-    process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-test-data";
-    process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-test-vault";
+    TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-test-data-"));
+    TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-test-vault-"));
+    process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+    process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
   });
+
+  afterEach(() => {
+    fs.rmSync(TMP_DATA, { recursive: true, force: true });
+    fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  });
+
   it("derives data + vault + session paths", () => {
-    expect(P.dataDir()).toBe("/tmp/sb-test-data");
-    expect(P.vaultPath()).toBe("/tmp/sb-test-vault");
-    expect(P.sessionNdjsonPath("abc")).toBe("/tmp/sb-test-data/sessions/abc.ndjson");
-    expect(P.cursorPath("abc")).toBe("/tmp/sb-test-data/sessions/abc.cursor");
-    expect(P.sentinelPath()).toBe("/tmp/sb-test-data/last-failure.txt");
-    expect(P.rollupStatePath()).toBe("/tmp/sb-test-data/rollup-state.json");
-    expect(P.lockDir("distill")).toBe("/tmp/sb-test-data/locks/distill.lock");
+    expect(P.dataDir()).toBe(TMP_DATA);
+    expect(P.vaultPath()).toBe(TMP_VAULT);
+    expect(P.sessionNdjsonPath("abc")).toBe(path.join(TMP_DATA, "sessions/abc.ndjson"));
+    expect(P.cursorPath("abc")).toBe(path.join(TMP_DATA, "sessions/abc.cursor"));
+    expect(P.sentinelPath()).toBe(path.join(TMP_DATA, "last-failure.txt"));
+    expect(P.rollupStatePath()).toBe(path.join(TMP_DATA, "rollup-state.json"));
+    expect(P.lockDir("distill")).toBe(path.join(TMP_DATA, "locks/distill.lock"));
   });
   it("falls back to ~/.superbrain and ~/vault", () => {
     delete process.env.SUPERBRAIN_DATA_DIR;

--- a/tests/pathsResolution.test.ts
+++ b/tests/pathsResolution.test.ts
@@ -1,39 +1,58 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { vaultPath, pluginRoot } from "../src/paths";
 import { setRecordedVaultPath, isOwned } from "../src/vaultMarker";
 
+let TMP_DATA: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-pr-data", { recursive: true, force: true });
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-pr-data";
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pr-data-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
   delete process.env.SUPERBRAIN_VAULT_DIR;
   delete process.env.CLAUDE_PLUGIN_ROOT;
 });
 
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+});
+
 it("SUPERBRAIN_VAULT_DIR wins and is marked", () => {
-  fs.mkdirSync("/tmp/sb-pr-explicit", { recursive: true });
-  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-pr-explicit";
-  expect(vaultPath()).toBe("/tmp/sb-pr-explicit");
-  expect(isOwned("/tmp/sb-pr-explicit")).toBe(true);
+  const explicitVault = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pr-explicit-"));
+  try {
+    process.env.SUPERBRAIN_VAULT_DIR = explicitVault;
+    expect(vaultPath()).toBe(explicitVault);
+    expect(isOwned(explicitVault)).toBe(true);
+  } finally {
+    fs.rmSync(explicitVault, { recursive: true, force: true });
+  }
 });
 
 it("recorded adopted path is used when no env", () => {
-  fs.mkdirSync("/tmp/sb-pr-adopted", { recursive: true });
-  setRecordedVaultPath("/tmp/sb-pr-adopted");
-  expect(vaultPath()).toBe("/tmp/sb-pr-adopted");
+  const adoptedVault = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pr-adopted-"));
+  try {
+    setRecordedVaultPath(adoptedVault);
+    expect(vaultPath()).toBe(adoptedVault);
+  } finally {
+    fs.rmSync(adoptedVault, { recursive: true, force: true });
+  }
 });
 
 it("owned default is dataDir/vault, created + marked; never ~/vault", () => {
   const home = os.homedir();
   const v = vaultPath();
-  expect(v).toBe(path.join("/tmp/sb-pr-data", "vault"));
+  expect(v).toBe(path.join(TMP_DATA, "vault"));
   expect(v).not.toBe(path.join(home, "vault"));
   expect(isOwned(v)).toBe(true);
 });
 
 it("pluginRoot honors CLAUDE_PLUGIN_ROOT", () => {
-  process.env.CLAUDE_PLUGIN_ROOT = "/tmp/sb-pr-root";
-  expect(pluginRoot()).toBe("/tmp/sb-pr-root");
+  const pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pr-root-"));
+  try {
+    process.env.CLAUDE_PLUGIN_ROOT = pluginDir;
+    expect(pluginRoot()).toBe(pluginDir);
+  } finally {
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  }
 });

--- a/tests/phase3E2E.test.ts
+++ b/tests/phase3E2E.test.ts
@@ -1,17 +1,27 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-e3", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-e3-vault", { recursive: true, force: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-e3-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-e3-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 it("pushback session yields a lesson note + reconciled preferences, injected next start", () => {
-  fs.mkdirSync("/tmp/sb-e3/sessions", { recursive: true });
-  fs.writeFileSync("/tmp/sb-e3/sessions/S.ndjson",
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/S.ndjson"),
     JSON.stringify({ type: "prompt", cwd: "/p", prompt: "No, stop adding inline comments" }) + "\n");
-  const stub = "/tmp/sb-e3/stub.json";
+  const stub = path.join(TMP_DATA, "stub.json");
   fs.writeFileSync(stub, JSON.stringify({
     items: [
       { kind: "lesson", title: "No inline comments", body: "User reverted commented code.", rule: "Do not add inline comments unless non-obvious.", date: "2026-05-19", links: [] },
@@ -19,22 +29,22 @@ it("pushback session yields a lesson note + reconciled preferences, injected nex
     ],
     digest: "Learned a code-style preference", openThreads: [],
   }));
-  fs.mkdirSync("/tmp/sb-e3/locks/distill.lock", { recursive: true });
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
 
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-e3", SUPERBRAIN_VAULT_DIR: "/tmp/sb-e3-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
       SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });
 
-  expect(fs.existsSync("/tmp/sb-e3-vault/lessons/2026-05-19-no-inline-comments.md")).toBe(true);
-  const pref = fs.readFileSync("/tmp/sb-e3-vault/meta/preferences.md", "utf8");
+  expect(fs.existsSync(path.join(TMP_VAULT, "lessons/2026-05-19-no-inline-comments.md"))).toBe(true);
+  const pref = fs.readFileSync(path.join(TMP_VAULT, "meta/preferences.md"), "utf8");
   expect(pref).toContain("No inline comments unless non-obvious");
   expect(pref).not.toMatch(/## \d{4}-\d\d-\d\d \d\d:\d\d/);
 
   const out = execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S2", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-e3", SUPERBRAIN_VAULT_DIR: "/tmp/sb-e3-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
       SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/preferences.test.ts
+++ b/tests/preferences.test.ts
@@ -1,10 +1,18 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { compileInjectionBlock } from "../src/preferences";
 
+let TMP: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-pref", { recursive: true, force: true });
-  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-pref";
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pref-"));
+  process.env.SUPERBRAIN_VAULT_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 it("returns '' when preferences.md is absent", () => {
@@ -12,8 +20,8 @@ it("returns '' when preferences.md is absent", () => {
 });
 
 it("compiles a compact block from preferences.md body", () => {
-  fs.mkdirSync("/tmp/sb-pref/meta", { recursive: true });
-  fs.writeFileSync("/tmp/sb-pref/meta/preferences.md",
+  fs.mkdirSync(path.join(TMP, "meta"), { recursive: true });
+  fs.writeFileSync(path.join(TMP, "meta/preferences.md"),
     "---\ntype: preference\ncreated: 2026-05-19\n---\n\n## Code\n- No inline comments\n\n## Tests\n- Integration over unit\n");
   const b = compileInjectionBlock();
   expect(b).toContain("Your preferences (SuperBrain)");
@@ -22,7 +30,7 @@ it("compiles a compact block from preferences.md body", () => {
 });
 
 it("returns '' for an empty/whitespace body", () => {
-  fs.mkdirSync("/tmp/sb-pref/meta", { recursive: true });
-  fs.writeFileSync("/tmp/sb-pref/meta/preferences.md", "---\ntype: preference\n---\n\n   \n");
+  fs.mkdirSync(path.join(TMP, "meta"), { recursive: true });
+  fs.writeFileSync(path.join(TMP, "meta/preferences.md"), "---\ntype: preference\n---\n\n   \n");
   expect(compileInjectionBlock()).toBe("");
 });

--- a/tests/recall.test.ts
+++ b/tests/recall.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { openIndex } from "../src/searchIndex";
 import { bm25Recall, hybridRecall } from "../src/recall";
 
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-recall";
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-recall-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
   process.env.SUPERBRAIN_EMBED_STUB = "1";
-  fs.rmSync("/tmp/sb-recall", { recursive: true, force: true });
   const ix = openIndex();
   ix.upsertNote("decisions/2026-05-01-vec.md", 1, "h", [
     { headingPath: "", anchor: "", text: "we chose sqlite-vec over chromadb for local vectors" },
   ], [Float32Array.from(Array(384).fill(0.5))]);
   ix.close();
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 describe("recall", () => {

--- a/tests/recallCorruptDb.test.ts
+++ b/tests/recallCorruptDb.test.ts
@@ -1,26 +1,27 @@
 import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { bm25Recall, hybridRecall } from "../src/recall";
 
-const DIR = "/tmp/sb-corrupt";
+let TMP: string;
 let prevData: string | undefined;
 let prevStub: string | undefined;
 
 beforeEach(() => {
-  fs.rmSync(DIR, { recursive: true, force: true });
-  fs.mkdirSync(DIR, { recursive: true });
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-corrupt-"));
   // A non-sqlite file at the index path => openIndex()'s WAL pragma throws.
-  fs.writeFileSync(`${DIR}/index.db`, "this is definitely not a sqlite database");
+  fs.writeFileSync(path.join(TMP, "index.db"), "this is definitely not a sqlite database");
   prevData = process.env.SUPERBRAIN_DATA_DIR;
   prevStub = process.env.SUPERBRAIN_EMBED_STUB;
-  process.env.SUPERBRAIN_DATA_DIR = DIR;
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
   process.env.SUPERBRAIN_EMBED_STUB = "1";
 });
 
 afterEach(() => {
   if (prevData === undefined) delete process.env.SUPERBRAIN_DATA_DIR; else process.env.SUPERBRAIN_DATA_DIR = prevData;
   if (prevStub === undefined) delete process.env.SUPERBRAIN_EMBED_STUB; else process.env.SUPERBRAIN_EMBED_STUB = prevStub;
-  fs.rmSync(DIR, { recursive: true, force: true });
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 it("bm25Recall returns [] on a corrupt index.db (spec §7), does not throw", async () => {

--- a/tests/rollupConvergence.test.ts
+++ b/tests/rollupConvergence.test.ts
@@ -1,31 +1,43 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-const BIN = "/tmp/sb-conv-bin";
+let TMP_DATA: string;
+let TMP_VAULT: string;
+let TMP_BIN: string;
+
 beforeEach(() => {
-  for (const d of ["/tmp/sb-conv", "/tmp/sb-conv-vault", BIN]) fs.rmSync(d, { recursive: true, force: true });
-  fs.mkdirSync(BIN, { recursive: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-conv-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-conv-vault-"));
+  TMP_BIN = fs.mkdtempSync(path.join(os.tmpdir(), "sb-conv-bin-"));
   // fake claude: append a line to a call-counter file each invocation, print a JSON array
-  fs.writeFileSync(`${BIN}/claude`,
-    '#!/usr/bin/env bash\necho call >> /tmp/sb-conv/claude-calls\necho \'[{"kind":"capture","title":"Daily 2026-05-18","body":"s","date":"2026-05-18","links":[]}]\'\n');
-  fs.chmodSync(`${BIN}/claude`, 0o755);
-  fs.mkdirSync("/tmp/sb-conv", { recursive: true });
+  fs.writeFileSync(path.join(TMP_BIN, "claude"),
+    `#!/usr/bin/env bash\necho call >> ${path.join(TMP_DATA, "claude-calls")}\necho '[{"kind":"capture","title":"Daily 2026-05-18","body":"s","date":"2026-05-18","links":[]}]'\n`);
+  fs.chmodSync(path.join(TMP_BIN, "claude"), 0o755);
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  fs.rmSync(TMP_BIN, { recursive: true, force: true });
 });
 
 it("daily rollup converges: real path triggers the writer at most once across repeated session starts", () => {
-  const env = { ...process.env, PATH: `${BIN}:${process.env.PATH}`,
-    SUPERBRAIN_DATA_DIR: "/tmp/sb-conv", SUPERBRAIN_VAULT_DIR: "/tmp/sb-conv-vault",
+  const env = { ...process.env, PATH: `${TMP_BIN}:${process.env.PATH}`,
+    SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
     SUPERBRAIN_EMBED_STUB: "1" };
   const input = JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" });
   for (let i = 0; i < 3; i++) {
     execFileSync("node", ["dist/bin/sb-session-start.js"], { input, env, encoding: "utf8" });
     execFileSync("bash", ["-c", "sleep 2"]);
   }
-  const calls = fs.existsSync("/tmp/sb-conv/claude-calls")
-    ? fs.readFileSync("/tmp/sb-conv/claude-calls", "utf8").trim().split("\n").filter(Boolean).length : 0;
+  const callsFile = path.join(TMP_DATA, "claude-calls");
+  const calls = fs.existsSync(callsFile)
+    ? fs.readFileSync(callsFile, "utf8").trim().split("\n").filter(Boolean).length : 0;
   // Exactly one rollup synthesis call total (subsequent session starts must NOT re-trigger).
   expect(calls).toBe(1);
-  const state = JSON.parse(fs.readFileSync("/tmp/sb-conv/rollup-state.json", "utf8"));
+  const state = JSON.parse(fs.readFileSync(path.join(TMP_DATA, "rollup-state.json"), "utf8"));
   expect(state["daily:" + new Date(Date.now() - 86400000).toISOString().slice(0,10)]).toBe("v1");
 });

--- a/tests/rollupState.test.ts
+++ b/tests/rollupState.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { needsRollup, markRollup } from "../src/rollupState";
 
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-rollup";
-  fs.rmSync("/tmp/sb-rollup", { recursive: true, force: true });
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rollup-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 describe("rollupState", () => {

--- a/tests/sbAdopt.test.ts
+++ b/tests/sbAdopt.test.ts
@@ -1,26 +1,35 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-am", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-am-home", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-am-vault", { recursive: true, force: true });
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-am";
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-am-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-am-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 function run(args: string[], env: Record<string,string> = {}) {
   return execFileSync("npx", ["tsx", "bin/sb.ts", ...args], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-am", ...env }, encoding: "utf8" });
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, ...env }, encoding: "utf8" });
 }
 
 it("adopt marks + records a writable dir, refuses a file", () => {
-  fs.mkdirSync("/tmp/sb-am-vault", { recursive: true });
-  run(["adopt", "/tmp/sb-am-vault"]);
-  expect(fs.existsSync("/tmp/sb-am-vault/.superbrain")).toBe(true);
-  expect(fs.readFileSync("/tmp/sb-am/vault-path", "utf8")).toBe("/tmp/sb-am-vault");
-  fs.writeFileSync("/tmp/sb-am-file", "x");
-  expect(() => run(["adopt", "/tmp/sb-am-file"])).toThrow();
+  run(["adopt", TMP_VAULT]);
+  expect(fs.existsSync(path.join(TMP_VAULT, ".superbrain"))).toBe(true);
+  expect(fs.readFileSync(path.join(TMP_DATA, "vault-path"), "utf8")).toBe(TMP_VAULT);
+  const tmpFile = path.join(TMP_DATA, "sb-am-file");
+  fs.writeFileSync(tmpFile, "x");
+  expect(() => run(["adopt", tmpFile])).toThrow();
 });
 
 // The `migrate` subcommand was removed. /superbrain:migrate is now a fully

--- a/tests/sbDistillNoDeps.test.ts
+++ b/tests/sbDistillNoDeps.test.ts
@@ -1,18 +1,28 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let TMP_DATA: string;
+let TMP_EMPTY: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-dnd", { recursive: true, force: true });
-  fs.mkdirSync("/tmp/sb-dnd/locks/distill.lock", { recursive: true });
-  fs.mkdirSync("/tmp/sb-dnd-empty", { recursive: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dnd-data-"));
+  TMP_EMPTY = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dnd-empty-"));
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_EMPTY, { recursive: true, force: true });
 });
 
 it("sb-distill releases the lock and exits 0 when deps absent", () => {
   execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-dnd",
-      CLAUDE_PLUGIN_ROOT: "/tmp/sb-dnd-empty", SUPERBRAIN_SESSION_ID: "S" },
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA,
+      CLAUDE_PLUGIN_ROOT: TMP_EMPTY, SUPERBRAIN_SESSION_ID: "S" },
     encoding: "utf8",
   });
-  expect(fs.existsSync("/tmp/sb-dnd/locks/distill.lock")).toBe(false);
+  expect(fs.existsSync(path.join(TMP_DATA, "locks/distill.lock"))).toBe(false);
 });

--- a/tests/sbMcp.test.ts
+++ b/tests/sbMcp.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { openIndex } from "../src/searchIndex";
 
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-mcp";
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-mcp-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
   process.env.SUPERBRAIN_EMBED_STUB = "1";
-  fs.rmSync("/tmp/sb-mcp", { recursive: true, force: true });
   const ix = openIndex();
   ix.upsertNote("projects/p.md", 1, "h",
     [{ headingPath: "", anchor: "", text: "the daily rollup converges with a stable v1 gate" }],
     [Float32Array.from(Array(384).fill(0.7))]);
   ix.close();
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 it("responds to initialize, tools/list, and tools/call over stdio", () => {

--- a/tests/sbMcpNoDeps.test.ts
+++ b/tests/sbMcpNoDeps.test.ts
@@ -1,12 +1,22 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-beforeEach(() => { fs.mkdirSync("/tmp/sb-mcp-empty", { recursive: true }); });
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-mcp-empty-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
 
 it("sb-mcp exits 0 cleanly when deps absent (no MCP, no crash)", () => {
   const out = execFileSync("npx", ["tsx", "bin/sb-mcp.ts"], {
-    env: { ...process.env, CLAUDE_PLUGIN_ROOT: "/tmp/sb-mcp-empty" },
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: TMP },
     encoding: "utf8", timeout: 10000,
   });
   expect(out).toMatch(/SuperBrain search not ready/);

--- a/tests/sbRecall.test.ts
+++ b/tests/sbRecall.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { openIndex } from "../src/searchIndex";
 
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-rh";
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rh-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
   process.env.SUPERBRAIN_EMBED_STUB = "1";
-  fs.rmSync("/tmp/sb-rh", { recursive: true, force: true });
   const ix = openIndex();
   ix.upsertNote("projects/super-brain.md", 1, "h",
     [{ headingPath: "Decisions", anchor: "decisions", text: "we picked RRF hybrid fusion for recall" }],
     [Float32Array.from(Array(384).fill(0.4))]);
   ix.close();
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 function run(hook: object, extraEnv: Record<string, string> = {}) {

--- a/tests/sbRecallNoDeps.test.ts
+++ b/tests/sbRecallNoDeps.test.ts
@@ -1,13 +1,23 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-beforeEach(() => { fs.mkdirSync("/tmp/sb-nodeps-empty", { recursive: true }); });
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-nodeps-empty-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
 
 it("sb-recall exits 0 (no crash) when deps are absent", () => {
   const out = execFileSync("npx", ["tsx", "bin/sb-recall.ts"], {
     input: JSON.stringify({ prompt: "anything" }),
-    env: { ...process.env, CLAUDE_PLUGIN_ROOT: "/tmp/sb-nodeps-empty" },
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: TMP },
     encoding: "utf8",
   });
   expect(out).toBe(""); // no additionalContext, no throw

--- a/tests/searchIndex.test.ts
+++ b/tests/searchIndex.test.ts
@@ -1,8 +1,19 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { openIndex, rrf } from "../src/searchIndex";
 
-beforeEach(() => { process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-idx"; fs.rmSync("/tmp/sb-idx", { recursive: true, force: true }); });
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-idx-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
 
 const vec = (n: number) => Float32Array.from(Array(384).fill(n));
 

--- a/tests/sentinel.test.ts
+++ b/tests/sentinel.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { writeFailure, readAndClearFailure } from "../src/sentinel";
 
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-sentinel";
-  fs.rmSync("/tmp/sb-sentinel", { recursive: true, force: true });
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-sentinel-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 describe("sentinel", () => {

--- a/tests/sessionStart.test.ts
+++ b/tests/sessionStart.test.ts
@@ -1,21 +1,33 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-beforeEach(() => fs.rmSync("/tmp/sb-ss", { recursive: true, force: true }));
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ss-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ss-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
 
 function run() {
   return execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ss", SUPERBRAIN_VAULT_DIR: "/tmp/sb-ss-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
            SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });
 }
 
 it("surfaces a prior failure once via additionalContext", () => {
-  fs.mkdirSync("/tmp/sb-ss", { recursive: true });
-  fs.writeFileSync("/tmp/sb-ss/last-failure.txt", "[t] distill failed: boom\n");
+  fs.writeFileSync(path.join(TMP_DATA, "last-failure.txt"), "[t] distill failed: boom\n");
   const out = run();
   expect(out).toMatch(/additionalContext/);
   expect(out).toMatch(/distill failed: boom/);
@@ -25,5 +37,5 @@ it("surfaces a prior failure once via additionalContext", () => {
 
 it("triggers a (faked) daily rollup when none compiled", () => {
   run();
-  expect(fs.existsSync("/tmp/sb-ss/rollup-invoked")).toBe(true);
+  expect(fs.existsSync(path.join(TMP_DATA, "rollup-invoked"))).toBe(true);
 });

--- a/tests/sessionStartBootstrap.test.ts
+++ b/tests/sessionStartBootstrap.test.ts
@@ -1,17 +1,26 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let TMP_DATA: string;
+let TMP_EMPTY: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-ssb", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-ssb-empty", { recursive: true, force: true });
-  fs.mkdirSync("/tmp/sb-ssb-empty", { recursive: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ssb-data-"));
+  TMP_EMPTY = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ssb-empty-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_EMPTY, { recursive: true, force: true });
 });
 
 it("no deps: emits the rebuilding-native-deps notice, exits 0, does NOT crash", () => {
   const out = execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ssb", CLAUDE_PLUGIN_ROOT: "/tmp/sb-ssb-empty",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, CLAUDE_PLUGIN_ROOT: TMP_EMPTY,
       SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });

--- a/tests/sessionStartDigest.test.ts
+++ b/tests/sessionStartDigest.test.ts
@@ -1,13 +1,18 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { openIndex } from "../src/searchIndex.js";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-ssd", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-ssd-vault", { recursive: true, force: true });
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ssd-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ssd-vault-"));
   process.env.SUPERBRAIN_EMBED_STUB = "1";
-  const old = process.env.SUPERBRAIN_DATA_DIR; process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-ssd";
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
   const ix = openIndex();
   // Fixture text includes "recent work" so that BM25 OR-query tokens from the seed
   // ("recent", "work") lexically overlap the indexed content — required because hybridRecall
@@ -16,13 +21,18 @@ beforeEach(() => {
   ix.upsertNote("projects/super-brain.md", 1, "h",
     [{ headingPath: "Status", anchor: "status", text: "recent work: phase 1 shipped; phase 2 adds hybrid search" }],
     [Float32Array.from(Array(384).fill(0.6))]);
-  ix.close(); process.env.SUPERBRAIN_DATA_DIR = old;
+  ix.close();
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 it("SessionStart emits a hybrid recall digest in additionalContext", () => {
   const out = execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ssd", SUPERBRAIN_VAULT_DIR: "/tmp/sb-ssd-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
            SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/sessionStartPrefs.test.ts
+++ b/tests/sessionStartPrefs.test.ts
@@ -1,23 +1,33 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-ssp", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-ssp-vault", { recursive: true, force: true });
-  fs.mkdirSync("/tmp/sb-ssp-vault/meta", { recursive: true });
-  fs.writeFileSync("/tmp/sb-ssp-vault/meta/preferences.md",
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ssp-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ssp-vault-"));
+  fs.mkdirSync(path.join(TMP_VAULT, "meta"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_VAULT, "meta/preferences.md"),
     "---\ntype: preference\ncreated: 2026-05-19\n---\n\n## Code\n- No inline comments\n");
   const today = new Date().toISOString().slice(0, 10);
-  fs.mkdirSync("/tmp/sb-ssp/daily", { recursive: true });
-  fs.writeFileSync(`/tmp/sb-ssp/daily/${today}.json`,
+  fs.mkdirSync(path.join(TMP_DATA, "daily"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, `daily/${today}.json`),
     JSON.stringify({ S1: { digestLine: "d", routedRelPaths: [], alsoDid: [], openThreads: ["finish phase 3"] } }));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 it("SessionStart injects compiled preferences and today's open threads", () => {
   const out = execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
-    env: { ...process.env, SUPERBRAIN_DATA_DIR: "/tmp/sb-ssp", SUPERBRAIN_VAULT_DIR: "/tmp/sb-ssp-vault",
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
       SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_EMBED_STUB: "1" },
     encoding: "utf8",
   });

--- a/tests/vaultMarker.test.ts
+++ b/tests/vaultMarker.test.ts
@@ -1,23 +1,32 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { MARKER, isOwned, markOwned, recordedVaultPath, setRecordedVaultPath } from "../src/vaultMarker";
 
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-vm", { recursive: true, force: true });
-  fs.rmSync("/tmp/sb-vm-data", { recursive: true, force: true });
-  process.env.SUPERBRAIN_DATA_DIR = "/tmp/sb-vm-data";
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-vm-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-vm-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
 });
 
 it("markOwned writes the marker; isOwned detects it", () => {
-  fs.mkdirSync("/tmp/sb-vm", { recursive: true });
-  expect(isOwned("/tmp/sb-vm")).toBe(false);
-  markOwned("/tmp/sb-vm");
-  expect(fs.existsSync(`/tmp/sb-vm/${MARKER}`)).toBe(true);
-  expect(isOwned("/tmp/sb-vm")).toBe(true);
+  expect(isOwned(TMP_VAULT)).toBe(false);
+  markOwned(TMP_VAULT);
+  expect(fs.existsSync(path.join(TMP_VAULT, MARKER))).toBe(true);
+  expect(isOwned(TMP_VAULT)).toBe(true);
 });
 
 it("recorded vault path round-trips and is undefined when unset", () => {
   expect(recordedVaultPath()).toBeUndefined();
-  setRecordedVaultPath("/tmp/sb-vm");
-  expect(recordedVaultPath()).toBe("/tmp/sb-vm");
+  setRecordedVaultPath(TMP_VAULT);
+  expect(recordedVaultPath()).toBe(TMP_VAULT);
 });

--- a/tests/vaultWriter.test.ts
+++ b/tests/vaultWriter.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { writeNote, softDelete } from "../src/vaultWriter";
 
+let TMP: string;
+
 beforeEach(() => {
-  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-vault";
-  fs.rmSync("/tmp/sb-vault", { recursive: true, force: true });
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-vault-"));
+  process.env.SUPERBRAIN_VAULT_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 describe("vaultWriter", () => {
   it("creates a note with validated frontmatter", () => {
     const r = writeNote("projects/x.md", { frontmatter: { type: "project", status: "active" }, body: "# X", mode: "create" });
     expect(r.ok).toBe(true);
-    expect(fs.readFileSync("/tmp/sb-vault/projects/x.md", "utf8")).toContain("type: project");
+    expect(fs.readFileSync(path.join(TMP, "projects/x.md"), "utf8")).toContain("type: project");
   });
   it("rejects disallowed extension and path traversal", () => {
     expect(writeNote("projects/x.exe", { frontmatter: { type: "project", status: "active" }, body: "", mode: "create" }).ok).toBe(false);
@@ -23,33 +31,33 @@ describe("vaultWriter", () => {
   it("appends without clobbering and never overwrites in append mode", () => {
     writeNote("daily/2026-05-19.md", { frontmatter: { type: "daily" }, body: "first", mode: "create" });
     writeNote("daily/2026-05-19.md", { frontmatter: { type: "daily" }, body: "second", mode: "append" });
-    const t = fs.readFileSync("/tmp/sb-vault/daily/2026-05-19.md", "utf8");
+    const t = fs.readFileSync(path.join(TMP, "daily/2026-05-19.md"), "utf8");
     expect(t).toContain("first"); expect(t).toContain("second");
   });
   it("dirty guard: appends instead of clobbering a user-edited note", () => {
     writeNote("projects/z.md", { frontmatter: { type: "project", status: "active" }, body: "orig", mode: "create" });
-    fs.appendFileSync("/tmp/sb-vault/projects/z.md", "\nUSER EDIT\n");
+    fs.appendFileSync(path.join(TMP, "projects/z.md"), "\nUSER EDIT\n");
     const r = writeNote("projects/z.md", { frontmatter: { type: "project", status: "active" }, body: "machine", mode: "create" });
     expect(r.ok).toBe(true);
-    const t = fs.readFileSync("/tmp/sb-vault/projects/z.md", "utf8");
+    const t = fs.readFileSync(path.join(TMP, "projects/z.md"), "utf8");
     expect(t).toContain("USER EDIT");
     expect(t).toContain("machine");
   });
   it("soft-deletes into .trash", () => {
     writeNote("capture/c.md", { frontmatter: { type: "capture", status: "active" }, body: "x", mode: "create" });
     softDelete("capture/c.md");
-    expect(fs.existsSync("/tmp/sb-vault/capture/c.md")).toBe(false);
-    expect(fs.readdirSync("/tmp/sb-vault/.trash").length).toBe(1);
+    expect(fs.existsSync(path.join(TMP, "capture/c.md"))).toBe(false);
+    expect(fs.readdirSync(path.join(TMP, ".trash")).length).toBe(1);
   });
   it("append: skips duplicate body that already appears in the file", () => {
     const fm = { type: "project", status: "active", project: "jarvis" };
     const body = "**SuperBrain v0.5 multi-tenancy is the hard prerequisite gate for Jarvis v0.1** — User explicitly established this sequencing in a planning conversation.";
     writeNote("projects/jarvis.md", { frontmatter: fm, body, mode: "create" });
-    const first = fs.readFileSync("/tmp/sb-vault/projects/jarvis.md", "utf8");
+    const first = fs.readFileSync(path.join(TMP, "projects/jarvis.md"), "utf8");
     const r = writeNote("projects/jarvis.md", { frontmatter: fm, body, mode: "append" });
     expect(r.ok).toBe(true);
     expect(r.reason).toBe("duplicate-skipped");
-    const second = fs.readFileSync("/tmp/sb-vault/projects/jarvis.md", "utf8");
+    const second = fs.readFileSync(path.join(TMP, "projects/jarvis.md"), "utf8");
     expect(second).toBe(first);
   });
   it("append: still writes when body differs from existing content", () => {
@@ -58,7 +66,7 @@ describe("vaultWriter", () => {
     const r = writeNote("projects/jarvis.md", { frontmatter: fm, body: "fact two also with enough unique words for dedup", mode: "append" });
     expect(r.ok).toBe(true);
     expect(r.reason).toBeUndefined();
-    const text = fs.readFileSync("/tmp/sb-vault/projects/jarvis.md", "utf8");
+    const text = fs.readFileSync(path.join(TMP, "projects/jarvis.md"), "utf8");
     expect(text).toContain("fact one");
     expect(text).toContain("fact two");
   });

--- a/tests/vaultWriterReplace.test.ts
+++ b/tests/vaultWriterReplace.test.ts
@@ -1,23 +1,31 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { writeNote } from "../src/vaultWriter";
 import { parseNote } from "../src/frontmatter";
 
+let TMP: string;
+
 beforeEach(() => {
-  fs.rmSync("/tmp/sb-vwr", { recursive: true, force: true });
-  process.env.SUPERBRAIN_VAULT_DIR = "/tmp/sb-vwr";
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-vwr-"));
+  process.env.SUPERBRAIN_VAULT_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
 });
 
 it("replace creates when absent", () => {
   const r = writeNote("meta/preferences.md", { frontmatter: { type: "preference", created: "2026-05-19", updated: "2026-05-19" }, body: "- a", mode: "replace" });
   expect(r.ok).toBe(true);
-  expect(parseNote(fs.readFileSync("/tmp/sb-vwr/meta/preferences.md", "utf8")).content.trim()).toBe("- a");
+  expect(parseNote(fs.readFileSync(path.join(TMP, "meta/preferences.md"), "utf8")).content.trim()).toBe("- a");
 });
 
 it("replace overwrites (not appends) and preserves created", () => {
   writeNote("meta/preferences.md", { frontmatter: { type: "preference", created: "2026-05-01", updated: "2026-05-01" }, body: "- a", mode: "replace" });
   writeNote("meta/preferences.md", { frontmatter: { type: "preference", created: "2026-05-19", updated: "2026-05-19" }, body: "- b", mode: "replace" });
-  const p = parseNote(fs.readFileSync("/tmp/sb-vwr/meta/preferences.md", "utf8"));
+  const p = parseNote(fs.readFileSync(path.join(TMP, "meta/preferences.md"), "utf8"));
   expect(p.content).toContain("- b");
   expect(p.content).not.toContain("- a");
   expect(p.content).not.toMatch(/## \d{4}-\d\d-\d\d \d\d:\d\d/);
@@ -26,9 +34,9 @@ it("replace overwrites (not appends) and preserves created", () => {
 
 it("replace no-ops when normalized body unchanged (mtime stable)", () => {
   writeNote("meta/preferences.md", { frontmatter: { type: "preference", created: "2026-05-19", updated: "2026-05-19" }, body: "- a\n", mode: "replace" });
-  const m1 = fs.statSync("/tmp/sb-vwr/meta/preferences.md").mtimeMs;
+  const m1 = fs.statSync(path.join(TMP, "meta/preferences.md")).mtimeMs;
   const r = writeNote("meta/preferences.md", { frontmatter: { type: "preference", created: "2026-05-19", updated: "2026-05-20" }, body: "  - a  ", mode: "replace" });
-  const m2 = fs.statSync("/tmp/sb-vwr/meta/preferences.md").mtimeMs;
+  const m2 = fs.statSync(path.join(TMP, "meta/preferences.md")).mtimeMs;
   expect(r.ok).toBe(true);
   expect(m2).toBe(m1);
 });
@@ -36,7 +44,7 @@ it("replace no-ops when normalized body unchanged (mtime stable)", () => {
 it("create/append modes still behave as before (regression guard)", () => {
   writeNote("projects/x.md", { frontmatter: { type: "project", status: "active", created: "2026-05-19" }, body: "first", mode: "create" });
   writeNote("projects/x.md", { frontmatter: { type: "project", status: "active", created: "2026-05-19" }, body: "second", mode: "append" });
-  const c = fs.readFileSync("/tmp/sb-vwr/projects/x.md", "utf8");
+  const c = fs.readFileSync(path.join(TMP, "projects/x.md"), "utf8");
   expect(c).toContain("first");
   expect(c).toContain("second");
   expect(c).toMatch(/## \d{4}-\d\d-\d\d \d\d:\d\d/);
@@ -48,6 +56,6 @@ it("replace does not throw when created is absent on both sides", () => {
   // Re-replace, also without created — must not throw, must succeed.
   const r = writeNote("meta/preferences.md", { frontmatter: { type: "preference" }, body: "- b", mode: "replace" });
   expect(r.ok).toBe(true);
-  const c = fs.readFileSync("/tmp/sb-vwr/meta/preferences.md", "utf8");
+  const c = fs.readFileSync(path.join(TMP, "meta/preferences.md"), "utf8");
   expect(c).toContain("- b");
 });


### PR DESCRIPTION
## Summary

Mechanical sweep across the test suite to remove hardcoded `/tmp/` paths. Each test now allocates its own unique tmpdir via `fs.mkdtempSync(path.join(os.tmpdir(), "sb-<slug>-"))` and cleans up via `afterEach`.

This is purely test-environment plumbing — no product code changes, no behavior changes, no new tests.

## Why now

`/tmp/` exists on macOS + Linux but not on Windows. PR C adds `macos-latest` and `windows-latest` to the CI matrix; PR B is the prerequisite that makes the Windows job possible.

## Verification

- All 280 tests still pass
- `grep -rn "/tmp/" tests/` → 5 matches, all string literals in assertions for pure functions (`projectSlug`, `buildDiscoveryPrompt`, `isBlockedPath`) — no tmpdir allocations
- `git diff --stat -- src/ bin/` → empty (no product files modified)

## Part of

3-PR cross-platform sequence (A→B→C) from the 2026-05-20 audit. PR A (#27) handled latent path-separator bugs + Obsidian discovery docs. PR C (next) adds Windows execFile handling, bootstrap UX, CI matrix, and README claims.
