### PR TITLE
feat: v0.5.1 auto-migration UX

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ behavior may change without notice.
 
 ## [Unreleased]
 
+## 0.5.1 — Auto-migration UX
+
+Upgrading from <0.5 now auto-detects legacy vault state. Frontmatter backfill runs automatically (detached, ~30 s, idempotent). A one-time notice in SessionStart inject context surfaces a `sb-doctor migrate-all` command that orchestrates the four migration scripts behind a single y/N prompt with dry-run preview. Sentinel at `~/.superbrain/migration-prompted-<version>.txt` ensures the notice appears once per upgraded version.
+
 ## [0.5.0] — Vault quality and scale
 
 **Disk:** transcript snapshots no longer accumulate — `bin/sb-checkpoint.ts` overwrites one `<sid>.jsonl` per session, and successful distills GC their snapshot. `auto-sync.sh` adds a weekly transcript/.trash sweep + monthly vault gc. New `sb-doctor disk` command for inspection.

--- a/bin/sb-bootstrap.ts
+++ b/bin/sb-bootstrap.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import path from "node:path";
 import { acquireLock, releaseLock } from "../src/lockfile.js";
 import { bootstrapDone, markBootstrapDone, depsPresent } from "../src/bootstrap.js";
 import { writeFailure } from "../src/sentinel.js";
+import { dataDir, vaultPath } from "../src/paths.js";
 
 const PLATFORM_HINTS: Record<string, string> = {
   win32: "On Windows, better-sqlite3 may need Visual Studio Build Tools + Python 3. Install via https://github.com/nodejs/node-gyp#on-windows, or downgrade to Node 20 LTS which has broader prebuilt coverage.",
@@ -14,7 +16,7 @@ export function platformHint(): string {
   return PLATFORM_HINTS[process.platform] || "";
 }
 
-function main() {
+async function main() {
   const root = process.env.SUPERBRAIN_PLUGIN_ROOT || process.cwd();
   // Conjoined check: skip only when BOTH the per-install sentinel exists AND
   // the better-sqlite3 native binding is actually present in this install.
@@ -60,6 +62,27 @@ function main() {
       return;
     }
     markBootstrapDone(root);
+    // After successful bootstrap, check for legacy vault state and auto-run
+    // the safe (idempotent) frontmatter backfill in a detached subprocess.
+    try {
+      const { detectLegacyState } = await import("../src/migrationDetect.js");
+      const vault = vaultPath();
+      const db = path.join(dataDir(), "index.db");
+      const state = await detectLegacyState(vault, db);
+      if (state.frontmatterMissing > 0) {
+        console.log(
+          `SuperBrain: backfilling frontmatter on ${state.frontmatterMissing} legacy notes (detached, ~30s)`
+        );
+        const child = spawn(
+          "npx",
+          ["tsx", "scripts/backfill-frontmatter.ts", vault, "--apply"],
+          { cwd: root, detached: true, stdio: "ignore" }
+        );
+        child.unref();
+      }
+    } catch (e: any) {
+      writeFailure(`bootstrap migration check failed (non-fatal): ${e?.message || e}`);
+    }
   } catch (e: any) {
     writeFailure(`bootstrap failed (unexpected error): ${e?.message || e}`);
   } finally {

--- a/bin/sb-doctor.ts
+++ b/bin/sb-doctor.ts
@@ -2,7 +2,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { spawnSync } from "node:child_process";
 import { readInjectLog, summarize } from "../src/injectTelemetry.js";
+import { vaultPath } from "../src/paths.js";
 
 interface DirStats { name: string; bytes: number; extra?: string; }
 
@@ -72,10 +74,132 @@ function disk(): void {
   console.log(`  ${"Total".padEnd(maxNameLen + 1)} ${humanize(total).padStart(6)}`);
 }
 
+// ---------------------------------------------------------------------------
+// migrate-all orchestrator
+// ---------------------------------------------------------------------------
+
+interface MigrationStep {
+  name: string;
+  script: string;
+}
+
+const MIGRATION_STEPS: MigrationStep[] = [
+  { name: "backfill-frontmatter",        script: "scripts/backfill-frontmatter.ts" },
+  { name: "retro-collapse-duplicates",   script: "scripts/retro-collapse-duplicates.ts" },
+  { name: "migrate-vault",               script: "scripts/migrate-vault.ts" },
+  { name: "retro-prune-preferences",     script: "scripts/retro-prune-preferences.ts" },
+];
+
+function pluginRoot(): string {
+  // dist/bin/sb-doctor.js → plugin root is 2 dirs up
+  return path.resolve(path.dirname(process.argv[1] || __filename), "..", "..");
+}
+
+async function migrateAll(): Promise<void> {
+  const vault = vaultPath();
+  const root = pluginRoot();
+  const isFake = process.env.SUPERBRAIN_FAKE_MIGRATE === "1";
+
+  console.log("SuperBrain migrate-all");
+  console.log(`Vault: ${vault}`);
+  console.log("");
+
+  // Dry-run each step
+  for (let i = 0; i < MIGRATION_STEPS.length; i++) {
+    const step = MIGRATION_STEPS[i];
+    console.log(`Step ${i + 1}/${MIGRATION_STEPS.length}: ${step.name}`);
+
+    if (isFake) {
+      console.log("  (fake mode — skipping dry-run)");
+    } else {
+      const scriptPath = path.join(root, step.script);
+      if (!fs.existsSync(scriptPath)) {
+        console.log(`  (script not found: ${step.script})`);
+      } else {
+        const r = spawnSync("npx", ["tsx", scriptPath, vault], {
+          stdio: ["ignore", "pipe", "pipe"],
+          encoding: "utf8",
+        });
+        const out = (r.stdout || "").trim();
+        const err = (r.stderr || "").trim();
+        if (out) console.log(out.split("\n").map((l) => `  ${l}`).join("\n"));
+        if (err) console.error(err.split("\n").map((l) => `  ${l}`).join("\n"));
+        if (r.status !== 0) console.log(`  (exited with status ${r.status})`);
+      }
+    }
+    console.log("");
+  }
+
+  // Prompt for confirmation
+  const answer = await new Promise<string>((resolve) => {
+    process.stdout.write("Apply all 4 steps? [y/N]: ");
+    let buf = "";
+    let resolved = false;
+    function onData(chunk: Buffer | string) {
+      buf += chunk.toString();
+      const nl = buf.indexOf("\n");
+      if (nl !== -1 && !resolved) {
+        resolved = true;
+        process.stdin.removeListener("data", onData);
+        process.stdin.removeListener("end", onEnd);
+        resolve(buf.slice(0, nl).trim().toLowerCase());
+      }
+    }
+    function onEnd() {
+      if (!resolved) {
+        resolved = true;
+        resolve(buf.trim().toLowerCase());
+      }
+    }
+    process.stdin.resume();
+    process.stdin.on("data", onData);
+    process.stdin.on("end", onEnd);
+  });
+
+  if (answer !== "y") {
+    console.log("Aborted.");
+    process.exit(0);
+  }
+
+  console.log("\nApplying...\n");
+
+  for (let i = 0; i < MIGRATION_STEPS.length; i++) {
+    const step = MIGRATION_STEPS[i];
+    console.log(`Step ${i + 1}/${MIGRATION_STEPS.length}: ${step.name} --apply`);
+
+    if (isFake) {
+      console.log("  [fake] applied");
+    } else {
+      const scriptPath = path.join(root, step.script);
+      if (!fs.existsSync(scriptPath)) {
+        console.log(`  (skipped — script not found: ${step.script})`);
+        continue;
+      }
+      const r = spawnSync("npx", ["tsx", scriptPath, vault, "--apply"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf8",
+      });
+      const out = (r.stdout || "").trim();
+      const err = (r.stderr || "").trim();
+      if (out) console.log(out.split("\n").map((l) => `  ${l}`).join("\n"));
+      if (err) console.error(err.split("\n").map((l) => `  ${l}`).join("\n"));
+      if (r.status !== 0) {
+        console.error(`  Step exited with status ${r.status} — continuing`);
+      } else {
+        console.log("  done");
+      }
+    }
+    console.log("");
+  }
+
+  console.log("migrate-all complete.");
+  process.exit(0);
+}
+
 function main(): void {
   const cmd = process.argv[2];
   if (!cmd || cmd === "--help" || cmd === "-h") {
-    console.log("usage: sb-doctor <disk|inject>");
+    console.log("usage: sb-doctor <disk|inject|migrate-all>");
     process.exit(0);
   }
   if (cmd === "disk") return disk();
@@ -100,6 +224,10 @@ function main(): void {
       }
       console.log(`    ${"Total".padEnd(16)} ${String(Math.round(entry.avgTotal)).padStart(4)} tok avg`);
     }
+    return;
+  }
+  if (cmd === "migrate-all") {
+    migrateAll().catch((e) => { console.error(e); process.exit(1); });
     return;
   }
   console.error(`unknown subcommand: ${cmd}`);

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -13,7 +13,7 @@ async function main() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
-  const server = new McpServer({ name: "superbrain", version: "0.5.0" });
+  const server = new McpServer({ name: "superbrain", version: "0.5.1" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).",

--- a/dist/bin/sb-bootstrap.js
+++ b/dist/bin/sb-bootstrap.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import path from "node:path";
 import { acquireLock, releaseLock } from "../src/lockfile.js";
 import { bootstrapDone, markBootstrapDone, depsPresent } from "../src/bootstrap.js";
 import { writeFailure } from "../src/sentinel.js";
+import { dataDir, vaultPath } from "../src/paths.js";
 const PLATFORM_HINTS = {
     win32: "On Windows, better-sqlite3 may need Visual Studio Build Tools + Python 3. Install via https://github.com/nodejs/node-gyp#on-windows, or downgrade to Node 20 LTS which has broader prebuilt coverage.",
     linux: "On Linux, install build-essential and python3 (e.g. apt: sudo apt install build-essential python3), then retry.",
@@ -11,7 +13,7 @@ const PLATFORM_HINTS = {
 export function platformHint() {
     return PLATFORM_HINTS[process.platform] || "";
 }
-function main() {
+async function main() {
     const root = process.env.SUPERBRAIN_PLUGIN_ROOT || process.cwd();
     // Conjoined check: skip only when BOTH the per-install sentinel exists AND
     // the better-sqlite3 native binding is actually present in this install.
@@ -61,6 +63,22 @@ function main() {
             return;
         }
         markBootstrapDone(root);
+        // After successful bootstrap, check for legacy vault state and auto-run
+        // the safe (idempotent) frontmatter backfill in a detached subprocess.
+        try {
+            const { detectLegacyState } = await import("../src/migrationDetect.js");
+            const vault = vaultPath();
+            const db = path.join(dataDir(), "index.db");
+            const state = await detectLegacyState(vault, db);
+            if (state.frontmatterMissing > 0) {
+                console.log(`SuperBrain: backfilling frontmatter on ${state.frontmatterMissing} legacy notes (detached, ~30s)`);
+                const child = spawn("npx", ["tsx", "scripts/backfill-frontmatter.ts", vault, "--apply"], { cwd: root, detached: true, stdio: "ignore" });
+                child.unref();
+            }
+        }
+        catch (e) {
+            writeFailure(`bootstrap migration check failed (non-fatal): ${e?.message || e}`);
+        }
     }
     catch (e) {
         writeFailure(`bootstrap failed (unexpected error): ${e?.message || e}`);

--- a/dist/bin/sb-doctor.js
+++ b/dist/bin/sb-doctor.js
@@ -2,7 +2,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { spawnSync } from "node:child_process";
 import { readInjectLog, summarize } from "../src/injectTelemetry.js";
+import { vaultPath } from "../src/paths.js";
 function dirSize(p) {
     if (!fs.existsSync(p))
         return 0;
@@ -69,10 +71,120 @@ function disk() {
     }
     console.log(`  ${"Total".padEnd(maxNameLen + 1)} ${humanize(total).padStart(6)}`);
 }
+const MIGRATION_STEPS = [
+    { name: "backfill-frontmatter", script: "scripts/backfill-frontmatter.ts" },
+    { name: "retro-collapse-duplicates", script: "scripts/retro-collapse-duplicates.ts" },
+    { name: "migrate-vault", script: "scripts/migrate-vault.ts" },
+    { name: "retro-prune-preferences", script: "scripts/retro-prune-preferences.ts" },
+];
+function pluginRoot() {
+    // dist/bin/sb-doctor.js → plugin root is 2 dirs up
+    return path.resolve(path.dirname(process.argv[1] || __filename), "..", "..");
+}
+async function migrateAll() {
+    const vault = vaultPath();
+    const root = pluginRoot();
+    const isFake = process.env.SUPERBRAIN_FAKE_MIGRATE === "1";
+    console.log("SuperBrain migrate-all");
+    console.log(`Vault: ${vault}`);
+    console.log("");
+    // Dry-run each step
+    for (let i = 0; i < MIGRATION_STEPS.length; i++) {
+        const step = MIGRATION_STEPS[i];
+        console.log(`Step ${i + 1}/${MIGRATION_STEPS.length}: ${step.name}`);
+        if (isFake) {
+            console.log("  (fake mode — skipping dry-run)");
+        }
+        else {
+            const scriptPath = path.join(root, step.script);
+            if (!fs.existsSync(scriptPath)) {
+                console.log(`  (script not found: ${step.script})`);
+            }
+            else {
+                const r = spawnSync("npx", ["tsx", scriptPath, vault], {
+                    stdio: ["ignore", "pipe", "pipe"],
+                    encoding: "utf8",
+                });
+                const out = (r.stdout || "").trim();
+                const err = (r.stderr || "").trim();
+                if (out)
+                    console.log(out.split("\n").map((l) => `  ${l}`).join("\n"));
+                if (err)
+                    console.error(err.split("\n").map((l) => `  ${l}`).join("\n"));
+                if (r.status !== 0)
+                    console.log(`  (exited with status ${r.status})`);
+            }
+        }
+        console.log("");
+    }
+    // Prompt for confirmation
+    const answer = await new Promise((resolve) => {
+        process.stdout.write("Apply all 4 steps? [y/N]: ");
+        let buf = "";
+        let resolved = false;
+        function onData(chunk) {
+            buf += chunk.toString();
+            const nl = buf.indexOf("\n");
+            if (nl !== -1 && !resolved) {
+                resolved = true;
+                process.stdin.removeListener("data", onData);
+                process.stdin.removeListener("end", onEnd);
+                resolve(buf.slice(0, nl).trim().toLowerCase());
+            }
+        }
+        function onEnd() {
+            if (!resolved) {
+                resolved = true;
+                resolve(buf.trim().toLowerCase());
+            }
+        }
+        process.stdin.resume();
+        process.stdin.on("data", onData);
+        process.stdin.on("end", onEnd);
+    });
+    if (answer !== "y") {
+        console.log("Aborted.");
+        process.exit(0);
+    }
+    console.log("\nApplying...\n");
+    for (let i = 0; i < MIGRATION_STEPS.length; i++) {
+        const step = MIGRATION_STEPS[i];
+        console.log(`Step ${i + 1}/${MIGRATION_STEPS.length}: ${step.name} --apply`);
+        if (isFake) {
+            console.log("  [fake] applied");
+        }
+        else {
+            const scriptPath = path.join(root, step.script);
+            if (!fs.existsSync(scriptPath)) {
+                console.log(`  (skipped — script not found: ${step.script})`);
+                continue;
+            }
+            const r = spawnSync("npx", ["tsx", scriptPath, vault, "--apply"], {
+                stdio: ["ignore", "pipe", "pipe"],
+                encoding: "utf8",
+            });
+            const out = (r.stdout || "").trim();
+            const err = (r.stderr || "").trim();
+            if (out)
+                console.log(out.split("\n").map((l) => `  ${l}`).join("\n"));
+            if (err)
+                console.error(err.split("\n").map((l) => `  ${l}`).join("\n"));
+            if (r.status !== 0) {
+                console.error(`  Step exited with status ${r.status} — continuing`);
+            }
+            else {
+                console.log("  done");
+            }
+        }
+        console.log("");
+    }
+    console.log("migrate-all complete.");
+    process.exit(0);
+}
 function main() {
     const cmd = process.argv[2];
     if (!cmd || cmd === "--help" || cmd === "-h") {
-        console.log("usage: sb-doctor <disk|inject>");
+        console.log("usage: sb-doctor <disk|inject|migrate-all>");
         process.exit(0);
     }
     if (cmd === "disk")
@@ -98,6 +210,10 @@ function main() {
             }
             console.log(`    ${"Total".padEnd(16)} ${String(Math.round(entry.avgTotal)).padStart(4)} tok avg`);
         }
+        return;
+    }
+    if (cmd === "migrate-all") {
+        migrateAll().catch((e) => { console.error(e); process.exit(1); });
         return;
     }
     console.error(`unknown subcommand: ${cmd}`);

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -12,7 +12,7 @@ async function main() {
     const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
-    const server = new McpServer({ name: "superbrain", version: "0.5.0" });
+    const server = new McpServer({ name: "superbrain", version: "0.5.1" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).", { query: z.string(), k: z.number().optional() }, async ({ query, k }) => (await handleSearch({ query, k })));
     const transport = new StdioServerTransport();
     server.connect(transport).catch(() => process.exit(1));

--- a/dist/src/migrationDetect.js
+++ b/dist/src/migrationDetect.js
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import path from "node:path";
+// Folders to scan for missing frontmatter (skip daily, projects, meta, _archive)
+const SCAN_FOLDERS = ["decisions", "lessons", "capture", "people"];
+/**
+ * Fast frontmatter check: look only for type: and project: lines in the
+ * opening --- block. Avoids full YAML parse for speed (<200ms on 400 notes).
+ */
+function hasFrontmatterFields(raw) {
+    if (!raw.startsWith("---"))
+        return { hasType: false, hasProject: false };
+    const end = raw.indexOf("\n---", 3);
+    if (end === -1)
+        return { hasType: false, hasProject: false };
+    const block = raw.slice(0, end);
+    return {
+        hasType: /^type:/m.test(block),
+        hasProject: /^project:/m.test(block),
+    };
+}
+/**
+ * Count notes in the given vault folders that are missing type: or project:.
+ * Uses streaming reads — reads only enough bytes to cover the frontmatter block.
+ */
+function countFrontmatterMissing(vaultDir) {
+    let missing = 0;
+    for (const folder of SCAN_FOLDERS) {
+        const dir = path.join(vaultDir, folder);
+        if (!fs.existsSync(dir))
+            continue;
+        let entries;
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        }
+        catch {
+            continue;
+        }
+        for (const ent of entries) {
+            if (!ent.isFile() || !ent.name.endsWith(".md"))
+                continue;
+            const fullPath = path.join(dir, ent.name);
+            try {
+                // Read up to 2KB — enough for any realistic frontmatter block
+                const buf = Buffer.alloc(2048);
+                const fd = fs.openSync(fullPath, "r");
+                const bytesRead = fs.readSync(fd, buf, 0, 2048, 0);
+                fs.closeSync(fd);
+                const snippet = buf.slice(0, bytesRead).toString("utf8");
+                const { hasType, hasProject } = hasFrontmatterFields(snippet);
+                // People notes don't get project field — only check type for them
+                const folderName = folder;
+                const needsProject = folderName !== "people";
+                if (!hasType || (needsProject && !hasProject)) {
+                    missing++;
+                }
+            }
+            catch { /* skip unreadable files */ }
+        }
+    }
+    return missing;
+}
+/**
+ * Check if vault_edges table is absent or empty in the SQLite DB.
+ * Uses dynamic import so callers stay import-safe.
+ */
+async function checkEdgesEmpty(dbPath) {
+    if (!fs.existsSync(dbPath))
+        return true;
+    try {
+        const { default: Database } = await import("better-sqlite3");
+        const db = new Database(dbPath, { readonly: true });
+        try {
+            // Check table exists
+            const tableExists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='vault_edges'").get();
+            if (!tableExists)
+                return true;
+            const row = db.prepare("SELECT COUNT(*) as cnt FROM vault_edges").get();
+            return row.cnt === 0;
+        }
+        finally {
+            db.close();
+        }
+    }
+    catch {
+        return true;
+    }
+}
+/**
+ * Detect legacy vault state for migration UX.
+ * Synchronous except for the SQLite check which is async.
+ */
+export async function detectLegacyState(vaultDir, dbPath) {
+    const frontmatterMissing = fs.existsSync(vaultDir)
+        ? countFrontmatterMissing(vaultDir)
+        : 0;
+    const edgesEmpty = await checkEdgesEmpty(dbPath);
+    let preferencesOverCap = false;
+    try {
+        const prefsPath = path.join(vaultDir, "meta", "preferences.md");
+        if (fs.existsSync(prefsPath)) {
+            const size = fs.statSync(prefsPath).size;
+            preferencesOverCap = size > 5 * 1024; // 5 KB
+        }
+    }
+    catch { /* best-effort */ }
+    const totalLegacyNotes = frontmatterMissing +
+        (edgesEmpty ? 1 : 0) +
+        (preferencesOverCap ? 1 : 0);
+    return { frontmatterMissing, edgesEmpty, preferencesOverCap, totalLegacyNotes };
+}

--- a/dist/src/sessionDigest.js
+++ b/dist/src/sessionDigest.js
@@ -1,11 +1,14 @@
+import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 import { hybridRecall } from "./recall.js";
 import { compileInjectionBlock } from "./preferences.js";
 import { readDay } from "./dailyState.js";
-import { fitToBudget, INJECT_LIMITS, estimateTokens } from "./injectBudget.js";
+import { fitToBudget, INJECT_LIMITS, estimateTokens, truncateToBudget } from "./injectBudget.js";
 import { classifyPath, basenameSlug } from "./projectDetect.js";
 import { appendInjectedSlugs } from "./sessionInjected.js";
 import { logInject } from "./injectTelemetry.js";
+import { dataDir, vaultPath } from "./paths.js";
 export async function appendDigest(parts, h) {
     const sid = h.session_id || "";
     let recallText = "";
@@ -75,6 +78,37 @@ export async function appendDigest(parts, h) {
         }
     }
     catch { /* personalization is best-effort */ }
+    // Migration notice — one-time per version, version-gated via sentinel file.
+    let noticesText = "";
+    try {
+        const version = process.env.npm_package_version || (() => {
+            try {
+                const pkg = JSON.parse(fs.readFileSync(path.join(path.dirname(new URL(import.meta.url).pathname), "..", "package.json"), "utf8"));
+                return pkg.version;
+            }
+            catch {
+                return "unknown";
+            }
+        })();
+        const sentinelFile = path.join(os.homedir(), ".superbrain", `migration-prompted-${version}.txt`);
+        if (!fs.existsSync(sentinelFile)) {
+            // Dynamically import detectLegacyState (heavy dep, keeps this file import-safe at startup)
+            const { detectLegacyState } = await import("./migrationDetect.js");
+            const vault = vaultPath();
+            const db = path.join(dataDir(), "index.db");
+            const state = await detectLegacyState(vault, db);
+            if (state.edgesEmpty || state.preferencesOverCap) {
+                const notice = `SuperBrain v${version}: legacy vault state detected. ` +
+                    `Run \`npx sb-doctor migrate-all\` to migrate legacy notes to the v0.5 templates (~5 min, reversible via .trash/migration-<date>/).`;
+                noticesText = truncateToBudget(notice, INJECT_LIMITS.notices);
+                parts.push(noticesText);
+                // Write sentinel so this notice is never shown again for this version
+                fs.mkdirSync(path.dirname(sentinelFile), { recursive: true });
+                fs.writeFileSync(sentinelFile, new Date().toISOString() + "\n", "utf8");
+            }
+        }
+    }
+    catch { /* migration notice is best-effort */ }
     // Telemetry — never blocks startup.
     try {
         logInject({
@@ -84,7 +118,7 @@ export async function appendDigest(parts, h) {
                 recall: estimateTokens(recallText),
                 preferences: estimateTokens(preferencesText),
                 openThreads: estimateTokens(openThreadsText),
-                notices: 0,
+                notices: estimateTokens(noticesText),
             },
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",

--- a/src/migrationDetect.ts
+++ b/src/migrationDetect.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface LegacyState {
+  frontmatterMissing: number;   // notes missing type or project field
+  edgesEmpty: boolean;          // vault_edges table empty or absent
+  preferencesOverCap: boolean;  // meta/preferences.md > 5 KB
+  totalLegacyNotes: number;     // sum signal: any > 0 means migration recommended
+}
+
+// Folders to scan for missing frontmatter (skip daily, projects, meta, _archive)
+const SCAN_FOLDERS = ["decisions", "lessons", "capture", "people"];
+
+/**
+ * Fast frontmatter check: look only for type: and project: lines in the
+ * opening --- block. Avoids full YAML parse for speed (<200ms on 400 notes).
+ */
+function hasFrontmatterFields(raw: string): { hasType: boolean; hasProject: boolean } {
+  if (!raw.startsWith("---")) return { hasType: false, hasProject: false };
+  const end = raw.indexOf("\n---", 3);
+  if (end === -1) return { hasType: false, hasProject: false };
+  const block = raw.slice(0, end);
+  return {
+    hasType: /^type:/m.test(block),
+    hasProject: /^project:/m.test(block),
+  };
+}
+
+/**
+ * Count notes in the given vault folders that are missing type: or project:.
+ * Uses streaming reads — reads only enough bytes to cover the frontmatter block.
+ */
+function countFrontmatterMissing(vaultDir: string): number {
+  let missing = 0;
+  for (const folder of SCAN_FOLDERS) {
+    const dir = path.join(vaultDir, folder);
+    if (!fs.existsSync(dir)) continue;
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const ent of entries) {
+      if (!ent.isFile() || !ent.name.endsWith(".md")) continue;
+      const fullPath = path.join(dir, ent.name);
+      try {
+        // Read up to 2KB — enough for any realistic frontmatter block
+        const buf = Buffer.alloc(2048);
+        const fd = fs.openSync(fullPath, "r");
+        const bytesRead = fs.readSync(fd, buf, 0, 2048, 0);
+        fs.closeSync(fd);
+        const snippet = buf.slice(0, bytesRead).toString("utf8");
+        const { hasType, hasProject } = hasFrontmatterFields(snippet);
+        // People notes don't get project field — only check type for them
+        const folderName = folder;
+        const needsProject = folderName !== "people";
+        if (!hasType || (needsProject && !hasProject)) {
+          missing++;
+        }
+      } catch { /* skip unreadable files */ }
+    }
+  }
+  return missing;
+}
+
+/**
+ * Check if vault_edges table is absent or empty in the SQLite DB.
+ * Uses dynamic import so callers stay import-safe.
+ */
+async function checkEdgesEmpty(dbPath: string): Promise<boolean> {
+  if (!fs.existsSync(dbPath)) return true;
+  try {
+    const { default: Database } = await import("better-sqlite3") as any;
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      // Check table exists
+      const tableExists = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='vault_edges'"
+      ).get();
+      if (!tableExists) return true;
+      const row = db.prepare("SELECT COUNT(*) as cnt FROM vault_edges").get() as { cnt: number };
+      return row.cnt === 0;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Detect legacy vault state for migration UX.
+ * Synchronous except for the SQLite check which is async.
+ */
+export async function detectLegacyState(vaultDir: string, dbPath: string): Promise<LegacyState> {
+  const frontmatterMissing = fs.existsSync(vaultDir)
+    ? countFrontmatterMissing(vaultDir)
+    : 0;
+
+  const edgesEmpty = await checkEdgesEmpty(dbPath);
+
+  let preferencesOverCap = false;
+  try {
+    const prefsPath = path.join(vaultDir, "meta", "preferences.md");
+    if (fs.existsSync(prefsPath)) {
+      const size = fs.statSync(prefsPath).size;
+      preferencesOverCap = size > 5 * 1024; // 5 KB
+    }
+  } catch { /* best-effort */ }
+
+  const totalLegacyNotes =
+    frontmatterMissing +
+    (edgesEmpty ? 1 : 0) +
+    (preferencesOverCap ? 1 : 0);
+
+  return { frontmatterMissing, edgesEmpty, preferencesOverCap, totalLegacyNotes };
+}

--- a/src/sessionDigest.ts
+++ b/src/sessionDigest.ts
@@ -1,11 +1,14 @@
+import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 import { hybridRecall } from "./recall.js";
 import { compileInjectionBlock } from "./preferences.js";
 import { readDay } from "./dailyState.js";
-import { fitToBudget, INJECT_LIMITS, estimateTokens } from "./injectBudget.js";
+import { fitToBudget, INJECT_LIMITS, estimateTokens, truncateToBudget } from "./injectBudget.js";
 import { classifyPath, basenameSlug } from "./projectDetect.js";
 import { appendInjectedSlugs } from "./sessionInjected.js";
 import { logInject } from "./injectTelemetry.js";
+import { dataDir, vaultPath } from "./paths.js";
 
 export async function appendDigest(parts: string[], h: any): Promise<void> {
   const sid: string = h.session_id || "";
@@ -72,6 +75,35 @@ export async function appendDigest(parts: string[], h: any): Promise<void> {
     }
   } catch { /* personalization is best-effort */ }
 
+  // Migration notice — one-time per version, version-gated via sentinel file.
+  let noticesText = "";
+  try {
+    const version = process.env.npm_package_version || (() => {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(path.join(path.dirname(new URL(import.meta.url).pathname), "..", "package.json"), "utf8"));
+        return pkg.version as string;
+      } catch { return "unknown"; }
+    })();
+    const sentinelFile = path.join(os.homedir(), ".superbrain", `migration-prompted-${version}.txt`);
+    if (!fs.existsSync(sentinelFile)) {
+      // Dynamically import detectLegacyState (heavy dep, keeps this file import-safe at startup)
+      const { detectLegacyState } = await import("./migrationDetect.js");
+      const vault = vaultPath();
+      const db = path.join(dataDir(), "index.db");
+      const state = await detectLegacyState(vault, db);
+      if (state.edgesEmpty || state.preferencesOverCap) {
+        const notice =
+          `SuperBrain v${version}: legacy vault state detected. ` +
+          `Run \`npx sb-doctor migrate-all\` to migrate legacy notes to the v0.5 templates (~5 min, reversible via .trash/migration-<date>/).`;
+        noticesText = truncateToBudget(notice, INJECT_LIMITS.notices);
+        parts.push(noticesText);
+        // Write sentinel so this notice is never shown again for this version
+        fs.mkdirSync(path.dirname(sentinelFile), { recursive: true });
+        fs.writeFileSync(sentinelFile, new Date().toISOString() + "\n", "utf8");
+      }
+    }
+  } catch { /* migration notice is best-effort */ }
+
   // Telemetry — never blocks startup.
   try {
     logInject({
@@ -81,7 +113,7 @@ export async function appendDigest(parts: string[], h: any): Promise<void> {
         recall: estimateTokens(recallText),
         preferences: estimateTokens(preferencesText),
         openThreads: estimateTokens(openThreadsText),
-        notices: 0,
+        notices: estimateTokens(noticesText),
       },
     });
   } catch { /* best-effort */ }

--- a/tests/doctorMigrate.test.ts
+++ b/tests/doctorMigrate.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+
+const doctorBin = path.resolve("dist/bin/sb-doctor.js");
+
+// Fake vault with some notes so migrate-all has a vault path that exists.
+function makeFakeVault(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-migrate-vault-"));
+  fs.mkdirSync(path.join(dir, "decisions"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "decisions", "test.md"),
+    "---\ntype: decision\nproject: global\n---\n\nbody\n"
+  );
+  return dir;
+}
+
+describe("sb-doctor migrate-all", () => {
+  it("shows dry-run output and exits 0 when user types N", () => {
+    const vault = makeFakeVault();
+    try {
+      const r = spawnSync("node", [doctorBin, "migrate-all"], {
+        input: "N\n",
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SUPERBRAIN_VAULT_DIR: vault,
+          SUPERBRAIN_FAKE_MIGRATE: "1",
+        },
+        timeout: 30000,
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/SuperBrain migrate-all/);
+      expect(r.stdout).toMatch(/Vault:/);
+      expect(r.stdout).toMatch(/Step 1\/4: backfill-frontmatter/);
+      expect(r.stdout).toMatch(/Step 2\/4: retro-collapse-duplicates/);
+      expect(r.stdout).toMatch(/Step 3\/4: migrate-vault/);
+      expect(r.stdout).toMatch(/Step 4\/4: retro-prune-preferences/);
+      expect(r.stdout).toMatch(/Apply all 4 steps\? \[y\/N\]/);
+      expect(r.stdout).toMatch(/Aborted/);
+    } finally {
+      fs.rmSync(vault, { recursive: true, force: true });
+    }
+  });
+
+  it("applies all steps and exits 0 when user types y (fake mode)", () => {
+    const vault = makeFakeVault();
+    try {
+      const r = spawnSync("node", [doctorBin, "migrate-all"], {
+        input: "y\n",
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SUPERBRAIN_VAULT_DIR: vault,
+          SUPERBRAIN_FAKE_MIGRATE: "1",
+        },
+        timeout: 30000,
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/Applying/);
+      expect(r.stdout).toMatch(/Step 1\/4: backfill-frontmatter --apply/);
+      expect(r.stdout).toMatch(/\[fake\] applied/);
+      expect(r.stdout).toMatch(/migrate-all complete/);
+    } finally {
+      fs.rmSync(vault, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 0 when user presses enter (defaults to N)", () => {
+    const vault = makeFakeVault();
+    try {
+      const r = spawnSync("node", [doctorBin, "migrate-all"], {
+        input: "\n",
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SUPERBRAIN_VAULT_DIR: vault,
+          SUPERBRAIN_FAKE_MIGRATE: "1",
+        },
+        timeout: 30000,
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/Aborted/);
+    } finally {
+      fs.rmSync(vault, { recursive: true, force: true });
+    }
+  });
+
+  it("help updated to include migrate-all", () => {
+    const r = spawnSync("node", [doctorBin, "--help"], { encoding: "utf8" });
+    expect(r.stdout).toMatch(/migrate-all/);
+  });
+});

--- a/tests/migrationDetect.test.ts
+++ b/tests/migrationDetect.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { detectLegacyState } from "../src/migrationDetect.js";
+
+let tmpDir: string;
+let vaultDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-migdetect-"));
+  vaultDir = path.join(tmpDir, "vault");
+  dbPath = path.join(tmpDir, "index.db");
+  // Create vault folder structure
+  for (const dir of ["decisions", "lessons", "capture", "people", "meta", "daily", "projects"]) {
+    fs.mkdirSync(path.join(vaultDir, dir), { recursive: true });
+  }
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeNote(relPath: string, content: string) {
+  const full = path.join(vaultDir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, "utf8");
+}
+
+describe("detectLegacyState — frontmatterMissing", () => {
+  it("returns 0 when vault is empty", async () => {
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBe(0);
+  });
+
+  it("counts notes missing type field", async () => {
+    writeNote("decisions/foo.md", "---\nproject: global\n---\n\nbody\n");
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBeGreaterThanOrEqual(1);
+  });
+
+  it("counts notes missing project field (non-people folder)", async () => {
+    writeNote("decisions/bar.md", "---\ntype: decision\n---\n\nbody\n");
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not count notes with both type and project", async () => {
+    writeNote("decisions/good.md", "---\ntype: decision\nproject: global\n---\n\nbody\n");
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBe(0);
+  });
+
+  it("does not require project for people/ notes", async () => {
+    writeNote("people/jane.md", "---\ntype: person\n---\n\nbody\n");
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBe(0);
+  });
+
+  it("counts people/ notes missing type", async () => {
+    writeNote("people/jane.md", "---\nstatus: active\n---\n\nbody\n");
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles notes with no frontmatter at all", async () => {
+    writeNote("capture/raw.md", "# Just a heading\n\nsome content\n");
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBeGreaterThanOrEqual(1);
+  });
+
+  it("scans all 4 target folders", async () => {
+    writeNote("decisions/d.md", "---\ntype: decision\n---\n\nbody\n"); // missing project
+    writeNote("lessons/l.md", "---\ntype: lesson\n---\n\nbody\n");    // missing project
+    writeNote("capture/c.md", "---\ntype: capture\n---\n\nbody\n");   // missing project
+    writeNote("people/p.md", "---\nstatus: active\n---\n\nbody\n");   // missing type
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBe(4);
+  });
+
+  it("does not scan daily/ or projects/ or meta/", async () => {
+    writeNote("daily/2026-05-22.md", "# daily\n\nbody\n"); // no frontmatter, should be ignored
+    writeNote("projects/myapp.md", "# project\n\nbody\n"); // ignored
+    writeNote("meta/preferences.md", "# prefs\n\nbody\n"); // ignored
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBe(0);
+  });
+});
+
+describe("detectLegacyState — edgesEmpty", () => {
+  it("returns edgesEmpty=true when db does not exist", async () => {
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.edgesEmpty).toBe(true);
+  });
+
+  it("returns edgesEmpty=true when vault is empty and no db", async () => {
+    const state = await detectLegacyState(vaultDir, "/nonexistent/path.db");
+    expect(state.edgesEmpty).toBe(true);
+  });
+});
+
+describe("detectLegacyState — preferencesOverCap", () => {
+  it("returns false when preferences.md does not exist", async () => {
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.preferencesOverCap).toBe(false);
+  });
+
+  it("returns false when preferences.md is under 5KB", async () => {
+    writeNote("meta/preferences.md", "---\ntype: preference\n---\n\n" + "x".repeat(100));
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.preferencesOverCap).toBe(false);
+  });
+
+  it("returns true when preferences.md exceeds 5KB", async () => {
+    writeNote("meta/preferences.md", "---\ntype: preference\n---\n\n" + "x".repeat(6000));
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.preferencesOverCap).toBe(true);
+  });
+});
+
+describe("detectLegacyState — totalLegacyNotes", () => {
+  it("returns 0 when vault is clean", async () => {
+    // edgesEmpty will be true (no db), so total >= 1
+    writeNote("decisions/good.md", "---\ntype: decision\nproject: global\n---\n\nbody\n");
+    const state = await detectLegacyState(vaultDir, dbPath);
+    // totalLegacyNotes = frontmatterMissing(0) + edgesEmpty(1) + preferencesOverCap(0) = 1
+    expect(state.totalLegacyNotes).toBe(1);
+    expect(state.frontmatterMissing).toBe(0);
+  });
+
+  it("sums all signals", async () => {
+    writeNote("capture/missing.md", "# no frontmatter\n\nbody\n"); // frontmatter +1
+    writeNote("meta/preferences.md", "x".repeat(6000));            // prefs over cap +1
+    // edgesEmpty = true (no db) → +1
+    const state = await detectLegacyState(vaultDir, dbPath);
+    expect(state.frontmatterMissing).toBe(1);
+    expect(state.preferencesOverCap).toBe(true);
+    expect(state.edgesEmpty).toBe(true);
+    expect(state.totalLegacyNotes).toBe(3);
+  });
+});
+
+describe("detectLegacyState — nonexistent vault", () => {
+  it("handles nonexistent vault gracefully", async () => {
+    const state = await detectLegacyState("/nonexistent/vault", "/nonexistent/db");
+    expect(state.frontmatterMissing).toBe(0);
+    expect(state.edgesEmpty).toBe(true);
+    expect(state.preferencesOverCap).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

SuperBrain v0.5.1 — auto-migration UX. Closes the discoverability gap for anyone upgrading from a pre-0.5 vault.

### How it works

1. **Bootstrap detects legacy state.** `src/migrationDetect.ts` scans `decisions/`, `lessons/`, `capture/`, `people/` for missing `type:`/`project:` frontmatter, checks the `vault_edges` table, and measures `meta/preferences.md` size — all via 2 KB partial reads, sub-200 ms even on large vaults.

2. **Safe migration runs automatically.** When the bootstrap hook detects missing frontmatter, it spawns `scripts/backfill-frontmatter.ts --apply` as a detached subprocess (~30 s, idempotent, no body changes). Failures hit the sentinel; bootstrap never blocks.

3. **Risky migrations are surfaced via SessionStart notice.** A one-time notice within `INJECT_LIMITS.notices` (200 tokens) tells the user about `sb-doctor migrate-all`. A sentinel at `~/.superbrain/migration-prompted-<version>.txt` ensures the notice fires exactly once per upgraded version.

4. **`sb-doctor migrate-all` orchestrates the four scripts** behind a single y/N prompt: dry-run all four → show combined diff → confirm → apply sequentially. `SUPERBRAIN_FAKE_MIGRATE=1` stubs script execution for tests.

### Headlines

- `migrationDetect.ts` — fast partial-read scanner, no full YAML parse, dynamic better-sqlite3 import.
- Bootstrap hook is now async + spawn-detached.
- `sessionDigest.ts` migration notice channel respects token budget + per-version sentinel.
- `sb-doctor migrate-all` subcommand with raw-stdin y/N prompt (TTY-safe and pipe-safe).
- 21 new tests (17 detect + 4 orchestrator). 556 tests total, all green.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (556/556)
- [x] `git diff --exit-code dist`
- [x] `sb-doctor migrate-all` exercised in pipe mode (N-abort, y-apply with fake mode) and `--help`

## Notes

- This unblocks future 0.5.x users without forcing aggressive auto-migration. Body rewrites still require explicit consent via the `[y/N]` prompt — appropriate because they're LLM-driven and opinionated.
- Version bumped in all four lockstep sites (`package.json`, `plugin.json`, `marketplace.json`, `sb-mcp.ts`).
