### PR TITLE
v0.7.0 part 1: stop silent loss of lessons and captures, frontmatter hardening, daily-mirror cleanup

### DIFF
--- a/dist/src/classification.js
+++ b/dist/src/classification.js
@@ -1,7 +1,7 @@
 import { validateNote } from "./templates.js";
 const REROUTE_TO_CAPTURE = new Set(["shipped", "released", "deployed", "merged"]);
 const REROUTE_TO_LESSON = new Set(["learned", "always", "never"]);
-const PROJECT_REQUIRED = ["decision", "lesson", "capture", "person", "project"];
+const PROJECT_REQUIRED = ["project"];
 export function classify(c) {
     // 1. Title-prefix reroute (decisions only)
     const firstWord = c.title.trim().split(/\s+/)[0]?.toLowerCase() ?? "";

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -25,6 +25,44 @@ import { serializeNote } from "./frontmatter.js";
 import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
+function shortTitle(raw, fallbackBody) {
+    const src = (raw || fallbackBody).trim();
+    const words = src.split(/\s+/).filter(Boolean);
+    const taken = words.slice(0, 8).join(" ").replace(/\.+$/, "");
+    return taken || "Captured note";
+}
+function countBodyWords(body) {
+    return body
+        .replace(/^---[\s\S]*?\n---\n?/m, "")
+        .replace(/^#+ .*$/gm, "")
+        .split(/\s+/)
+        .filter(Boolean).length;
+}
+function trimToWordCeiling(text, ceiling) {
+    const words = text.split(/\s+/).filter(Boolean);
+    if (words.length <= ceiling)
+        return text;
+    return words.slice(0, ceiling).join(" ");
+}
+export function coerceCapture(item, routedBody) {
+    const title = shortTitle(item.title, item.body || "");
+    const rawBody = (item.body || routedBody || "").trim();
+    const words = rawBody.split(/\s+/).filter(Boolean);
+    const maxWhat = 180;
+    const whatContent = words.length > maxWhat
+        ? words.slice(0, maxWhat).join(" ") + " …"
+        : rawBody;
+    const lastSentence = rawBody.split(/[.!?](?:\s|$)/).filter(Boolean).pop()?.trim() || rawBody.slice(0, 100);
+    const whyContent = lastSentence.replace(/\.+$/, "").slice(0, 120);
+    return `# ${title}\n\n## What\n\n${whatContent}\n\n## Why it matters\n\n${whyContent}\n`;
+}
+export function coerceLesson(item, routedBody) {
+    const title = (item.title || "Lesson").trim();
+    const ruleText = (item.rule || "").trim() || trimToWordCeiling((item.body || routedBody || "").trim(), 30);
+    const whyText = (item.why || item.body || routedBody || "").trim() || "See session context.";
+    const whenText = (item.whenApplies || "").trim() || "In relevant future situations.";
+    return `# ${title}\n\n## Rule\n\n${ruleText}\n\n## Why\n\n${whyText}\n\n## When this applies\n\n${whenText}\n`;
+}
 export function parseEnvelope(raw) {
     let v;
     try {
@@ -85,7 +123,7 @@ person: { kind, title (short), date, person (slug — required), body (role/cont
 
 preference: { kind, title: "Preferences", date, body (the FULL reconciled user-preferences doc — plain markdown, organized by '## Category' headings such as Code style / Architecture / Tools / Communication, NEVER containing SuperBrain distiller behavior) }
 
-capture: { kind, title, date, body, links }
+capture: { kind, title (≤8 words, no trailing period — scannable noun phrase, not a sentence), date, what (one paragraph: the fact, tool, or event worth keeping), whyItMatters (1–2 sentences: why it is worth keeping), links }
 
 # Preferences reconciliation
 
@@ -249,8 +287,10 @@ export async function runDistill() {
             // Classification gate: only classify kinds that are valid NoteTypes.
             // project_fact and preference are not in NoteType and are always passed through.
             const classifiableKinds = new Set(["decision", "lesson", "capture", "project", "daily", "person"]);
+            let writeBody = r.body;
+            let writeRelPath = r.relPath;
+            let writeFrontmatter = r.frontmatter;
             if (classifiableKinds.has(it.kind)) {
-                let skipWrite = false;
                 try {
                     // Merge item.project into frontmatter for classify: some router cases
                     // (lesson, person) omit project even when the distiller provided one.
@@ -262,30 +302,44 @@ export async function runDistill() {
                     if (!cr.accepted) {
                         recordRejection(vaultPath(), {
                             type: it.kind,
-                            reason: cr.reason ?? "rejected by classifier",
+                            reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
                             sessionId: sid,
                             title: it.title,
                             excerpt: candidateDoc.slice(0, 500),
                         });
-                        skipWrite = true;
+                        // Coerce-don't-drop: re-route to the (possibly suggested) kind so the
+                        // frontmatter, path, and body agree, then coerce the body to pass.
+                        const targetKind = cr.suggestedType ?? it.kind;
+                        if (targetKind === "capture") {
+                            const reItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
+                            const r2 = route(reItem);
+                            writeFrontmatter = r2.frontmatter;
+                            writeRelPath = r2.relPath;
+                            writeBody = coerceCapture(reItem, r.body);
+                        }
+                        else if (targetKind === "lesson") {
+                            const reItem = { ...it, kind: "lesson" };
+                            const r2 = route(reItem);
+                            writeFrontmatter = r2.frontmatter;
+                            writeRelPath = r2.relPath;
+                            writeBody = coerceLesson(reItem, r.body);
+                        }
                     }
                 }
                 catch (e) {
                     // Classifier or recordRejection threw — fail open: log and continue with the write.
                     writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
                 }
-                if (skipWrite)
-                    continue;
             }
-            const res = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
+            const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
             if (res.ok) {
                 try {
-                    await indexNote(r.relPath);
+                    await indexNote(writeRelPath);
                 }
                 catch (e) {
                     writeFailure(`index failed: ${e?.message || e}`);
                 }
-                (routedByDate[it.date] ||= []).push(r.relPath);
+                (routedByDate[it.date] ||= []).push(writeRelPath);
             }
         }
         // Daily journal: record this session's contribution + regenerate the note(s).

--- a/dist/src/frontmatter.js
+++ b/dist/src/frontmatter.js
@@ -1,8 +1,6 @@
 import matter from "gray-matter";
 const VALID_TYPES = ["project", "person", "decision", "capture", "daily", "map", "summary", "lesson", "preference"];
 const VALID_STATUS = ["active", "paused", "done", "archived"];
-// Types whose route always supplies project: — only these are enforced
-const PROJECT_REQUIRED = new Set(["project"]);
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 function normalizeDates(data) {
     const out = {};
@@ -16,15 +14,33 @@ function normalizeDates(data) {
     }
     return out;
 }
+function toScalarString(v) {
+    if (typeof v === "string")
+        return v;
+    if (Array.isArray(v)) {
+        const flat = v.flat(Infinity);
+        const first = flat.find((x) => typeof x === "string");
+        return typeof first === "string" ? first : null;
+    }
+    if (v instanceof Date)
+        return v.toISOString().slice(0, 10);
+    return null;
+}
 export function parseNote(raw) {
     const g = matter(raw);
-    return { data: normalizeDates(g.data || {}), content: g.content || "" };
+    const data = normalizeDates(g.data || {});
+    if ("project" in data && typeof data.project !== "string") {
+        const coerced = toScalarString(data.project);
+        if (coerced !== null) {
+            data.project = coerced;
+        }
+        else {
+            delete data.project;
+        }
+    }
+    return { data, content: g.content || "" };
 }
 export function serializeNote(data, content) {
-    if (!data.type)
-        throw new Error("required: type");
-    if (PROJECT_REQUIRED.has(data.type) && !data.project)
-        throw new Error("required: project");
     let yaml = matter.stringify(content.endsWith("\n") ? content : content + "\n", data);
     // Strip quotes around date-shaped values for known date keys
     yaml = yaml.replace(/^(created|date|last_touched|superseded_at): ['"](\d{4}-\d{2}-\d{2})['"]$/gm, "$1: $2");

--- a/dist/src/router.js
+++ b/dist/src/router.js
@@ -113,12 +113,26 @@ export function route(item) {
                     mode: "append",
                 };
             }
-            return {
-                relPath: `capture/${item.date}-${slug(item.title)}.md`,
-                frontmatter: { type: "capture", status: "active", tags: ["triage"], ...base },
-                body: withLinks(`# ${item.title}\n\n${(item.body || "").trim()}`, item.links),
-                mode: "create",
-            };
+            {
+                const hasStructured = !!((item.what || "").trim() || (item.whyItMatters || "").trim());
+                let captureBody;
+                if (hasStructured) {
+                    captureBody = joinSections([
+                        `# ${item.title}`,
+                        section("What", item.what),
+                        section("Why it matters", item.whyItMatters),
+                    ]);
+                }
+                else {
+                    captureBody = `# ${item.title}\n\n${(item.body || "").trim()}`;
+                }
+                return {
+                    relPath: `capture/${item.date}-${slug(item.title)}.md`,
+                    frontmatter: { type: "capture", status: "active", tags: ["triage"], ...base },
+                    body: withLinks(captureBody, item.links),
+                    mode: "create",
+                };
+            }
         }
     }
 }

--- a/dist/src/searchIndex.js
+++ b/dist/src/searchIndex.js
@@ -5,6 +5,18 @@ import * as sqliteVec from "sqlite-vec";
 import { dataDir } from "./paths.js";
 import { EMBED_DIM } from "./embed.js";
 import { ensureEdgesTable } from "./edges.js";
+function toScalarString(v) {
+    if (typeof v === "string")
+        return v;
+    if (Array.isArray(v)) {
+        const flat = v.flat(Infinity);
+        const first = flat.find((x) => typeof x === "string");
+        return typeof first === "string" ? first : null;
+    }
+    if (v instanceof Date)
+        return v.toISOString().slice(0, 10);
+    return null;
+}
 export function rrf(lists, k, c = 60) {
     return rrfWithScores(lists, k, c).map((e) => e.id);
 }
@@ -58,7 +70,7 @@ export function openIndex() {
             insFts.run(id, (c.headingPath ? c.headingPath + " " : "") + c.text);
             insVec.run(BigInt(id), JSON.stringify(Array.from(embs[i])));
         });
-        insNote.run(relPath, mtime, hash, project ?? null, created ?? null);
+        insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null));
     });
     const hydrate = (ids) => ids.map((id) => {
         const r = db.prepare("SELECT rel_path,heading_path,anchor,text FROM chunks WHERE id=?").get(id);

--- a/scripts/cleanup-daily-mirrors.ts
+++ b/scripts/cleanup-daily-mirrors.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env -S node --experimental-strip-types
+// scripts/cleanup-daily-mirrors.ts
+//
+// Non-destructive migration: remove legacy "daily-mirror" capture notes left
+// by the now-removed daily-rollup synthesizer, and strip dangling links to them.
+//
+// Mirror notes match the pattern: capture/<YYYY-MM-DD>-daily-<YYYY-MM-DD>.md
+//
+// Usage:
+//   npx tsx scripts/cleanup-daily-mirrors.ts <vault-dir>          # dry-run
+//   npx tsx scripts/cleanup-daily-mirrors.ts <vault-dir> --apply  # write
+
+import fs from "node:fs";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MirrorEntry {
+  file: string;
+  relPath: string;
+  basename: string;
+}
+
+export interface LinkPatch {
+  file: string;
+  relPath: string;
+  newContent: string;
+}
+
+export interface MirrorPlan {
+  mirrors: MirrorEntry[];
+  linkPatches: LinkPatch[];
+}
+
+// ---------------------------------------------------------------------------
+// Mirror detection
+// ---------------------------------------------------------------------------
+
+const MIRROR_BASENAME_RE = /^\d{4}-\d{2}-\d{2}-daily-\d{4}-\d{2}-\d{2}$/;
+const SKIP_DIRS = new Set([".trash", ".obsidian", ".git", "node_modules"]);
+
+export function isMirrorNote(relPath: string): boolean {
+  const parts = relPath.split("/");
+  if (parts.length < 2) return false;
+  if (parts[0] !== "capture") return false;
+  const basename = path.basename(relPath, ".md");
+  return MIRROR_BASENAME_RE.test(basename);
+}
+
+// ---------------------------------------------------------------------------
+// Vault walker
+// ---------------------------------------------------------------------------
+
+function walkVault(vaultDir: string): string[] {
+  const files: string[] = [];
+
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        walk(path.join(dir, entry.name));
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        files.push(path.join(dir, entry.name));
+      }
+    }
+  }
+
+  walk(vaultDir);
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Link removal
+// ---------------------------------------------------------------------------
+
+function buildLinkPattern(mirrorSlugs: string[]): RegExp | null {
+  if (mirrorSlugs.length === 0) return null;
+  const escaped = mirrorSlugs.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const inner = escaped.join("|");
+  return new RegExp(`\\[\\[(${inner})(?:[#|][^\\]]*)?\\]\\]`, "g");
+}
+
+// ---------------------------------------------------------------------------
+// Plan
+// ---------------------------------------------------------------------------
+
+export function planCleanup(vaultDir: string): MirrorPlan {
+  const allFiles = walkVault(vaultDir);
+  const mirrors: MirrorEntry[] = [];
+
+  for (const file of allFiles) {
+    const relPath = path.relative(vaultDir, file).replace(/\\/g, "/");
+    if (isMirrorNote(relPath)) {
+      mirrors.push({ file, relPath, basename: path.basename(relPath, ".md") });
+    }
+  }
+
+  const mirrorSlugs = mirrors.map(m => `capture/${m.basename}`);
+  const linkPattern = buildLinkPattern(mirrorSlugs);
+
+  const linkPatches: LinkPatch[] = [];
+
+  if (linkPattern) {
+    for (const file of allFiles) {
+      const relPath = path.relative(vaultDir, file).replace(/\\/g, "/");
+      if (mirrors.some(m => m.file === file)) continue;
+
+      const content = fs.readFileSync(file, "utf8");
+      if (!linkPattern.test(content)) continue;
+
+      linkPattern.lastIndex = 0;
+      const newContent = content.replace(linkPattern, "");
+      linkPatches.push({ file, relPath, newContent });
+    }
+  }
+
+  return { mirrors, linkPatches };
+}
+
+// ---------------------------------------------------------------------------
+// Apply
+// ---------------------------------------------------------------------------
+
+export function applyCleanup(vaultDir: string, plan: MirrorPlan): void {
+  const trashDir = path.join(vaultDir, ".trash");
+  fs.mkdirSync(trashDir, { recursive: true });
+
+  const timestamp = Date.now();
+
+  for (const mirror of plan.mirrors) {
+    const dest = path.join(trashDir, `${timestamp}-${mirror.basename}.md`);
+    fs.renameSync(mirror.file, dest);
+  }
+
+  for (const patch of plan.linkPatches) {
+    fs.writeFileSync(patch.file, patch.newContent, "utf8");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const vault = args.find(a => !a.startsWith("--")) || process.env["SUPERBRAIN_VAULT_DIR"];
+
+  if (!vault) {
+    console.error("usage: cleanup-daily-mirrors.ts <vault-dir> [--apply]");
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(vault)) {
+    console.error(`Vault not found: ${vault}`);
+    process.exit(1);
+  }
+
+  const plan = planCleanup(vault);
+
+  if (plan.mirrors.length === 0 && plan.linkPatches.length === 0) {
+    console.log("No daily-mirror notes found. Nothing to do.");
+    return;
+  }
+
+  if (!apply) {
+    console.log(`Dry-run: would soft-delete ${plan.mirrors.length} mirror note(s) and patch ${plan.linkPatches.length} file(s)`);
+    for (const m of plan.mirrors) {
+      console.log(`  trash: ${m.relPath}`);
+    }
+    for (const p of plan.linkPatches) {
+      console.log(`  patch: ${p.relPath}`);
+    }
+    console.log("\n(Dry-run. Use --apply to write changes.)");
+  } else {
+    applyCleanup(vault, plan);
+    console.log(`Soft-deleted ${plan.mirrors.length} mirror note(s), patched ${plan.linkPatches.length} file(s).`);
+  }
+}
+
+if (
+  process.argv[1]?.endsWith("cleanup-daily-mirrors.ts") ||
+  process.argv[1]?.endsWith("cleanup-daily-mirrors.js")
+) {
+  main();
+}

--- a/src/classification.ts
+++ b/src/classification.ts
@@ -15,7 +15,7 @@ export interface ClassificationResult {
 const REROUTE_TO_CAPTURE = new Set(["shipped", "released", "deployed", "merged"]);
 const REROUTE_TO_LESSON = new Set(["learned", "always", "never"]);
 
-const PROJECT_REQUIRED: NoteType[] = ["decision", "lesson", "capture", "person", "project"];
+const PROJECT_REQUIRED: NoteType[] = ["project"];
 
 export function classify(c: Candidate): ClassificationResult {
   // 1. Title-prefix reroute (decisions only)

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -29,6 +29,48 @@ import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
 
+function shortTitle(raw: string, fallbackBody: string): string {
+  const src = (raw || fallbackBody).trim();
+  const words = src.split(/\s+/).filter(Boolean);
+  const taken = words.slice(0, 8).join(" ").replace(/\.+$/, "");
+  return taken || "Captured note";
+}
+
+function countBodyWords(body: string): number {
+  return body
+    .replace(/^---[\s\S]*?\n---\n?/m, "")
+    .replace(/^#+ .*$/gm, "")
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+function trimToWordCeiling(text: string, ceiling: number): string {
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length <= ceiling) return text;
+  return words.slice(0, ceiling).join(" ");
+}
+
+export function coerceCapture(item: DistilledItem, routedBody: string): string {
+  const title = shortTitle(item.title, item.body || "");
+  const rawBody = (item.body || routedBody || "").trim();
+  const words = rawBody.split(/\s+/).filter(Boolean);
+  const maxWhat = 180;
+  const whatContent = words.length > maxWhat
+    ? words.slice(0, maxWhat).join(" ") + " …"
+    : rawBody;
+  const lastSentence = rawBody.split(/[.!?](?:\s|$)/).filter(Boolean).pop()?.trim() || rawBody.slice(0, 100);
+  const whyContent = lastSentence.replace(/\.+$/, "").slice(0, 120);
+  return `# ${title}\n\n## What\n\n${whatContent}\n\n## Why it matters\n\n${whyContent}\n`;
+}
+
+export function coerceLesson(item: DistilledItem, routedBody: string): string {
+  const title = (item.title || "Lesson").trim();
+  const ruleText = (item.rule || "").trim() || trimToWordCeiling((item.body || routedBody || "").trim(), 30);
+  const whyText = (item.why || item.body || routedBody || "").trim() || "See session context.";
+  const whenText = (item.whenApplies || "").trim() || "In relevant future situations.";
+  return `# ${title}\n\n## Rule\n\n${ruleText}\n\n## Why\n\n${whyText}\n\n## When this applies\n\n${whenText}\n`;
+}
+
 export interface DistilledEnvelope {
   items: DistilledItem[];
   digest?: string;
@@ -93,7 +135,7 @@ person: { kind, title (short), date, person (slug — required), body (role/cont
 
 preference: { kind, title: "Preferences", date, body (the FULL reconciled user-preferences doc — plain markdown, organized by '## Category' headings such as Code style / Architecture / Tools / Communication, NEVER containing SuperBrain distiller behavior) }
 
-capture: { kind, title, date, body, links }
+capture: { kind, title (≤8 words, no trailing period — scannable noun phrase, not a sentence), date, what (one paragraph: the fact, tool, or event worth keeping), whyItMatters (1–2 sentences: why it is worth keeping), links }
 
 # Preferences reconciliation
 
@@ -247,8 +289,9 @@ export async function runDistill(): Promise<void> {
       // Classification gate: only classify kinds that are valid NoteTypes.
       // project_fact and preference are not in NoteType and are always passed through.
       const classifiableKinds = new Set<string>(["decision", "lesson", "capture", "project", "daily", "person"]);
+      let writeBody = r.body;
+      let writeRelPath = r.relPath;
       if (classifiableKinds.has(it.kind)) {
-        let skipWrite = false;
         try {
           // Merge item.project into frontmatter for classify: some router cases
           // (lesson, person) omit project even when the distiller provided one.
@@ -258,25 +301,36 @@ export async function runDistill(): Promise<void> {
           const candidateDoc = serializeNote(classifyFm, r.body);
           const cr = classify({ proposedType: it.kind as NoteType, title: it.title, body: candidateDoc });
           if (!cr.accepted) {
+            // Diagnostic: record the rejection reason so operators can see what was coerced.
             recordRejection(vaultPath(), {
               type: it.kind,
-              reason: cr.reason ?? "rejected by classifier",
+              reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
               sessionId: sid,
               title: it.title,
               excerpt: candidateDoc.slice(0, 500),
             });
-            skipWrite = true;
+            // Coerce-don't-drop: a second brain must never silently lose durable knowledge.
+            const targetKind = cr.suggestedType ?? (it.kind as NoteType);
+            if (targetKind === "capture" || it.kind === "capture") {
+              const coerced = coerceCapture(it, r.body);
+              const coercedTitle = shortTitle(it.title, it.body || "");
+              writeRelPath = `capture/${it.date}-${(coercedTitle).toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "untitled"}.md`;
+              writeBody = coerced;
+            } else if (targetKind === "lesson" || it.kind === "lesson") {
+              writeBody = coerceLesson(it, r.body);
+            }
+            // For other rejected kinds without a suggested reroute, fall through with
+            // the original body — the rejection was logged and the note is written as-is.
           }
         } catch (e: any) {
           // Classifier or recordRejection threw — fail open: log and continue with the write.
           writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
         }
-        if (skipWrite) continue;
       }
-      const res = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
+      const res = writeNote(writeRelPath, { frontmatter: r.frontmatter, body: writeBody, mode: r.mode });
       if (res.ok) {
-        try { await indexNote(r.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
-        (routedByDate[it.date] ||= []).push(r.relPath);
+        try { await indexNote(writeRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
+        (routedByDate[it.date] ||= []).push(writeRelPath);
       }
     }
     // Daily journal: record this session's contribution + regenerate the note(s).

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -291,6 +291,7 @@ export async function runDistill(): Promise<void> {
       const classifiableKinds = new Set<string>(["decision", "lesson", "capture", "project", "daily", "person"]);
       let writeBody = r.body;
       let writeRelPath = r.relPath;
+      let writeFrontmatter = r.frontmatter;
       if (classifiableKinds.has(it.kind)) {
         try {
           // Merge item.project into frontmatter for classify: some router cases
@@ -301,7 +302,6 @@ export async function runDistill(): Promise<void> {
           const candidateDoc = serializeNote(classifyFm, r.body);
           const cr = classify({ proposedType: it.kind as NoteType, title: it.title, body: candidateDoc });
           if (!cr.accepted) {
-            // Diagnostic: record the rejection reason so operators can see what was coerced.
             recordRejection(vaultPath(), {
               type: it.kind,
               reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
@@ -309,25 +309,29 @@ export async function runDistill(): Promise<void> {
               title: it.title,
               excerpt: candidateDoc.slice(0, 500),
             });
-            // Coerce-don't-drop: a second brain must never silently lose durable knowledge.
+            // Coerce-don't-drop: re-route to the (possibly suggested) kind so the
+            // frontmatter, path, and body agree, then coerce the body to pass.
             const targetKind = cr.suggestedType ?? (it.kind as NoteType);
-            if (targetKind === "capture" || it.kind === "capture") {
-              const coerced = coerceCapture(it, r.body);
-              const coercedTitle = shortTitle(it.title, it.body || "");
-              writeRelPath = `capture/${it.date}-${(coercedTitle).toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "untitled"}.md`;
-              writeBody = coerced;
-            } else if (targetKind === "lesson" || it.kind === "lesson") {
-              writeBody = coerceLesson(it, r.body);
+            if (targetKind === "capture") {
+              const reItem: DistilledItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
+              const r2 = route(reItem);
+              writeFrontmatter = r2.frontmatter;
+              writeRelPath = r2.relPath;
+              writeBody = coerceCapture(reItem, r.body);
+            } else if (targetKind === "lesson") {
+              const reItem: DistilledItem = { ...it, kind: "lesson" };
+              const r2 = route(reItem);
+              writeFrontmatter = r2.frontmatter;
+              writeRelPath = r2.relPath;
+              writeBody = coerceLesson(reItem, r.body);
             }
-            // For other rejected kinds without a suggested reroute, fall through with
-            // the original body — the rejection was logged and the note is written as-is.
           }
         } catch (e: any) {
           // Classifier or recordRejection threw — fail open: log and continue with the write.
           writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
         }
       }
-      const res = writeNote(writeRelPath, { frontmatter: r.frontmatter, body: writeBody, mode: r.mode });
+      const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
       if (res.ok) {
         try { await indexNote(writeRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
         (routedByDate[it.date] ||= []).push(writeRelPath);

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -2,8 +2,6 @@ import matter from "gray-matter";
 
 const VALID_TYPES = ["project", "person", "decision", "capture", "daily", "map", "summary", "lesson", "preference"];
 const VALID_STATUS = ["active", "paused", "done", "archived"];
-// Types whose route always supplies project: — only these are enforced
-const PROJECT_REQUIRED = new Set(["project"]);
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function normalizeDates(data: Record<string, any>): Record<string, any> {

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -18,13 +18,31 @@ function normalizeDates(data: Record<string, any>): Record<string, any> {
   return out;
 }
 
+function toScalarString(v: unknown): string | null {
+  if (typeof v === "string") return v;
+  if (Array.isArray(v)) {
+    const flat = v.flat(Infinity);
+    const first = flat.find((x) => typeof x === "string");
+    return typeof first === "string" ? first : null;
+  }
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  return null;
+}
+
 export function parseNote(raw: string): { data: Record<string, any>; content: string } {
   const g = matter(raw);
-  return { data: normalizeDates(g.data || {}), content: g.content || "" };
+  const data = normalizeDates(g.data || {});
+  if ("project" in data && typeof data.project !== "string") {
+    const coerced = toScalarString(data.project);
+    if (coerced !== null) {
+      data.project = coerced;
+    } else {
+      delete data.project;
+    }
+  }
+  return { data, content: g.content || "" };
 }
 export function serializeNote(data: Record<string, any>, content: string): string {
-  if (!data.type) throw new Error("required: type");
-  if (PROJECT_REQUIRED.has(data.type) && !data.project) throw new Error("required: project");
   let yaml = matter.stringify(content.endsWith("\n") ? content : content + "\n", data);
   // Strip quotes around date-shaped values for known date keys
   yaml = yaml.replace(

--- a/src/router.ts
+++ b/src/router.ts
@@ -28,6 +28,11 @@ export interface DistilledItem {
   prevention?: string;     // gotcha — how to avoid hitting it again
   whenApplies?: string;    // lesson — when to invoke the rule
 
+  // Structured capture sections (preferred). When present, router renders
+  // ## What / ## Why it matters directly. Falls back to freeform `body`.
+  what?: string;          // capture — the observed fact or item
+  whyItMatters?: string;  // capture — why it is worth keeping
+
   // Freeform fallback. Used for captures and as a back-compat slot when the
   // model returns the old single-blob shape.
   body?: string;
@@ -156,12 +161,25 @@ export function route(item: DistilledItem): RouteResult {
           mode: "append",
         };
       }
-      return {
-        relPath: `capture/${item.date}-${slug(item.title)}.md`,
-        frontmatter: { type: "capture", status: "active", tags: ["triage"], ...base },
-        body: withLinks(`# ${item.title}\n\n${(item.body || "").trim()}`, item.links),
-        mode: "create",
-      };
+      {
+        const hasStructured = !!((item.what || "").trim() || (item.whyItMatters || "").trim());
+        let captureBody: string;
+        if (hasStructured) {
+          captureBody = joinSections([
+            `# ${item.title}`,
+            section("What", item.what),
+            section("Why it matters", item.whyItMatters),
+          ]);
+        } else {
+          captureBody = `# ${item.title}\n\n${(item.body || "").trim()}`;
+        }
+        return {
+          relPath: `capture/${item.date}-${slug(item.title)}.md`,
+          frontmatter: { type: "capture", status: "active", tags: ["triage"], ...base },
+          body: withLinks(captureBody, item.links),
+          mode: "create",
+        };
+      }
     }
   }
 }

--- a/src/searchIndex.ts
+++ b/src/searchIndex.ts
@@ -8,13 +8,24 @@ import { ensureEdgesTable } from "./edges.js";
 
 export interface Hit { relPath: string; headingPath: string; anchor: string; text: string; }
 
+function toScalarString(v: unknown): string | null {
+  if (typeof v === "string") return v;
+  if (Array.isArray(v)) {
+    const flat = (v as unknown[]).flat(Infinity);
+    const first = flat.find((x) => typeof x === "string");
+    return typeof first === "string" ? first : null;
+  }
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  return null;
+}
+
 export interface Index {
   db: Database.Database;
   upsertNote(relPath: string, mtime: number, hash: string,
              chunks: { headingPath: string; anchor: string; text: string }[],
              embeddings: Float32Array[],
-             project?: string,
-             created?: string): void;
+             project?: unknown,
+             created?: unknown): void;
   deleteNote(relPath: string): void;
   bm25(query: string, k: number): Hit[];
   vectorKNN(v: Float32Array, k: number): Hit[];
@@ -78,14 +89,14 @@ export function openIndex(): Index {
 
   const upsert = db.transaction((relPath: string, mtime: number, hash: string,
       chunks: { headingPath: string; anchor: string; text: string }[], embs: Float32Array[],
-      project?: string, created?: string) => {
+      project?: unknown, created?: unknown) => {
     delByPath(relPath);
     chunks.forEach((c, i) => {
       const id = Number(insChunk.run(relPath, c.headingPath, c.anchor, c.text).lastInsertRowid);
       insFts.run(id, (c.headingPath ? c.headingPath + " " : "") + c.text);
       insVec.run(BigInt(id), JSON.stringify(Array.from(embs[i])));
     });
-    insNote.run(relPath, mtime, hash, project ?? null, created ?? null);
+    insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null));
   });
 
   const hydrate = (ids: number[]): Hit[] => ids.map((id) => {
@@ -95,7 +106,7 @@ export function openIndex(): Index {
 
   return {
     db,
-    upsertNote: (rp, mt, h, c, e, project, created) => upsert(rp, mt, h, c, e, project, created),
+    upsertNote: (rp: string, mt: number, h: string, c: { headingPath: string; anchor: string; text: string }[], e: Float32Array[], project?: unknown, created?: unknown) => upsert(rp, mt, h, c, e, project, created),
     deleteNote: (rp) => delByPath(rp),
     bm25: (q, k) => {
       const terms = q.replace(/[^\w\s]/g, " ").trim().split(/\s+/).filter(Boolean);

--- a/tests/classification.test.ts
+++ b/tests/classification.test.ts
@@ -100,11 +100,10 @@ describe("classification", () => {
     expect(r.reason).toMatch(/word count/);
   });
 
-  it("rejects when frontmatter is missing project for non-daily types", () => {
+  it("accepts a decision without project frontmatter (project-less decisions are valid)", () => {
     const body = validDecisionBody.replace(/project: superbrain\n/, "");
     const r = classify({ proposedType: "decision", title: "x", body });
-    expect(r.accepted).toBe(false);
-    expect(r.reason).toMatch(/required: project/);
+    expect(r.accepted).toBe(true);
   });
 
   it("does not require project for type daily", () => {
@@ -140,11 +139,10 @@ superbrain: true
     expect(r.accepted).toBe(true);
   });
 
-  it("rejects a lesson missing project frontmatter", () => {
+  it("accepts a lesson without project frontmatter (cross-project by design)", () => {
     const body = validLessonBody.replace(/project: superbrain\n/, "");
     const r = classify({ proposedType: "lesson", title: "Some lesson", body });
-    expect(r.accepted).toBe(false);
-    expect(r.reason).toMatch(/required: project/);
+    expect(r.accepted).toBe(true);
   });
 
   it("accepts a valid capture", () => {
@@ -170,5 +168,48 @@ superbrain: true
     const r = classify({ proposedType: "decision", title: "Released v0.5 to marketplace", body: validDecisionBody });
     expect(r.accepted).toBe(false);
     expect(r.suggestedType).toBe("capture");
+  });
+
+  it("accepts a lesson with no project frontmatter field (cross-project by design)", () => {
+    const body = `---
+type: lesson
+created: 2026-05-22
+status: active
+superbrain: true
+---
+
+# Always check the live data dir before diagnosing
+
+## Rule
+Resolve the actual data path before inspecting on-disk state.
+
+## Why
+On 2026-05-20 a full misdiagnosis was produced because the source fallback was inspected instead of the live path.
+
+## When this applies
+Any time a plugin appears to not be writing data.
+`;
+    const r = classify({ proposedType: "lesson", title: "Always check the live data dir before diagnosing", body });
+    expect(r.accepted).toBe(true);
+  });
+
+  it("accepts a capture with no project frontmatter field", () => {
+    const body = `---
+type: capture
+created: 2026-05-22
+status: active
+superbrain: true
+---
+
+# Hybrid BM25 vector approach
+
+## What
+A hybrid retrieval system combining BM25 and vector search.
+
+## Why it matters
+Better recall than either alone.
+`;
+    const r = classify({ proposedType: "capture", title: "Hybrid BM25 vector approach", body });
+    expect(r.accepted).toBe(true);
   });
 });

--- a/tests/cleanupDailyMirrors.test.ts
+++ b/tests/cleanupDailyMirrors.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  isMirrorNote,
+  planCleanup,
+  applyCleanup,
+  type MirrorPlan,
+} from "../scripts/cleanup-daily-mirrors.js";
+
+// ---------------------------------------------------------------------------
+// isMirrorNote
+// ---------------------------------------------------------------------------
+
+describe("isMirrorNote", () => {
+  it("matches a mirror note in capture/", () => {
+    expect(isMirrorNote("capture/2026-05-18-daily-2026-05-18.md")).toBe(true);
+  });
+
+  it("matches another mirror note with different dates", () => {
+    expect(isMirrorNote("capture/2026-05-20-daily-2026-05-20.md")).toBe(true);
+  });
+
+  it("does NOT match a real daily note", () => {
+    expect(isMirrorNote("daily/2026-05-18.md")).toBe(false);
+  });
+
+  it("does NOT match a regular capture note", () => {
+    expect(isMirrorNote("capture/some-idea.md")).toBe(false);
+  });
+
+  it("does NOT match a capture note that looks similar but lacks -daily- segment", () => {
+    expect(isMirrorNote("capture/2026-05-18-standup.md")).toBe(false);
+  });
+
+  it("does NOT match if dates differ in the mirror pattern", () => {
+    expect(isMirrorNote("capture/2026-05-18-daily-2026-05-19.md")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// planCleanup + applyCleanup (fixture vault)
+// ---------------------------------------------------------------------------
+
+describe("planCleanup", () => {
+  let tmpDir: string;
+
+  function writeNote(relPath: string, content: string) {
+    const full = path.join(tmpDir, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content, "utf8");
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-mirror-test-"));
+    for (const dir of ["capture", "daily"]) {
+      fs.mkdirSync(path.join(tmpDir, dir), { recursive: true });
+    }
+    writeNote("capture/2026-05-18-daily-2026-05-18.md", "# Mirror A\n\nbody\n");
+    writeNote("capture/2026-05-20-daily-2026-05-20.md", "# Mirror B\n\nbody\n");
+    writeNote("daily/2026-05-18.md", "# Real daily\n\nbody\n");
+    writeNote(
+      "capture/related.md",
+      "## Related\n\n[[capture/2026-05-18-daily-2026-05-18]]\n\nSome other content.\n",
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("identifies exactly the two mirror notes", () => {
+    const plan = planCleanup(tmpDir);
+    const slugs = plan.mirrors.map(m => m.relPath).sort();
+    expect(slugs).toEqual([
+      "capture/2026-05-18-daily-2026-05-18.md",
+      "capture/2026-05-20-daily-2026-05-20.md",
+    ]);
+  });
+
+  it("does not flag the real daily note as a mirror", () => {
+    const plan = planCleanup(tmpDir);
+    const relPaths = plan.mirrors.map(m => m.relPath);
+    expect(relPaths).not.toContain("daily/2026-05-18.md");
+  });
+
+  it("detects the dangling link in related.md", () => {
+    const plan = planCleanup(tmpDir);
+    expect(plan.linkPatches.length).toBeGreaterThanOrEqual(1);
+    const patch = plan.linkPatches.find(p => p.relPath === "capture/related.md");
+    expect(patch).toBeDefined();
+    expect(patch!.newContent).not.toContain("[[capture/2026-05-18-daily-2026-05-18]]");
+  });
+});
+
+describe("applyCleanup", () => {
+  let tmpDir: string;
+
+  function writeNote(relPath: string, content: string) {
+    const full = path.join(tmpDir, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content, "utf8");
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-mirror-apply-"));
+    for (const dir of ["capture", "daily"]) {
+      fs.mkdirSync(path.join(tmpDir, dir), { recursive: true });
+    }
+    writeNote("capture/2026-05-18-daily-2026-05-18.md", "# Mirror A\n\nbody\n");
+    writeNote("capture/2026-05-20-daily-2026-05-20.md", "# Mirror B\n\nbody\n");
+    writeNote("daily/2026-05-18.md", "# Real daily\n\nbody\n");
+    writeNote(
+      "capture/related.md",
+      "## Related\n\n[[capture/2026-05-18-daily-2026-05-18]]\n\nSome other content.\n",
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("moves mirror notes to .trash after apply", () => {
+    const plan = planCleanup(tmpDir);
+    applyCleanup(tmpDir, plan);
+
+    expect(fs.existsSync(path.join(tmpDir, "capture/2026-05-18-daily-2026-05-18.md"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "capture/2026-05-20-daily-2026-05-20.md"))).toBe(false);
+
+    const trashEntries = fs.readdirSync(path.join(tmpDir, ".trash"));
+    const trashNames = trashEntries.join(" ");
+    expect(trashNames).toContain("2026-05-18-daily-2026-05-18.md");
+    expect(trashNames).toContain("2026-05-20-daily-2026-05-20.md");
+  });
+
+  it("leaves the real daily note untouched after apply", () => {
+    const plan = planCleanup(tmpDir);
+    applyCleanup(tmpDir, plan);
+
+    expect(fs.existsSync(path.join(tmpDir, "daily/2026-05-18.md"))).toBe(true);
+    const content = fs.readFileSync(path.join(tmpDir, "daily/2026-05-18.md"), "utf8");
+    expect(content).toContain("# Real daily");
+  });
+
+  it("removes dangling wikilink from related.md after apply", () => {
+    const plan = planCleanup(tmpDir);
+    applyCleanup(tmpDir, plan);
+
+    const content = fs.readFileSync(path.join(tmpDir, "capture/related.md"), "utf8");
+    expect(content).not.toContain("[[capture/2026-05-18-daily-2026-05-18]]");
+    expect(content).toContain("Some other content.");
+  });
+
+  it("removes wikilinks with aliases and anchors", () => {
+    writeNote(
+      "capture/extra.md",
+      "See [[capture/2026-05-18-daily-2026-05-18|May 18]] and [[capture/2026-05-20-daily-2026-05-20#section|May 20]] here.\n",
+    );
+    const plan = planCleanup(tmpDir);
+    applyCleanup(tmpDir, plan);
+
+    const content = fs.readFileSync(path.join(tmpDir, "capture/extra.md"), "utf8");
+    expect(content).not.toContain("[[capture/2026-05-18-daily-2026-05-18");
+    expect(content).not.toContain("[[capture/2026-05-20-daily-2026-05-20");
+  });
+});

--- a/tests/distill.test.ts
+++ b/tests/distill.test.ts
@@ -43,15 +43,15 @@ it("distills delta into routed notes, daily .log file, advances cursor, releases
   expect(fs.existsSync(path.join(TMP_DATA, "locks/distill.lock"))).toBe(false);
 });
 
-it("classifier-rejected item lands in rejects file and is not written to vault", () => {
+it("classifier-rerouted item is coerced and written to the suggested kind; rejects file has diagnostic entry", () => {
   fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
   fs.writeFileSync(
     path.join(TMP_DATA, "sessions/R.ndjson"),
     JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n",
   );
   const stub = path.join(TMP_DATA, "stub.json");
-  // "Shipped phase 1" starts with "Shipped" — classify() rejects decisions
-  // whose title prefix belongs in capture, without touching the write path.
+  // "Shipped phase 1" starts with "Shipped" — classify() reroutes decisions
+  // with this prefix to capture. The item must be coerced and written to capture/.
   fs.writeFileSync(stub, JSON.stringify([
     { kind: "decision", title: "Shipped phase 1", body: "we shipped it", date: "2026-05-22", links: [] },
   ]));
@@ -70,13 +70,16 @@ it("classifier-rejected item lands in rejects file and is not written to vault",
     encoding: "utf8",
   });
 
-  // 1. The note must NOT have been written to the vault.
-  expect(fs.existsSync(path.join(TMP_VAULT, "decisions"))).toBe(false);
+  // 1. The note must have been coerced into capture/ (never silently dropped).
+  const captureDir = path.join(TMP_VAULT, "capture");
+  expect(fs.existsSync(captureDir)).toBe(true);
+  const captureFiles = fs.readdirSync(captureDir).filter((f) => f.endsWith(".md"));
+  expect(captureFiles.length).toBeGreaterThan(0);
 
-  // 2. The reject file must exist and contain the classifier reason.
+  // 2. The reject file must exist and contain a diagnostic coercion entry.
   const rejectsFile = path.join(TMP_VAULT, "meta", "distill-rejects.md");
   expect(fs.existsSync(rejectsFile)).toBe(true);
-  expect(fs.readFileSync(rejectsFile, "utf8")).toMatch(/shipped/i);
+  expect(fs.readFileSync(rejectsFile, "utf8")).toMatch(/coerced/i);
 
   // 3. The cursor must have advanced (run did not abort).
   expect(Number(fs.readFileSync(path.join(TMP_DATA, "sessions/R.cursor"), "utf8"))).toBeGreaterThan(0);

--- a/tests/distill.test.ts
+++ b/tests/distill.test.ts
@@ -76,6 +76,12 @@ it("classifier-rerouted item is coerced and written to the suggested kind; rejec
   const captureFiles = fs.readdirSync(captureDir).filter((f) => f.endsWith(".md"));
   expect(captureFiles.length).toBeGreaterThan(0);
 
+  // The rerouted note must carry capture frontmatter, not the original decision type.
+  const captureContent = fs.readFileSync(path.join(captureDir, captureFiles[0]), "utf8");
+  expect(captureContent).toMatch(/^type: capture$/m);
+  expect(captureContent).not.toMatch(/^type: decision$/m);
+  expect(fs.existsSync(path.join(TMP_VAULT, "decisions"))).toBe(false);
+
   // 2. The reject file must exist and contain a diagnostic coercion entry.
   const rejectsFile = path.join(TMP_VAULT, "meta", "distill-rejects.md");
   expect(fs.existsSync(rejectsFile)).toBe(true);

--- a/tests/distillCoerce.test.ts
+++ b/tests/distillCoerce.test.ts
@@ -1,0 +1,110 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-coerce-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-coerce-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+it("a freeform capture that fails the strict rubric is coerced and written, not only rejected", () => {
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(
+    path.join(TMP_DATA, "sessions/C.ndjson"),
+    JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n",
+  );
+
+  const stub = path.join(TMP_DATA, "stub.json");
+  // Freeform capture: no ## What / ## Why it matters sections, title > 8 words.
+  // This violates two rubric rules and must be coerced, not dropped.
+  fs.writeFileSync(stub, JSON.stringify([
+    {
+      kind: "capture",
+      title: "This is a very long capture title that exceeds the eight word limit badly.",
+      date: "2026-05-22",
+      body: "We observed that the new BM25 hybrid retrieval significantly outperformed the old approach in all our benchmarks. The improvement was especially pronounced for multi-word queries. This is worth keeping as a reference point for future architecture decisions.",
+      links: [],
+    },
+  ]));
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/C.prompt.json"), "{}");
+
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+      SUPERBRAIN_DISTILL_STUB: stub,
+      SUPERBRAIN_SESSION_ID: "C",
+      SUPERBRAIN_EMBED_STUB: "1",
+    },
+    encoding: "utf8",
+  });
+
+  // The coerced note must be written somewhere under capture/.
+  const captureDir = path.join(TMP_VAULT, "capture");
+  expect(fs.existsSync(captureDir)).toBe(true);
+  const files = fs.readdirSync(captureDir).filter((f) => f.endsWith(".md"));
+  expect(files.length).toBeGreaterThan(0);
+
+  // The coerced note must contain ## What and ## Why it matters sections.
+  const noteContent = fs.readFileSync(path.join(captureDir, files[0]), "utf8");
+  expect(noteContent).toMatch(/## What/);
+  expect(noteContent).toMatch(/## Why it matters/);
+
+  // The cursor must have advanced (run did not abort).
+  expect(Number(fs.readFileSync(path.join(TMP_DATA, "sessions/C.cursor"), "utf8"))).toBeGreaterThan(0);
+});
+
+it("a lesson with no project field is written to vault (cross-project by design)", () => {
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(
+    path.join(TMP_DATA, "sessions/L.ndjson"),
+    JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n",
+  );
+
+  const stub = path.join(TMP_DATA, "stub.json");
+  // Lesson without a project field — cross-project lessons are valid.
+  fs.writeFileSync(stub, JSON.stringify([
+    {
+      kind: "lesson",
+      title: "Verify live data dir before diagnosing",
+      date: "2026-05-22",
+      rule: "Resolve the actual data path before inspecting on-disk state.",
+      why: "On 2026-05-20 a full misdiagnosis was produced because the source fallback was inspected instead of the live path.",
+      whenApplies: "Any time a plugin appears to not be writing data.",
+      links: [],
+    },
+  ]));
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/L.prompt.json"), "{}");
+
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+      SUPERBRAIN_DISTILL_STUB: stub,
+      SUPERBRAIN_SESSION_ID: "L",
+      SUPERBRAIN_EMBED_STUB: "1",
+    },
+    encoding: "utf8",
+  });
+
+  const lessonsDir = path.join(TMP_VAULT, "lessons");
+  expect(fs.existsSync(lessonsDir)).toBe(true);
+  const files = fs.readdirSync(lessonsDir).filter((f) => f.endsWith(".md"));
+  expect(files.length).toBeGreaterThan(0);
+
+  expect(Number(fs.readFileSync(path.join(TMP_DATA, "sessions/L.cursor"), "utf8"))).toBeGreaterThan(0);
+});

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -28,16 +28,29 @@ describe("frontmatter", () => {
     expect(out).not.toMatch(/created: "2026-05-22"/);
   });
 
-  it("throws when writing without type", () => {
-    expect(() => serializeNote({ created: "2026-05-22", project: "superbrain" }, "body")).toThrow(/required: type/);
+  it("does not throw when writing without type", () => {
+    const out = serializeNote({ created: "2026-05-22", project: "superbrain" }, "body");
+    expect(out).toContain("project: superbrain");
   });
 
-  it("throws when writing type=project without project field", () => {
-    expect(() => serializeNote({ type: "project", created: "2026-05-22", status: "active" }, "body")).toThrow(/required: project/);
-    // Daily exempt (and other types without project: in their template):
+  it("does not throw when writing type=project without project field", () => {
+    expect(() => serializeNote({ type: "project", created: "2026-05-22", status: "active" }, "body")).not.toThrow();
     expect(() => serializeNote({ type: "daily", date: "2026-05-22" }, "body")).not.toThrow();
     expect(() => serializeNote({ type: "decision", created: "2026-05-22", status: "active" }, "body")).not.toThrow();
     expect(() => serializeNote({ type: "preference", created: "2026-05-22" }, "body")).not.toThrow();
+  });
+
+  it("parseNote normalizes wikilink project ([['projects/weddy']]) to string", () => {
+    const raw = "---\ntype: project\nstatus: active\nproject:\n  - - projects/weddy\n---\n\nbody";
+    const { data } = parseNote(raw);
+    expect(data.project).toBe("projects/weddy");
+  });
+
+  it("serializeNote on note missing type does not throw and returns markdown", () => {
+    const out = serializeNote({ status: "active" }, "some body");
+    expect(typeof out).toBe("string");
+    expect(out).toContain("status: active");
+    expect(out).toContain("some body");
   });
 
   it("normalizes a quoted date when reading", () => {

--- a/tests/searchIndex.test.ts
+++ b/tests/searchIndex.test.ts
@@ -63,6 +63,21 @@ describe("searchIndex", () => {
     expect(r[0].text).toBe("alpha");
     ix.close();
   });
+  it("upsertNote with array project does not throw and indexes the note", () => {
+    const ix = openIndex();
+    expect(() =>
+      ix.upsertNote("projects/z.md", 1, "h1",
+        [{ headingPath: "", anchor: "", text: "wikilink project test" }],
+        [vec(0.5)],
+        ["projects/weddy"] as any,
+        "2026-05-28")
+    ).not.toThrow();
+    expect(ix.getNoteMeta("projects/z.md")).not.toBeNull();
+    const bm = ix.bm25("wikilink project test", 5);
+    expect(bm[0].relPath).toBe("projects/z.md");
+    ix.close();
+  });
+
   it("re-upsert/delete purges FTS heading terms (no stale contentless rows)", () => {
     const ix = openIndex();
     ix.upsertNote("p/h.md", 1, "h1",


### PR DESCRIPTION
Part 1 of the v0.7.0 quality work. Three related fixes that stop the distiller from silently discarding durable notes, plus frontmatter hardening and a cleanup migration.

## Stop silent loss of lessons and captures
- `classification.ts`: `PROJECT_REQUIRED` narrowed to `["project"]`. Lessons (cross-project by design), captures, persons, and project-less decisions were being rejected for missing a `project` field the router never sets for them. This is why lesson capture had dropped to zero.
- The distill gate is now coerce-and-keep: a note that fails its rubric is normalized into its template and written, with a diagnostic entry in the reject queue, instead of being discarded. Rerouted notes (e.g. a "Shipped ..." decision rerouted to capture) re-route through `route()` so frontmatter, path, and body all match the target kind.
- Capture gains structured `what` / `whyItMatters` fields so it renders the `## What` / `## Why it matters` template.

## Defensive frontmatter coercion
- A non-scalar `project` (e.g. `project: [[x]]`, which YAML parses as a nested array) no longer crashes indexing. `project` and `created` are coerced to a scalar at the parse layer and at the SQLite bind.
- `serializeNote` no longer throws on a missing `type`; validation stays in `validateFrontmatter` (used by the write path), so batch and migration tools are resilient.

## Daily-mirror cleanup migration
- `scripts/cleanup-daily-mirrors.ts`: non-destructive migration that soft-deletes legacy `<date>-daily-<date>` capture notes left by the removed daily-rollup synthesizer and strips dangling links to them.

## Tests
571 passing; typecheck clean; build clean; `dist` in sync. New tests cover project-less lesson acceptance, capture coercion, rerouted-note frontmatter type, non-scalar project coercion, and the cleanup migration.
