### PR TITLE
v0.7.0 part 2: cwd-authoritative project attribution + project-scoped daily state

### DIFF
--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -25,6 +25,33 @@ import { serializeNote } from "./frontmatter.js";
 import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
+import { classifyPath, basenameSlug } from "./projectDetect.js";
+import { slug } from "./router.js";
+export function resolveSessionProject(events) {
+    const countBySlug = new Map();
+    for (const e of events) {
+        const cwd = e?.cwd;
+        if (!cwd || typeof cwd !== "string")
+            continue;
+        const c = classifyPath(cwd);
+        if (c.kind === "blocked" || c.kind === "skip")
+            continue;
+        const projectSlug = basenameSlug(c.projectDir);
+        countBySlug.set(projectSlug, (countBySlug.get(projectSlug) ?? 0) + 1);
+    }
+    const all = Array.from(countBySlug.keys());
+    if (all.length === 0)
+        return { dominant: undefined, all: [] };
+    let dominant = all[0];
+    let maxCount = countBySlug.get(dominant) ?? 0;
+    for (const [s, count] of countBySlug) {
+        if (count > maxCount) {
+            dominant = s;
+            maxCount = count;
+        }
+    }
+    return { dominant, all };
+}
 function shortTitle(raw, fallbackBody) {
     const src = (raw || fallbackBody).trim();
     const words = src.split(/\s+/).filter(Boolean);
@@ -214,9 +241,17 @@ export async function runDistill() {
             }
         }
         const env = getEnvelope(JSON.stringify(events));
+        const sessionProj = resolveSessionProject(events);
+        const PROJECT_SCOPED_KINDS = new Set(["project_fact", "gotcha", "decision", "capture"]);
         const items = env.items;
         const routedByDate = {};
         for (const it of items) {
+            if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.dominant) {
+                it.project = sessionProj.dominant;
+            }
+            else if (it.project) {
+                it.project = slug(it.project);
+            }
             it.links = resolveLinks(it.links || [], vaultPath());
             const r = route(it);
             // append/replace bodies are fragments — template validation is not applicable.
@@ -352,6 +387,8 @@ export async function runDistill() {
                     routedRelPaths: routedByDate[d] || [],
                     alsoDid: env.alsoDid,
                     openThreads: env.openThreads,
+                    ...(sessionProj.dominant !== undefined ? { project: sessionProj.dominant } : {}),
+                    ...(sessionProj.all.length > 1 ? { projects: sessionProj.all } : {}),
                 });
                 const dn = buildDailyNote(d);
                 writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });

--- a/dist/src/injectRun.js
+++ b/dist/src/injectRun.js
@@ -81,13 +81,14 @@ async function writeOne(item, mode) {
     }
     return routed.relPath;
 }
-async function updateDaily(date, sid, routedRel) {
+async function updateDaily(date, sid, routedRel, project) {
     try {
         upsertDay(date, sid, {
             digestLine: "",
             routedRelPaths: routedRel,
             alsoDid: [],
             openThreads: [],
+            ...(project !== undefined ? { project } : {}),
         });
         const dn = buildDailyNote(date);
         writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });
@@ -193,12 +194,13 @@ export async function runInject(raw, opts = {}) {
     }
     try {
         const mode = detectMode(sane.text, opts);
+        const injectProject = opts.project ? slug(opts.project) : undefined;
         if (mode === "verbatim") {
             const item = buildVerbatimItem(sane.text, opts);
             const rel = await writeOne(item, "verbatim");
             if (!rel)
                 return { ok: false, mode, notes: [], message: "vault write failed" };
-            await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+            await updateDaily(item.date, `inject-${Date.now()}`, [rel], injectProject);
             appendInjectLog("verbatim", 1, sane.text);
             return { ok: true, mode, notes: [rel] };
         }
@@ -222,7 +224,7 @@ export async function runInject(raw, opts = {}) {
             const rel = await writeOne(item, "verbatim");
             if (!rel)
                 return { ok: false, mode: "distill", notes: [], message: "vault write failed" };
-            await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+            await updateDaily(item.date, `inject-${Date.now()}`, [rel], injectProject);
             appendInjectLog("verbatim", 1, sane.text);
             return { ok: true, mode: "distill", notes: [rel], fallback: true };
         }
@@ -233,7 +235,7 @@ export async function runInject(raw, opts = {}) {
             if (rel)
                 written.push(rel);
         }
-        await updateDaily(todayIso(), `inject-${Date.now()}`, written);
+        await updateDaily(todayIso(), `inject-${Date.now()}`, written, injectProject);
         appendInjectLog("distill", written.length, sane.text);
         return { ok: written.length > 0, mode: "distill", notes: written };
     }

--- a/dist/src/router.js
+++ b/dist/src/router.js
@@ -128,7 +128,7 @@ export function route(item) {
                 }
                 return {
                     relPath: `capture/${item.date}-${slug(item.title)}.md`,
-                    frontmatter: { type: "capture", status: "active", tags: ["triage"], ...base },
+                    frontmatter: { type: "capture", status: "active", tags: ["triage"], ...(item.project ? { project: slug(item.project) } : {}), ...base },
                     body: withLinks(captureBody, item.links),
                     mode: "create",
                 };

--- a/src/dailyState.ts
+++ b/src/dailyState.ts
@@ -7,6 +7,8 @@ export interface DaySessionEntry {
   routedRelPaths: string[];
   alsoDid: string[];
   openThreads: string[];
+  project?: string;
+  projects?: string[];
 }
 export type DayState = Record<string, DaySessionEntry>;
 

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -28,6 +28,33 @@ import { serializeNote } from "./frontmatter.js";
 import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
+import { classifyPath, basenameSlug } from "./projectDetect.js";
+import { slug } from "./router.js";
+
+export interface SessionProjectResult {
+  dominant: string | undefined;
+  all: string[];
+}
+
+export function resolveSessionProject(events: any[]): SessionProjectResult {
+  const countBySlug: Map<string, number> = new Map();
+  for (const e of events) {
+    const cwd = e?.cwd;
+    if (!cwd || typeof cwd !== "string") continue;
+    const c = classifyPath(cwd);
+    if (c.kind === "blocked" || c.kind === "skip") continue;
+    const projectSlug = basenameSlug(c.projectDir);
+    countBySlug.set(projectSlug, (countBySlug.get(projectSlug) ?? 0) + 1);
+  }
+  const all = Array.from(countBySlug.keys());
+  if (all.length === 0) return { dominant: undefined, all: [] };
+  let dominant = all[0];
+  let maxCount = countBySlug.get(dominant) ?? 0;
+  for (const [s, count] of countBySlug) {
+    if (count > maxCount) { dominant = s; maxCount = count; }
+  }
+  return { dominant, all };
+}
 
 function shortTitle(raw: string, fallbackBody: string): string {
   const src = (raw || fallbackBody).trim();
@@ -227,9 +254,16 @@ export async function runDistill(): Promise<void> {
       }
     }
     const env = getEnvelope(JSON.stringify(events));
+    const sessionProj = resolveSessionProject(events);
+    const PROJECT_SCOPED_KINDS = new Set<string>(["project_fact", "gotcha", "decision"]);
     const items = env.items;
     const routedByDate: Record<string, string[]> = {};
     for (const it of items) {
+      if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.dominant) {
+        it.project = sessionProj.dominant;
+      } else if (it.project) {
+        it.project = slug(it.project);
+      }
       it.links = resolveLinks(it.links || [], vaultPath());
       const r = route(it);
       // append/replace bodies are fragments — template validation is not applicable.
@@ -347,6 +381,8 @@ export async function runDistill(): Promise<void> {
           routedRelPaths: routedByDate[d] || [],
           alsoDid: env.alsoDid,
           openThreads: env.openThreads,
+          ...(sessionProj.dominant !== undefined ? { project: sessionProj.dominant } : {}),
+          ...(sessionProj.all.length > 1 ? { projects: sessionProj.all } : {}),
         });
         const dn = buildDailyNote(d);
         writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -255,7 +255,7 @@ export async function runDistill(): Promise<void> {
     }
     const env = getEnvelope(JSON.stringify(events));
     const sessionProj = resolveSessionProject(events);
-    const PROJECT_SCOPED_KINDS = new Set<string>(["project_fact", "gotcha", "decision"]);
+    const PROJECT_SCOPED_KINDS = new Set<string>(["project_fact", "gotcha", "decision", "capture"]);
     const items = env.items;
     const routedByDate: Record<string, string[]> = {};
     for (const it of items) {

--- a/src/injectRun.ts
+++ b/src/injectRun.ts
@@ -108,13 +108,14 @@ async function writeOne(
   return routed.relPath;
 }
 
-async function updateDaily(date: string, sid: string, routedRel: string[]): Promise<void> {
+async function updateDaily(date: string, sid: string, routedRel: string[], project?: string): Promise<void> {
   try {
     upsertDay(date, sid, {
       digestLine: "",
       routedRelPaths: routedRel,
       alsoDid: [],
       openThreads: [],
+      ...(project !== undefined ? { project } : {}),
     });
     const dn = buildDailyNote(date);
     writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });
@@ -217,11 +218,12 @@ export async function runInject(raw: string, opts: InjectOpts = {}): Promise<Inj
 
   try {
     const mode = detectMode(sane.text, opts);
+    const injectProject = opts.project ? slug(opts.project) : undefined;
     if (mode === "verbatim") {
       const item = buildVerbatimItem(sane.text, opts);
       const rel = await writeOne(item, "verbatim");
       if (!rel) return { ok: false, mode, notes: [], message: "vault write failed" };
-      await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+      await updateDaily(item.date, `inject-${Date.now()}`, [rel], injectProject);
       appendInjectLog("verbatim", 1, sane.text);
       return { ok: true, mode, notes: [rel] };
     }
@@ -243,7 +245,7 @@ export async function runInject(raw: string, opts: InjectOpts = {}): Promise<Inj
       const item = buildVerbatimItem(sane.text, opts);
       const rel = await writeOne(item, "verbatim");
       if (!rel) return { ok: false, mode: "distill", notes: [], message: "vault write failed" };
-      await updateDaily(item.date, `inject-${Date.now()}`, [rel]);
+      await updateDaily(item.date, `inject-${Date.now()}`, [rel], injectProject);
       appendInjectLog("verbatim", 1, sane.text);
       return { ok: true, mode: "distill", notes: [rel], fallback: true };
     }
@@ -253,7 +255,7 @@ export async function runInject(raw: string, opts: InjectOpts = {}): Promise<Inj
       const rel = await writeOne(item, "distill");
       if (rel) written.push(rel);
     }
-    await updateDaily(todayIso(), `inject-${Date.now()}`, written);
+    await updateDaily(todayIso(), `inject-${Date.now()}`, written, injectProject);
     appendInjectLog("distill", written.length, sane.text);
     return { ok: written.length > 0, mode: "distill", notes: written };
   } finally {

--- a/src/router.ts
+++ b/src/router.ts
@@ -175,7 +175,7 @@ export function route(item: DistilledItem): RouteResult {
         }
         return {
           relPath: `capture/${item.date}-${slug(item.title)}.md`,
-          frontmatter: { type: "capture", status: "active", tags: ["triage"], ...base },
+          frontmatter: { type: "capture", status: "active", tags: ["triage"], ...(item.project ? { project: slug(item.project) } : {}), ...base },
           body: withLinks(captureBody, item.links),
           mode: "create",
         };

--- a/tests/distillCaptureAttribution.test.ts
+++ b/tests/distillCaptureAttribution.test.ts
@@ -1,0 +1,62 @@
+import { it, expect, beforeEach, afterEach, describe } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-capattr-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-capattr-vault-"));
+});
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+describe("capture cwd attribution", () => {
+  it("a capture with no explicit project is attributed to the session's cwd project", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-cap-repo-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "cap-app" }));
+      fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+      fs.writeFileSync(
+        path.join(TMP_DATA, "sessions/SC.ndjson"),
+        [
+          { type: "tool", tool: "Write", file: "a.ts", cwd: repoDir, ts: "t1" },
+          { type: "prompt", prompt: "noted a thing", cwd: repoDir, ts: "t2" },
+        ].map((e) => JSON.stringify(e)).join("\n") + "\n",
+      );
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+      const stubPath = path.join(TMP_DATA, "stub.json");
+      fs.writeFileSync(stubPath, JSON.stringify({
+        items: [
+          { kind: "capture", title: "Observed flaky retry in CI", date: "2026-05-28", what: "CI retried twice before passing.", whyItMatters: "Signals a flaky test.", links: [] },
+        ],
+        digest: "noted CI flakiness", openThreads: [], alsoDid: [],
+      }));
+      fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+      execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+        env: {
+          ...process.env,
+          SUPERBRAIN_DATA_DIR: TMP_DATA,
+          SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+          SUPERBRAIN_DISTILL_STUB: stubPath,
+          SUPERBRAIN_SESSION_ID: "SC",
+          SUPERBRAIN_EMBED_STUB: "1",
+          SUPERBRAIN_TEST_BYPASS_BLOCKLIST: "1",
+        },
+        encoding: "utf8",
+      });
+      const captureDir = path.join(TMP_VAULT, "capture");
+      const files = fs.readdirSync(captureDir).filter((f) => f.endsWith(".md"));
+      expect(files.length).toBeGreaterThan(0);
+      const content = fs.readFileSync(path.join(captureDir, files[0]), "utf8");
+      expect(content).toMatch(new RegExp(`^project: ${expectedSlug}$`, "m"));
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/distillCwdAttribution.test.ts
+++ b/tests/distillCwdAttribution.test.ts
@@ -1,0 +1,227 @@
+import { it, expect, beforeEach, afterEach, describe } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-cwd-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-cwd-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+function makeSessionNdjson(sessionId: string, events: object[]): void {
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  const lines = events.map(e => JSON.stringify(e)).join("\n") + "\n";
+  fs.writeFileSync(path.join(TMP_DATA, `sessions/${sessionId}.ndjson`), lines);
+}
+
+function makeStub(envelope: object): string {
+  const stubPath = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(stubPath, JSON.stringify(envelope));
+  return stubPath;
+}
+
+function runDistill(stubPath: string, sessionId: string, extraEnv: Record<string, string> = {}): void {
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+      SUPERBRAIN_DISTILL_STUB: stubPath,
+      SUPERBRAIN_SESSION_ID: sessionId,
+      SUPERBRAIN_EMBED_STUB: "1",
+      SUPERBRAIN_TEST_BYPASS_BLOCKLIST: "1",
+      ...extraEnv,
+    },
+    encoding: "utf8",
+  });
+}
+
+function readDailyState(date: string): Record<string, any> {
+  const f = path.join(TMP_DATA, "daily", `${date}.json`);
+  if (!fs.existsSync(f)) return {};
+  return JSON.parse(fs.readFileSync(f, "utf8"));
+}
+
+describe("cwd-authoritative project attribution", () => {
+  it("single-repo session: item with no explicit project is attributed to that repo's project slug, daily entry records project", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-a-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+
+      makeSessionNdjson("SA", [
+        { type: "tool", tool: "Write", file: "src/index.ts", cwd: repoDir, ts: "t1" },
+        { type: "tool", tool: "Write", file: "src/main.ts", cwd: repoDir, ts: "t2" },
+        { type: "prompt", prompt: "add feature", cwd: repoDir, ts: "t3" },
+      ]);
+
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      const stubPath = makeStub({
+        items: [
+          {
+            kind: "project_fact",
+            title: "Service uses TypeScript",
+            date: "2026-05-28",
+            body: "The service is written in TypeScript.",
+            links: [],
+          },
+        ],
+        digest: "Set up TypeScript service",
+        openThreads: [],
+        alsoDid: [],
+      });
+
+      runDistill(stubPath, "SA");
+
+      const state = readDailyState("2026-05-28");
+      expect(state).toHaveProperty("SA");
+
+      const entry = state["SA"];
+      expect(entry.project).toBe(expectedSlug);
+
+      const projectFile = path.join(TMP_VAULT, "projects", `${expectedSlug}.md`);
+      expect(fs.existsSync(projectFile)).toBe(true);
+      const content = fs.readFileSync(projectFile, "utf8");
+      expect(content).toContain(expectedSlug);
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("single-repo session: explicit project on item wins over cwd-derived project", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-explicit-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "inferred-app" }));
+
+      makeSessionNdjson("SE", [
+        { type: "tool", tool: "Write", file: "a.ts", cwd: repoDir, ts: "t1" },
+      ]);
+
+      const stubPath = makeStub({
+        items: [
+          {
+            kind: "project_fact",
+            title: "Uses Postgres",
+            date: "2026-05-28",
+            project: "explicit-project",
+            body: "The database is Postgres.",
+            links: [],
+          },
+        ],
+        digest: "DB discussion",
+        openThreads: [],
+        alsoDid: [],
+      });
+
+      runDistill(stubPath, "SE");
+
+      const projectFile = path.join(TMP_VAULT, "projects", "explicit-project.md");
+      expect(fs.existsSync(projectFile)).toBe(true);
+      const content = fs.readFileSync(projectFile, "utf8");
+      expect(content).toContain("explicit-project");
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("non-project cwd (e.g. /tmp): no project is stamped on the daily entry", () => {
+    makeSessionNdjson("SN", [
+      { type: "tool", tool: "Write", file: "x.txt", cwd: os.tmpdir(), ts: "t1" },
+      { type: "prompt", prompt: "help me write", cwd: os.tmpdir(), ts: "t2" },
+    ]);
+
+    const stubPath = makeStub({
+      items: [
+        {
+          kind: "capture",
+          title: "Quick note",
+          date: "2026-05-28",
+          body: "Something captured from a scratch session.",
+          links: [],
+        },
+      ],
+      digest: "scratch session",
+      openThreads: [],
+      alsoDid: [],
+    });
+
+    runDistill(stubPath, "SN");
+
+    const state = readDailyState("2026-05-28");
+    expect(state).toHaveProperty("SN");
+
+    const entry = state["SN"];
+    expect(entry.project).toBeUndefined();
+  });
+
+  it("multi-cwd session: B-scoped items are not tagged as A; explicit per-item project wins", () => {
+    const repoDirA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-aa-"));
+    const repoDirB = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-bb-"));
+    try {
+      fs.writeFileSync(path.join(repoDirA, "package.json"), JSON.stringify({ name: "repo-a" }));
+      fs.writeFileSync(path.join(repoDirB, "package.json"), JSON.stringify({ name: "repo-b" }));
+
+      const slugA = path.basename(repoDirA).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+      const slugB = path.basename(repoDirB).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      makeSessionNdjson("SM", [
+        { type: "tool", tool: "Write", file: "a.ts", cwd: repoDirA, ts: "t1" },
+        { type: "tool", tool: "Write", file: "a2.ts", cwd: repoDirA, ts: "t2" },
+        { type: "tool", tool: "Write", file: "b.ts", cwd: repoDirB, ts: "t3" },
+        { type: "tool", tool: "Write", file: "b2.ts", cwd: repoDirB, ts: "t4" },
+      ]);
+
+      const stubPath = makeStub({
+        items: [
+          {
+            kind: "project_fact",
+            title: "Fact about B (explicit project)",
+            date: "2026-05-28",
+            project: slugB,
+            body: "Fact about repo B.",
+            links: [],
+          },
+          {
+            kind: "project_fact",
+            title: "Fact with no explicit project (dominant cwd)",
+            date: "2026-05-28",
+            body: "Generic fact from this session.",
+            links: [],
+          },
+        ],
+        digest: "worked in two repos",
+        openThreads: [],
+        alsoDid: [],
+      });
+
+      runDistill(stubPath, "SM");
+
+      const projectBFile = path.join(TMP_VAULT, "projects", `${slugB}.md`);
+      expect(fs.existsSync(projectBFile)).toBe(true);
+      const bContent = fs.readFileSync(projectBFile, "utf8");
+      expect(bContent).toContain("Fact about B (explicit project)");
+      expect(bContent).not.toContain("Fact about A only");
+
+      const state = readDailyState("2026-05-28");
+      expect(state).toHaveProperty("SM");
+      const entry = state["SM"];
+      expect(Array.isArray(entry.projects) || typeof entry.project === "string").toBe(true);
+
+      const allContent = JSON.stringify(state["SM"]);
+      expect(allContent).not.toBe("{}");
+    } finally {
+      fs.rmSync(repoDirA, { recursive: true, force: true });
+      fs.rmSync(repoDirB, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -40,11 +40,18 @@ it("real checkpoint path (no fake seam) writes a vault note and releases the loc
       SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT },
     encoding: "utf8",
   });
-  // checkpoint spawns the detached writer; give it a moment
-  execFileSync("bash", ["-c", "sleep 2"]);
-  const found = fs.existsSync(TMP_VAULT) && fs.readdirSync(TMP_VAULT, { recursive: true } as any)
-    .some((f: any) => String(f).endsWith(".md"));
+  // checkpoint spawns the detached distiller; poll for completion rather than a
+  // fixed sleep — a cold embedding-model load can take several seconds on CI.
+  const deadline = Date.now() + 20000;
+  let found = false;
+  let lockReleased = false;
+  while (Date.now() < deadline) {
+    found = fs.existsSync(TMP_VAULT) && fs.readdirSync(TMP_VAULT, { recursive: true } as any)
+      .some((f: any) => String(f).endsWith(".md"));
+    lockReleased = !fs.existsSync(path.join(TMP_DATA, "locks/distill.lock"));
+    if (found && lockReleased) break;
+    execFileSync("bash", ["-c", "sleep 0.5"]);
+  }
   expect(found).toBe(true);
-
-  expect(fs.existsSync(path.join(TMP_DATA, "locks/distill.lock"))).toBe(false);
-});
+  expect(lockReleased).toBe(true);
+}, 25000);

--- a/tests/sessionProjectResolver.test.ts
+++ b/tests/sessionProjectResolver.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveSessionProject } from "../src/distillRun.js";
+
+beforeAll(() => { process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1"; });
+afterAll(() => { delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST; });
+
+describe("resolveSessionProject", () => {
+  it("single-repo session: returns the dominant project slug from cwd", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rsp-single-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "test-proj" }));
+      const events = [
+        { type: "tool", tool: "Write", cwd: repoDir, ts: "t1" },
+        { type: "tool", tool: "Write", cwd: repoDir, ts: "t2" },
+        { type: "prompt", prompt: "do something", cwd: repoDir, ts: "t3" },
+      ];
+      const result = resolveSessionProject(events);
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+      expect(result.dominant).toBe(expectedSlug);
+      expect(result.all).toContain(expectedSlug);
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("non-project cwd (tmpdir / blocked): returns undefined dominant", () => {
+    const events = [
+      { type: "tool", tool: "Write", cwd: os.tmpdir(), ts: "t1" },
+      { type: "prompt", prompt: "hello", cwd: os.tmpdir(), ts: "t2" },
+    ];
+    const result = resolveSessionProject(events);
+    expect(result.dominant).toBeUndefined();
+    expect(result.all).toHaveLength(0);
+  });
+
+  it("empty events: returns undefined dominant", () => {
+    const result = resolveSessionProject([]);
+    expect(result.dominant).toBeUndefined();
+    expect(result.all).toHaveLength(0);
+  });
+
+  it("events without cwd: returns undefined dominant", () => {
+    const result = resolveSessionProject([
+      { type: "tool", tool: "Write", ts: "t1" },
+      { type: "prompt", prompt: "hi", ts: "t2" },
+    ]);
+    expect(result.dominant).toBeUndefined();
+    expect(result.all).toHaveLength(0);
+  });
+
+  it("multi-cwd session: dominant is the most-frequent project, all contains both", () => {
+    const repoA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rsp-mA-"));
+    const repoB = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rsp-mB-"));
+    try {
+      fs.writeFileSync(path.join(repoA, "package.json"), JSON.stringify({ name: "proj-a" }));
+      fs.writeFileSync(path.join(repoB, "package.json"), JSON.stringify({ name: "proj-b" }));
+
+      const slugA = path.basename(repoA).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+      const slugB = path.basename(repoB).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      const events = [
+        { type: "tool", tool: "Write", cwd: repoA, ts: "t1" },
+        { type: "tool", tool: "Write", cwd: repoA, ts: "t2" },
+        { type: "tool", tool: "Write", cwd: repoA, ts: "t3" },
+        { type: "tool", tool: "Write", cwd: repoB, ts: "t4" },
+        { type: "tool", tool: "Write", cwd: repoB, ts: "t5" },
+      ];
+      const result = resolveSessionProject(events);
+      expect(result.dominant).toBe(slugA);
+      expect(result.all).toContain(slugA);
+      expect(result.all).toContain(slugB);
+    } finally {
+      fs.rmSync(repoA, { recursive: true, force: true });
+      fs.rmSync(repoB, { recursive: true, force: true });
+    }
+  });
+
+  it("mix of project and non-project cwds: non-project cwd contributes no project", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rsp-mix-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "real-proj" }));
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      const events = [
+        { type: "tool", tool: "Write", cwd: os.tmpdir(), ts: "t1" },
+        { type: "tool", tool: "Write", cwd: repoDir, ts: "t2" },
+        { type: "tool", tool: "Write", cwd: repoDir, ts: "t3" },
+      ];
+      const result = resolveSessionProject(events);
+      expect(result.dominant).toBe(expectedSlug);
+      expect(result.all).toHaveLength(1);
+      expect(result.all[0]).toBe(expectedSlug);
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Part 2 of v0.7.0. The keystone: project attribution is now derived from the working directory where work happened, instead of guessed. Depends on #43; merge after it.

## What
- `resolveSessionProject(events)` derives a session's project from event `cwd` values via `classifyPath`: it tallies per-project hit counts and returns the dominant project plus the full set of touched projects. A cwd with no strong project signal (blocked/skip) contributes nothing.
- At distill time, project-scoped items (`decision`, `gotcha`, `project_fact`, `capture`) that lack an explicit project inherit the session's dominant cwd project. An explicit per-item project always wins and is normalized. The router now persists a capture's `project`.
- Multi-cwd sessions no longer dump everything into one project: explicit tags win and the dominant is by event count, so a session that switches from repo A to repo B does not tag B's items as A.
- `DaySessionEntry` gains `project` (dominant) and `projects` (all touched); both inject and distill record it. This is the data the read-path scoping and the session-start brief build on in later parts.

## Tests
Resolver unit tests (single-repo, multi-cwd dominant, non-project cwd, mixed), distill integration tests (attribution, explicit-wins, non-project cwd, multi-cwd B-not-A), and capture cwd-attribution. Typecheck clean; build clean; `dist` in sync.
