### PR TITLE
v0.7.0 part 4 (final): user-visible session-start brief + lesson-recovery migration

### DIFF
--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -213,6 +213,162 @@ function logDistillSkip(sid, reason) {
     }
     catch { /* best-effort */ }
 }
+export async function distillFromEvents(sid, events) {
+    const env = getEnvelope(JSON.stringify(events));
+    const sessionProj = resolveSessionProject(events);
+    const PROJECT_SCOPED_KINDS = new Set(["project_fact", "gotcha", "decision", "capture"]);
+    const items = env.items;
+    const routedByDate = {};
+    let notesWritten = 0;
+    for (const it of items) {
+        if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.dominant) {
+            it.project = sessionProj.dominant;
+        }
+        else if (it.project) {
+            it.project = slug(it.project);
+        }
+        it.links = resolveLinks(it.links || [], vaultPath());
+        const r = route(it);
+        if (r.mode !== "create") {
+            const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
+            if (res0.ok && res0.reason !== "duplicate-skipped") {
+                try {
+                    await indexNote(r.relPath);
+                }
+                catch (e) {
+                    writeFailure(`index failed: ${e?.message || e}`);
+                }
+                (routedByDate[it.date] ||= []).push(r.relPath);
+                notesWritten++;
+            }
+            continue;
+        }
+        {
+            let vaultDedupSkip = false;
+            try {
+                const vaultSearchFn = async (query, _opts) => {
+                    let ix;
+                    try {
+                        ix = openIndex();
+                        const [qv] = await embed([query]);
+                        const hits = ix.vectorKNN(qv, 1);
+                        if (!hits.length)
+                            return [];
+                        const [hv] = await embed([hits[0].text]);
+                        let dot = 0, na = 0, nb = 0;
+                        const n = Math.min(qv.length, hv.length);
+                        for (let i = 0; i < n; i++) {
+                            dot += qv[i] * hv[i];
+                            na += qv[i] ** 2;
+                            nb += hv[i] ** 2;
+                        }
+                        const sim = (na && nb) ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0;
+                        return [{ path: hits[0].relPath, score: sim }];
+                    }
+                    catch {
+                        return [];
+                    }
+                    finally {
+                        ix?.close();
+                    }
+                };
+                const vaultMatch = await dedupAgainstVault({ title: it.title, body: r.body, project: it.project, type: r.frontmatter.type }, vaultSearchFn);
+                if (vaultMatch.match) {
+                    recordRejection(vaultPath(), {
+                        type: r.frontmatter.type ?? it.kind,
+                        reason: `dedup vs ${vaultMatch.match} (score ${vaultMatch.score?.toFixed(2)})`,
+                        sessionId: sid,
+                        title: it.title,
+                        excerpt: r.body.slice(0, 500),
+                    });
+                    vaultDedupSkip = true;
+                }
+            }
+            catch (e) {
+                writeFailure(`vault dedup error: ${e?.message || e}`);
+            }
+            if (vaultDedupSkip)
+                continue;
+        }
+        const classifiableKinds = new Set(["decision", "lesson", "capture", "project", "daily", "person"]);
+        let writeBody = r.body;
+        let writeRelPath = r.relPath;
+        let writeFrontmatter = r.frontmatter;
+        if (classifiableKinds.has(it.kind)) {
+            try {
+                const classifyFm = it.project
+                    ? { ...r.frontmatter, project: it.project }
+                    : r.frontmatter;
+                const candidateDoc = serializeNote(classifyFm, r.body);
+                const cr = classify({ proposedType: it.kind, title: it.title, body: candidateDoc });
+                if (!cr.accepted) {
+                    recordRejection(vaultPath(), {
+                        type: it.kind,
+                        reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
+                        sessionId: sid,
+                        title: it.title,
+                        excerpt: candidateDoc.slice(0, 500),
+                    });
+                    const targetKind = cr.suggestedType ?? it.kind;
+                    if (targetKind === "capture") {
+                        const reItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
+                        const r2 = route(reItem);
+                        writeFrontmatter = r2.frontmatter;
+                        writeRelPath = r2.relPath;
+                        writeBody = coerceCapture(reItem, r.body);
+                    }
+                    else if (targetKind === "lesson") {
+                        const reItem = { ...it, kind: "lesson" };
+                        const r2 = route(reItem);
+                        writeFrontmatter = r2.frontmatter;
+                        writeRelPath = r2.relPath;
+                        writeBody = coerceLesson(reItem, r.body);
+                    }
+                }
+            }
+            catch (e) {
+                writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
+            }
+        }
+        const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
+        if (res.ok && res.reason !== "duplicate-skipped") {
+            try {
+                await indexNote(writeRelPath);
+            }
+            catch (e) {
+                writeFailure(`index failed: ${e?.message || e}`);
+            }
+            (routedByDate[it.date] ||= []).push(writeRelPath);
+            notesWritten++;
+        }
+    }
+    try {
+        const dates = Object.keys(routedByDate);
+        const today = new Date().toISOString().slice(0, 10);
+        for (const d of dates.length ? dates : [today]) {
+            upsertDay(d, sid, {
+                digestLine: env.digest || "",
+                routedRelPaths: routedByDate[d] || [],
+                alsoDid: env.alsoDid,
+                openThreads: env.openThreads,
+                ...(sessionProj.dominant !== undefined ? { project: sessionProj.dominant } : {}),
+                ...(sessionProj.all.length > 1 ? { projects: sessionProj.all } : {}),
+            });
+            const dn = buildDailyNote(d);
+            writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });
+            try {
+                await indexNote(dn.relPath);
+            }
+            catch (e) {
+                writeFailure(`index failed: ${e?.message || e}`);
+            }
+        }
+    }
+    catch (e) {
+        writeFailure(`daily note failed: ${e?.message || e}`);
+    }
+    return { notesWritten };
+}
 export async function runDistill() {
     const sid = process.env.SUPERBRAIN_SESSION_ID
         || (() => { try {
@@ -240,169 +396,7 @@ export async function runDistill() {
                 return;
             }
         }
-        const env = getEnvelope(JSON.stringify(events));
-        const sessionProj = resolveSessionProject(events);
-        const PROJECT_SCOPED_KINDS = new Set(["project_fact", "gotcha", "decision", "capture"]);
-        const items = env.items;
-        const routedByDate = {};
-        for (const it of items) {
-            if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.dominant) {
-                it.project = sessionProj.dominant;
-            }
-            else if (it.project) {
-                it.project = slug(it.project);
-            }
-            it.links = resolveLinks(it.links || [], vaultPath());
-            const r = route(it);
-            // append/replace bodies are fragments — template validation is not applicable.
-            if (r.mode !== "create") {
-                writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
-                try {
-                    await indexNote(r.relPath);
-                }
-                catch (e) {
-                    writeFailure(`index failed: ${e?.message || e}`);
-                }
-                (routedByDate[it.date] ||= []).push(r.relPath);
-                continue;
-            }
-            // Vault-dedup gate: skip write if vault already contains a near-duplicate.
-            // Inline adapter: embeds the query, runs vectorKNN against the index, and
-            // computes cosine similarity from the returned chunk text embedding.
-            // type/project filters are passed through for future support but are currently
-            // best-effort (vectorKNN has no per-field filter).
-            {
-                let vaultDedupSkip = false;
-                try {
-                    const vaultSearchFn = async (query, _opts) => {
-                        let ix;
-                        try {
-                            ix = openIndex();
-                            const [qv] = await embed([query]);
-                            const hits = ix.vectorKNN(qv, 1);
-                            if (!hits.length)
-                                return [];
-                            // Compute cosine between query vector and re-embed the top hit's text.
-                            const [hv] = await embed([hits[0].text]);
-                            let dot = 0, na = 0, nb = 0;
-                            const n = Math.min(qv.length, hv.length);
-                            for (let i = 0; i < n; i++) {
-                                dot += qv[i] * hv[i];
-                                na += qv[i] ** 2;
-                                nb += hv[i] ** 2;
-                            }
-                            const sim = (na && nb) ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0;
-                            return [{ path: hits[0].relPath, score: sim }];
-                        }
-                        catch {
-                            return [];
-                        }
-                        finally {
-                            ix?.close();
-                        }
-                    };
-                    const vaultMatch = await dedupAgainstVault({ title: it.title, body: r.body, project: it.project, type: r.frontmatter.type }, vaultSearchFn);
-                    if (vaultMatch.match) {
-                        recordRejection(vaultPath(), {
-                            type: r.frontmatter.type ?? it.kind,
-                            reason: `dedup vs ${vaultMatch.match} (score ${vaultMatch.score?.toFixed(2)})`,
-                            sessionId: sid,
-                            title: it.title,
-                            excerpt: r.body.slice(0, 500),
-                        });
-                        vaultDedupSkip = true;
-                    }
-                }
-                catch (e) {
-                    writeFailure(`vault dedup error: ${e?.message || e}`);
-                }
-                if (vaultDedupSkip)
-                    continue;
-            }
-            // Classification gate: only classify kinds that are valid NoteTypes.
-            // project_fact and preference are not in NoteType and are always passed through.
-            const classifiableKinds = new Set(["decision", "lesson", "capture", "project", "daily", "person"]);
-            let writeBody = r.body;
-            let writeRelPath = r.relPath;
-            let writeFrontmatter = r.frontmatter;
-            if (classifiableKinds.has(it.kind)) {
-                try {
-                    // Merge item.project into frontmatter for classify: some router cases
-                    // (lesson, person) omit project even when the distiller provided one.
-                    const classifyFm = it.project
-                        ? { ...r.frontmatter, project: it.project }
-                        : r.frontmatter;
-                    const candidateDoc = serializeNote(classifyFm, r.body);
-                    const cr = classify({ proposedType: it.kind, title: it.title, body: candidateDoc });
-                    if (!cr.accepted) {
-                        recordRejection(vaultPath(), {
-                            type: it.kind,
-                            reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
-                            sessionId: sid,
-                            title: it.title,
-                            excerpt: candidateDoc.slice(0, 500),
-                        });
-                        // Coerce-don't-drop: re-route to the (possibly suggested) kind so the
-                        // frontmatter, path, and body agree, then coerce the body to pass.
-                        const targetKind = cr.suggestedType ?? it.kind;
-                        if (targetKind === "capture") {
-                            const reItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
-                            const r2 = route(reItem);
-                            writeFrontmatter = r2.frontmatter;
-                            writeRelPath = r2.relPath;
-                            writeBody = coerceCapture(reItem, r.body);
-                        }
-                        else if (targetKind === "lesson") {
-                            const reItem = { ...it, kind: "lesson" };
-                            const r2 = route(reItem);
-                            writeFrontmatter = r2.frontmatter;
-                            writeRelPath = r2.relPath;
-                            writeBody = coerceLesson(reItem, r.body);
-                        }
-                    }
-                }
-                catch (e) {
-                    // Classifier or recordRejection threw — fail open: log and continue with the write.
-                    writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
-                }
-            }
-            const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
-            if (res.ok) {
-                try {
-                    await indexNote(writeRelPath);
-                }
-                catch (e) {
-                    writeFailure(`index failed: ${e?.message || e}`);
-                }
-                (routedByDate[it.date] ||= []).push(writeRelPath);
-            }
-        }
-        // Daily journal: record this session's contribution + regenerate the note(s).
-        try {
-            const dates = Object.keys(routedByDate);
-            const today = new Date().toISOString().slice(0, 10);
-            for (const d of dates.length ? dates : [today]) {
-                upsertDay(d, sid, {
-                    digestLine: env.digest || "",
-                    routedRelPaths: routedByDate[d] || [],
-                    alsoDid: env.alsoDid,
-                    openThreads: env.openThreads,
-                    ...(sessionProj.dominant !== undefined ? { project: sessionProj.dominant } : {}),
-                    ...(sessionProj.all.length > 1 ? { projects: sessionProj.all } : {}),
-                });
-                const dn = buildDailyNote(d);
-                writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });
-                try {
-                    await indexNote(dn.relPath);
-                }
-                catch (e) {
-                    writeFailure(`index failed: ${e?.message || e}`);
-                }
-            }
-        }
-        catch (e) {
-            writeFailure(`daily note failed: ${e?.message || e}`);
-        }
+        await distillFromEvents(sid, events);
         writeCursor(sid, newOffset);
         // GC the transcript snapshot now that distillation succeeded. Best-effort:
         // a missing snapshot is fine (checkpoint may not have run), and a deletion

--- a/dist/src/injectBudget.js
+++ b/dist/src/injectBudget.js
@@ -1,4 +1,5 @@
 export const INJECT_LIMITS = {
+    brief: 150,
     recall: 500,
     preferences: 500,
     openThreads: 200,

--- a/dist/src/sessionDigest.js
+++ b/dist/src/sessionDigest.js
@@ -25,6 +25,44 @@ export async function appendDigest(parts, h) {
             currentProjectKnown = true;
         }
     }
+    // Project-scoped session brief: leads additionalContext when we know the project.
+    try {
+        if (currentProjectKnown && currentProjectSlug) {
+            let lastDigestLine = "";
+            const recentSlugs = [];
+            // Scan the last 7 calendar days newest-first for this project's activity.
+            for (let i = 0; i <= 7; i++) {
+                const d = new Date(Date.now() - i * 86_400_000).toISOString().slice(0, 10);
+                const day = readDay(d);
+                for (const entry of Object.values(day)) {
+                    if (entry.project !== currentProjectSlug)
+                        continue;
+                    if (!lastDigestLine && entry.digestLine)
+                        lastDigestLine = entry.digestLine;
+                    for (const r of entry.routedRelPaths) {
+                        const slug = path.basename(r, ".md");
+                        if (!recentSlugs.includes(slug) && recentSlugs.length < 3)
+                            recentSlugs.push(slug);
+                    }
+                }
+                if (lastDigestLine && recentSlugs.length >= 3)
+                    break;
+            }
+            if (lastDigestLine) {
+                const lines = [
+                    `Tell the user in one sentence that SuperBrain has loaded context for this project.`,
+                    `SuperBrain — ${currentProjectSlug}`,
+                    `Last session: ${lastDigestLine}`,
+                ];
+                if (recentSlugs.length)
+                    lines.push(`Recent: ${recentSlugs.join(", ")}`);
+                const body = fitToBudget(lines, INJECT_LIMITS.brief);
+                if (body)
+                    parts.unshift(body);
+            }
+        }
+    }
+    catch { /* brief is best-effort */ }
     // Hybrid recall digest: project-slug filtered when cwd resolves to a known project.
     try {
         let query;

--- a/scripts/recover-lessons.ts
+++ b/scripts/recover-lessons.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env -S node --experimental-strip-types
+// scripts/recover-lessons.ts
+//
+// One-shot manual recovery: re-distill past sessions whose lessons/captures were
+// lost to the pre-v0.7.0 classification reject regression. Now that the gate
+// accepts project-less lessons and coerces sub-rubric notes, re-running the full
+// pipeline over old event logs recovers what was dropped.
+//
+// Usage:
+//   npx tsx scripts/recover-lessons.ts [--since YYYY-MM-DD] [--data-dir <path>]  # dry-run
+//   npx tsx scripts/recover-lessons.ts --apply [--since YYYY-MM-DD] [--data-dir <path>]
+
+import fs from "node:fs";
+import path from "node:path";
+
+const DEFAULT_SINCE = "2026-05-22";
+
+export interface RecoverySession {
+  sid: string;
+  ndjsonPath: string;
+  firstEventDate: string;
+}
+
+export interface RecoveryPlan {
+  sessionsDir: string;
+  since: string;
+  sessions: RecoverySession[];
+}
+
+export interface RecoveryResult {
+  sid: string;
+  notesWritten: number;
+}
+
+function parseFirstEventDate(ndjsonPath: string): string | null {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(ndjsonPath, "r");
+    const buf = Buffer.alloc(4096);
+    const bytesRead = fs.readSync(fd, buf, 0, 4096, 0);
+    const text = buf.slice(0, bytesRead).toString("utf8");
+    const firstLine = text.split("\n")[0];
+    if (!firstLine) return null;
+    const obj = JSON.parse(firstLine);
+    const ts: string | undefined = obj?.ts ?? obj?.date ?? obj?.timestamp;
+    if (!ts) return null;
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return null;
+    return d.toISOString().slice(0, 10);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch { /* best-effort */ }
+    }
+  }
+}
+
+export function planRecovery(sessionsDir: string, since: string): RecoveryPlan {
+  const sessions: RecoverySession[] = [];
+  if (!fs.existsSync(sessionsDir)) return { sessionsDir, since, sessions };
+
+  for (const entry of fs.readdirSync(sessionsDir)) {
+    if (!entry.endsWith(".ndjson")) continue;
+    const sid = entry.slice(0, -7);
+    const ndjsonPath = path.join(sessionsDir, entry);
+    const firstEventDate = parseFirstEventDate(ndjsonPath);
+    if (!firstEventDate) continue;
+    if (firstEventDate >= since) {
+      sessions.push({ sid, ndjsonPath, firstEventDate });
+    }
+  }
+
+  sessions.sort((a, b) => a.firstEventDate.localeCompare(b.firstEventDate));
+  return { sessionsDir, since, sessions };
+}
+
+export async function applyRecovery(
+  plan: RecoveryPlan,
+  distillFn: (sid: string, events: any[]) => Promise<{ notesWritten: number }>,
+): Promise<RecoveryResult[]> {
+  const results: RecoveryResult[] = [];
+  for (const s of plan.sessions) {
+    const raw = fs.readFileSync(s.ndjsonPath, "utf8");
+    const events = raw
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .filter((x) => x !== null);
+    const { notesWritten } = await distillFn(s.sid, events);
+    results.push({ sid: s.sid, notesWritten });
+  }
+  return results;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+
+  const sinceIdx = args.indexOf("--since");
+  const since = sinceIdx >= 0 && args[sinceIdx + 1] ? args[sinceIdx + 1] : DEFAULT_SINCE;
+
+  const dataDirIdx = args.indexOf("--data-dir");
+  let resolvedDataDir: string;
+  if (dataDirIdx >= 0 && args[dataDirIdx + 1]) {
+    resolvedDataDir = args[dataDirIdx + 1];
+  } else {
+    const { dataDir } = await import("../src/paths.js");
+    resolvedDataDir = dataDir();
+  }
+
+  const sessionsDir = path.join(resolvedDataDir, "sessions");
+  const plan = planRecovery(sessionsDir, since);
+
+  if (plan.sessions.length === 0) {
+    console.log(`No sessions found on/after ${since} in ${sessionsDir}.`);
+    return;
+  }
+
+  if (!apply) {
+    console.log(`Dry-run: ${plan.sessions.length} session(s) on/after ${since} would be re-distilled.`);
+    console.log("Each reprocess makes one LLM call. Run with --apply to write notes.\n");
+    for (const s of plan.sessions) {
+      console.log(`  ${s.sid}  (first event: ${s.firstEventDate})`);
+    }
+    console.log("\n(Dry-run. Use --apply to write changes.)");
+    return;
+  }
+
+  console.log(`Recovering ${plan.sessions.length} session(s) on/after ${since}...`);
+
+  const { distillFromEvents } = await import("../src/distillRun.js");
+  const results = await applyRecovery(plan, distillFromEvents);
+
+  let totalNotes = 0;
+  for (const r of results) {
+    console.log(`  ${r.sid}: ${r.notesWritten} note(s) written`);
+    totalNotes += r.notesWritten;
+  }
+  console.log(`\nDone. ${totalNotes} total note(s) written across ${results.length} session(s).`);
+}
+
+if (
+  process.argv[1]?.endsWith("recover-lessons.ts") ||
+  process.argv[1]?.endsWith("recover-lessons.js")
+) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -234,6 +234,140 @@ function logDistillSkip(sid: string, reason: string): void {
   } catch { /* best-effort */ }
 }
 
+export interface DistillEventsResult {
+  notesWritten: number;
+}
+
+export async function distillFromEvents(sid: string, events: any[]): Promise<DistillEventsResult> {
+  const env = getEnvelope(JSON.stringify(events));
+  const sessionProj = resolveSessionProject(events);
+  const PROJECT_SCOPED_KINDS = new Set<string>(["project_fact", "gotcha", "decision", "capture"]);
+  const items = env.items;
+  const routedByDate: Record<string, string[]> = {};
+  let notesWritten = 0;
+  for (const it of items) {
+    if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.dominant) {
+      it.project = sessionProj.dominant;
+    } else if (it.project) {
+      it.project = slug(it.project);
+    }
+    it.links = resolveLinks(it.links || [], vaultPath());
+    const r = route(it);
+    if (r.mode !== "create") {
+      const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
+      if (res0.ok && res0.reason !== "duplicate-skipped") {
+        try { await indexNote(r.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
+        (routedByDate[it.date] ||= []).push(r.relPath);
+        notesWritten++;
+      }
+      continue;
+    }
+    {
+      let vaultDedupSkip = false;
+      try {
+        const vaultSearchFn = async (
+          query: string,
+          _opts?: { k?: number; type?: string; project?: string },
+        ): Promise<Array<{ path: string; score: number }>> => {
+          let ix;
+          try {
+            ix = openIndex();
+            const [qv] = await embed([query]);
+            const hits = ix.vectorKNN(qv, 1);
+            if (!hits.length) return [];
+            const [hv] = await embed([hits[0].text]);
+            let dot = 0, na = 0, nb = 0;
+            const n = Math.min(qv.length, hv.length);
+            for (let i = 0; i < n; i++) { dot += qv[i] * hv[i]; na += qv[i] ** 2; nb += hv[i] ** 2; }
+            const sim = (na && nb) ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0;
+            return [{ path: hits[0].relPath, score: sim }];
+          } catch { return []; }
+          finally { ix?.close(); }
+        };
+        const vaultMatch = await dedupAgainstVault(
+          { title: it.title, body: r.body, project: it.project, type: r.frontmatter.type as string | undefined },
+          vaultSearchFn,
+        );
+        if (vaultMatch.match) {
+          recordRejection(vaultPath(), {
+            type: r.frontmatter.type as string ?? it.kind,
+            reason: `dedup vs ${vaultMatch.match} (score ${vaultMatch.score?.toFixed(2)})`,
+            sessionId: sid,
+            title: it.title,
+            excerpt: r.body.slice(0, 500),
+          });
+          vaultDedupSkip = true;
+        }
+      } catch (e: any) {
+        writeFailure(`vault dedup error: ${e?.message || e}`);
+      }
+      if (vaultDedupSkip) continue;
+    }
+    const classifiableKinds = new Set<string>(["decision", "lesson", "capture", "project", "daily", "person"]);
+    let writeBody = r.body;
+    let writeRelPath = r.relPath;
+    let writeFrontmatter = r.frontmatter;
+    if (classifiableKinds.has(it.kind)) {
+      try {
+        const classifyFm = it.project
+          ? { ...r.frontmatter, project: it.project }
+          : r.frontmatter;
+        const candidateDoc = serializeNote(classifyFm, r.body);
+        const cr = classify({ proposedType: it.kind as NoteType, title: it.title, body: candidateDoc });
+        if (!cr.accepted) {
+          recordRejection(vaultPath(), {
+            type: it.kind,
+            reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
+            sessionId: sid,
+            title: it.title,
+            excerpt: candidateDoc.slice(0, 500),
+          });
+          const targetKind = cr.suggestedType ?? (it.kind as NoteType);
+          if (targetKind === "capture") {
+            const reItem: DistilledItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
+            const r2 = route(reItem);
+            writeFrontmatter = r2.frontmatter;
+            writeRelPath = r2.relPath;
+            writeBody = coerceCapture(reItem, r.body);
+          } else if (targetKind === "lesson") {
+            const reItem: DistilledItem = { ...it, kind: "lesson" };
+            const r2 = route(reItem);
+            writeFrontmatter = r2.frontmatter;
+            writeRelPath = r2.relPath;
+            writeBody = coerceLesson(reItem, r.body);
+          }
+        }
+      } catch (e: any) {
+        writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
+      }
+    }
+    const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
+    if (res.ok && res.reason !== "duplicate-skipped") {
+      try { await indexNote(writeRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
+      (routedByDate[it.date] ||= []).push(writeRelPath);
+      notesWritten++;
+    }
+  }
+  try {
+    const dates = Object.keys(routedByDate);
+    const today = new Date().toISOString().slice(0, 10);
+    for (const d of dates.length ? dates : [today]) {
+      upsertDay(d, sid, {
+        digestLine: env.digest || "",
+        routedRelPaths: routedByDate[d] || [],
+        alsoDid: env.alsoDid,
+        openThreads: env.openThreads,
+        ...(sessionProj.dominant !== undefined ? { project: sessionProj.dominant } : {}),
+        ...(sessionProj.all.length > 1 ? { projects: sessionProj.all } : {}),
+      });
+      const dn = buildDailyNote(d);
+      writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });
+      try { await indexNote(dn.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
+    }
+  } catch (e: any) { writeFailure(`daily note failed: ${e?.message || e}`); }
+  return { notesWritten };
+}
+
 export async function runDistill(): Promise<void> {
   const sid = process.env.SUPERBRAIN_SESSION_ID
     || (() => { try { return JSON.parse(fs.readFileSync(0, "utf8")).session_id; } catch { return "unknown"; } })();
@@ -253,142 +387,7 @@ export async function runDistill(): Promise<void> {
         return;
       }
     }
-    const env = getEnvelope(JSON.stringify(events));
-    const sessionProj = resolveSessionProject(events);
-    const PROJECT_SCOPED_KINDS = new Set<string>(["project_fact", "gotcha", "decision", "capture"]);
-    const items = env.items;
-    const routedByDate: Record<string, string[]> = {};
-    for (const it of items) {
-      if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.dominant) {
-        it.project = sessionProj.dominant;
-      } else if (it.project) {
-        it.project = slug(it.project);
-      }
-      it.links = resolveLinks(it.links || [], vaultPath());
-      const r = route(it);
-      // append/replace bodies are fragments — template validation is not applicable.
-      if (r.mode !== "create") {
-        writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
-        try { await indexNote(r.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
-        (routedByDate[it.date] ||= []).push(r.relPath);
-        continue;
-      }
-      // Vault-dedup gate: skip write if vault already contains a near-duplicate.
-      // Inline adapter: embeds the query, runs vectorKNN against the index, and
-      // computes cosine similarity from the returned chunk text embedding.
-      // type/project filters are passed through for future support but are currently
-      // best-effort (vectorKNN has no per-field filter).
-      {
-        let vaultDedupSkip = false;
-        try {
-          const vaultSearchFn = async (
-            query: string,
-            _opts?: { k?: number; type?: string; project?: string },
-          ): Promise<Array<{ path: string; score: number }>> => {
-            let ix;
-            try {
-              ix = openIndex();
-              const [qv] = await embed([query]);
-              const hits = ix.vectorKNN(qv, 1);
-              if (!hits.length) return [];
-              // Compute cosine between query vector and re-embed the top hit's text.
-              const [hv] = await embed([hits[0].text]);
-              let dot = 0, na = 0, nb = 0;
-              const n = Math.min(qv.length, hv.length);
-              for (let i = 0; i < n; i++) { dot += qv[i] * hv[i]; na += qv[i] ** 2; nb += hv[i] ** 2; }
-              const sim = (na && nb) ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0;
-              return [{ path: hits[0].relPath, score: sim }];
-            } catch { return []; }
-            finally { ix?.close(); }
-          };
-          const vaultMatch = await dedupAgainstVault(
-            { title: it.title, body: r.body, project: it.project, type: r.frontmatter.type as string | undefined },
-            vaultSearchFn,
-          );
-          if (vaultMatch.match) {
-            recordRejection(vaultPath(), {
-              type: r.frontmatter.type as string ?? it.kind,
-              reason: `dedup vs ${vaultMatch.match} (score ${vaultMatch.score?.toFixed(2)})`,
-              sessionId: sid,
-              title: it.title,
-              excerpt: r.body.slice(0, 500),
-            });
-            vaultDedupSkip = true;
-          }
-        } catch (e: any) {
-          writeFailure(`vault dedup error: ${e?.message || e}`);
-        }
-        if (vaultDedupSkip) continue;
-      }
-      // Classification gate: only classify kinds that are valid NoteTypes.
-      // project_fact and preference are not in NoteType and are always passed through.
-      const classifiableKinds = new Set<string>(["decision", "lesson", "capture", "project", "daily", "person"]);
-      let writeBody = r.body;
-      let writeRelPath = r.relPath;
-      let writeFrontmatter = r.frontmatter;
-      if (classifiableKinds.has(it.kind)) {
-        try {
-          // Merge item.project into frontmatter for classify: some router cases
-          // (lesson, person) omit project even when the distiller provided one.
-          const classifyFm = it.project
-            ? { ...r.frontmatter, project: it.project }
-            : r.frontmatter;
-          const candidateDoc = serializeNote(classifyFm, r.body);
-          const cr = classify({ proposedType: it.kind as NoteType, title: it.title, body: candidateDoc });
-          if (!cr.accepted) {
-            recordRejection(vaultPath(), {
-              type: it.kind,
-              reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
-              sessionId: sid,
-              title: it.title,
-              excerpt: candidateDoc.slice(0, 500),
-            });
-            // Coerce-don't-drop: re-route to the (possibly suggested) kind so the
-            // frontmatter, path, and body agree, then coerce the body to pass.
-            const targetKind = cr.suggestedType ?? (it.kind as NoteType);
-            if (targetKind === "capture") {
-              const reItem: DistilledItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
-              const r2 = route(reItem);
-              writeFrontmatter = r2.frontmatter;
-              writeRelPath = r2.relPath;
-              writeBody = coerceCapture(reItem, r.body);
-            } else if (targetKind === "lesson") {
-              const reItem: DistilledItem = { ...it, kind: "lesson" };
-              const r2 = route(reItem);
-              writeFrontmatter = r2.frontmatter;
-              writeRelPath = r2.relPath;
-              writeBody = coerceLesson(reItem, r.body);
-            }
-          }
-        } catch (e: any) {
-          // Classifier or recordRejection threw — fail open: log and continue with the write.
-          writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
-        }
-      }
-      const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
-      if (res.ok) {
-        try { await indexNote(writeRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
-        (routedByDate[it.date] ||= []).push(writeRelPath);
-      }
-    }
-    // Daily journal: record this session's contribution + regenerate the note(s).
-    try {
-      const dates = Object.keys(routedByDate);
-      const today = new Date().toISOString().slice(0, 10);
-      for (const d of dates.length ? dates : [today]) {
-        upsertDay(d, sid, {
-          digestLine: env.digest || "",
-          routedRelPaths: routedByDate[d] || [],
-          alsoDid: env.alsoDid,
-          openThreads: env.openThreads,
-          ...(sessionProj.dominant !== undefined ? { project: sessionProj.dominant } : {}),
-          ...(sessionProj.all.length > 1 ? { projects: sessionProj.all } : {}),
-        });
-        const dn = buildDailyNote(d);
-        writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });
-        try { await indexNote(dn.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
-      }
-    } catch (e: any) { writeFailure(`daily note failed: ${e?.message || e}`); }
+    await distillFromEvents(sid, events);
     writeCursor(sid, newOffset);
     // GC the transcript snapshot now that distillation succeeded. Best-effort:
     // a missing snapshot is fine (checkpoint may not have run), and a deletion

--- a/src/injectBudget.ts
+++ b/src/injectBudget.ts
@@ -1,4 +1,5 @@
 export const INJECT_LIMITS = {
+  brief: 150,
   recall: 500,
   preferences: 500,
   openThreads: 200,

--- a/src/sessionDigest.ts
+++ b/src/sessionDigest.ts
@@ -28,6 +28,40 @@ export async function appendDigest(parts: string[], h: any): Promise<void> {
     }
   }
 
+  // Project-scoped session brief: leads additionalContext when we know the project.
+  try {
+    if (currentProjectKnown && currentProjectSlug) {
+      let lastDigestLine = "";
+      const recentSlugs: string[] = [];
+
+      // Scan the last 7 calendar days newest-first for this project's activity.
+      for (let i = 1; i <= 7; i++) {
+        const d = new Date(Date.now() - i * 86_400_000).toISOString().slice(0, 10);
+        const day = readDay(d);
+        for (const entry of Object.values(day)) {
+          if (entry.project !== currentProjectSlug) continue;
+          if (!lastDigestLine && entry.digestLine) lastDigestLine = entry.digestLine;
+          for (const r of entry.routedRelPaths) {
+            const slug = path.basename(r, ".md");
+            if (!recentSlugs.includes(slug) && recentSlugs.length < 3) recentSlugs.push(slug);
+          }
+        }
+        if (lastDigestLine && recentSlugs.length >= 3) break;
+      }
+
+      if (lastDigestLine) {
+        const lines = [
+          `Tell the user in one sentence that SuperBrain has loaded context for this project.`,
+          `SuperBrain — ${currentProjectSlug}`,
+          `Last session: ${lastDigestLine}`,
+        ];
+        if (recentSlugs.length) lines.push(`Recent: ${recentSlugs.join(", ")}`);
+        const body = fitToBudget(lines, INJECT_LIMITS.brief);
+        if (body) parts.unshift(body);
+      }
+    }
+  } catch { /* brief is best-effort */ }
+
   // Hybrid recall digest: project-slug filtered when cwd resolves to a known project.
   try {
     let query: string;

--- a/src/sessionDigest.ts
+++ b/src/sessionDigest.ts
@@ -35,7 +35,7 @@ export async function appendDigest(parts: string[], h: any): Promise<void> {
       const recentSlugs: string[] = [];
 
       // Scan the last 7 calendar days newest-first for this project's activity.
-      for (let i = 1; i <= 7; i++) {
+      for (let i = 0; i <= 7; i++) {
         const d = new Date(Date.now() - i * 86_400_000).toISOString().slice(0, 10);
         const day = readDay(d);
         for (const entry of Object.values(day)) {

--- a/tests/recoverLessons.test.ts
+++ b/tests/recoverLessons.test.ts
@@ -1,0 +1,220 @@
+import { it, describe, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { planRecovery, applyRecovery } from "../scripts/recover-lessons.js";
+import type { RecoverySession } from "../scripts/recover-lessons.js";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+let SESSIONS_DIR: string;
+let STUB_PATH: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-recover-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-recover-vault-"));
+  SESSIONS_DIR = path.join(TMP_DATA, "sessions");
+  fs.mkdirSync(SESSIONS_DIR, { recursive: true });
+
+  STUB_PATH = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(
+    STUB_PATH,
+    JSON.stringify({
+      items: [
+        {
+          kind: "lesson",
+          title: "Verify live data dir before diagnosing plugin issues",
+          date: "2026-05-22",
+          rule: "Resolve the actual data path before inspecting on-disk state.",
+          why: "On 2026-05-22 a misdiagnosis was produced because the source fallback was inspected instead of the live path.",
+          whenApplies: "Any time a plugin appears to not be writing data.",
+          links: [],
+        },
+      ],
+      digest: "Investigated plugin data dir issue.",
+      openThreads: [],
+      alsoDid: [],
+    }),
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+function writeSession(sid: string, firstEventDate: string, extraEvents: object[] = []) {
+  const firstEvent = {
+    type: "tool",
+    tool: "Write",
+    file: "a.ts",
+    cwd: "/p",
+    ts: `${firstEventDate}T10:00:00.000Z`,
+  };
+  const lines = [firstEvent, ...extraEvents].map((e) => JSON.stringify(e)).join("\n") + "\n";
+  fs.writeFileSync(path.join(SESSIONS_DIR, `${sid}.ndjson`), lines);
+}
+
+describe("planRecovery", () => {
+  it("includes sessions whose first event is on/after the since date", () => {
+    writeSession("IN-1", "2026-05-22");
+    writeSession("IN-2", "2026-05-25");
+    writeSession("OUT-1", "2026-05-21");
+
+    const plan = planRecovery(SESSIONS_DIR, "2026-05-22");
+    const sids = plan.sessions.map((s: RecoverySession) => s.sid);
+    expect(sids).toContain("IN-1");
+    expect(sids).toContain("IN-2");
+    expect(sids).not.toContain("OUT-1");
+  });
+
+  it("returns an empty list when sessionsDir does not exist", () => {
+    const plan = planRecovery(path.join(TMP_DATA, "no-such-dir"), "2026-05-22");
+    expect(plan.sessions).toHaveLength(0);
+  });
+
+  it("ignores non-.ndjson files", () => {
+    fs.writeFileSync(path.join(SESSIONS_DIR, "S.cursor"), "42");
+    const plan = planRecovery(SESSIONS_DIR, "2026-05-22");
+    expect(plan.sessions).toHaveLength(0);
+  });
+
+  it("sorts sessions by first event date ascending", () => {
+    writeSession("B", "2026-05-24");
+    writeSession("A", "2026-05-22");
+    const plan = planRecovery(SESSIONS_DIR, "2026-05-22");
+    const sids = plan.sessions.map((s: RecoverySession) => s.sid);
+    expect(sids.indexOf("A")).toBeLessThan(sids.indexOf("B"));
+  });
+
+  it("skips sessions whose ndjson has no parseable first line", () => {
+    fs.writeFileSync(path.join(SESSIONS_DIR, "BAD.ndjson"), "not json\n");
+    const plan = planRecovery(SESSIONS_DIR, "2026-05-22");
+    expect(plan.sessions.map((s: RecoverySession) => s.sid)).not.toContain("BAD");
+  });
+});
+
+describe("applyRecovery", () => {
+  it("calls distillFn for in-window session and accumulates results", async () => {
+    writeSession("S1", "2026-05-22");
+
+    const plan = planRecovery(SESSIONS_DIR, "2026-05-22");
+    const calls: string[] = [];
+    const stubDistill = async (sid: string, _events: any[]) => {
+      calls.push(sid);
+      return { notesWritten: 2 };
+    };
+
+    const results = await applyRecovery(plan, stubDistill);
+    expect(calls).toEqual(["S1"]);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({ sid: "S1", notesWritten: 2 });
+  });
+
+  it("processes multiple sessions in order", async () => {
+    writeSession("A", "2026-05-22");
+    writeSession("B", "2026-05-24");
+
+    const plan = planRecovery(SESSIONS_DIR, "2026-05-22");
+    const order: string[] = [];
+    const stubDistill = async (sid: string, _events: any[]) => {
+      order.push(sid);
+      return { notesWritten: 1 };
+    };
+
+    await applyRecovery(plan, stubDistill);
+    expect(order).toEqual(["A", "B"]);
+  });
+
+  it("passes all events from the ndjson to distillFn", async () => {
+    writeSession("EV", "2026-05-22", [
+      { type: "prompt", content: "hello", ts: "2026-05-22T11:00:00.000Z" },
+    ]);
+
+    const plan = planRecovery(SESSIONS_DIR, "2026-05-22");
+    let capturedEvents: any[] = [];
+    const stubDistill = async (_sid: string, events: any[]) => {
+      capturedEvents = events;
+      return { notesWritten: 0 };
+    };
+
+    await applyRecovery(plan, stubDistill);
+    expect(capturedEvents).toHaveLength(2);
+    expect(capturedEvents[0].type).toBe("tool");
+    expect(capturedEvents[1].type).toBe("prompt");
+  });
+});
+
+describe("end-to-end with real distillFromEvents", () => {
+  it("writes lesson note for in-window session, skips out-of-window", async () => {
+    process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+    process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+    process.env.SUPERBRAIN_DISTILL_STUB = STUB_PATH;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    writeSession("IN", "2026-05-22");
+    writeSession("OLD", "2026-05-21");
+
+    try {
+      const { distillFromEvents } = await import("../src/distillRun.js");
+      const plan = planRecovery(SESSIONS_DIR, "2026-05-22");
+
+      expect(plan.sessions.map((s: RecoverySession) => s.sid)).toContain("IN");
+      expect(plan.sessions.map((s: RecoverySession) => s.sid)).not.toContain("OLD");
+
+      const results = await applyRecovery(plan, distillFromEvents);
+      expect(results).toHaveLength(1);
+      expect(results[0].sid).toBe("IN");
+      expect(results[0].notesWritten).toBeGreaterThan(0);
+
+      const lessonsDir = path.join(TMP_VAULT, "lessons");
+      expect(fs.existsSync(lessonsDir)).toBe(true);
+      const lessonFiles = fs.readdirSync(lessonsDir).filter((f) => f.endsWith(".md"));
+      expect(lessonFiles.length).toBeGreaterThan(0);
+
+      const lessonContent = fs.readFileSync(path.join(lessonsDir, lessonFiles[0]), "utf8");
+      expect(lessonContent).toMatch(/type: lesson/);
+      expect(lessonContent).toMatch(/Verify live data dir/i);
+
+      // cursor for "IN" must NOT have been advanced by recovery
+      expect(fs.existsSync(path.join(SESSIONS_DIR, "IN.cursor"))).toBe(false);
+    } finally {
+      delete process.env.SUPERBRAIN_DATA_DIR;
+      delete process.env.SUPERBRAIN_VAULT_DIR;
+      delete process.env.SUPERBRAIN_DISTILL_STUB;
+      delete process.env.SUPERBRAIN_EMBED_STUB;
+    }
+  });
+
+  it("second --apply run writes nothing new (idempotent via vault dedup)", async () => {
+    process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+    process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+    process.env.SUPERBRAIN_DISTILL_STUB = STUB_PATH;
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+    writeSession("IDEM", "2026-05-22");
+
+    try {
+      const { distillFromEvents } = await import("../src/distillRun.js");
+      const plan = planRecovery(SESSIONS_DIR, "2026-05-22");
+
+      await applyRecovery(plan, distillFromEvents);
+
+      const lessonsDir = path.join(TMP_VAULT, "lessons");
+      const countAfterFirst = fs.existsSync(lessonsDir)
+        ? fs.readdirSync(lessonsDir).filter((f) => f.endsWith(".md")).length
+        : 0;
+      expect(countAfterFirst).toBeGreaterThan(0);
+
+      const results2 = await applyRecovery(plan, distillFromEvents);
+      const countAfterSecond = fs.readdirSync(lessonsDir).filter((f) => f.endsWith(".md")).length;
+      expect(countAfterSecond).toBe(countAfterFirst);
+      expect(results2[0].notesWritten).toBe(0);
+    } finally {
+      delete process.env.SUPERBRAIN_DATA_DIR;
+      delete process.env.SUPERBRAIN_VAULT_DIR;
+      delete process.env.SUPERBRAIN_DISTILL_STUB;
+      delete process.env.SUPERBRAIN_EMBED_STUB;
+    }
+  });
+});

--- a/tests/sessionStartDigest.test.ts
+++ b/tests/sessionStartDigest.test.ts
@@ -80,6 +80,107 @@ describe("appendDigest — project-aware seed", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Session brief tests
+// ---------------------------------------------------------------------------
+
+describe("appendDigest — project-scoped session brief", () => {
+  let projectDir: string;
+  let readDayMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    projectDir = makeFixtureProject("my-widget");
+    process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+
+    const { readDay } = await import("../src/dailyState.js");
+    readDayMock = readDay as ReturnType<typeof vi.fn>;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+  });
+
+  it("prepends a brief containing the last-session digestLine when project is known", async () => {
+    const { appendDigest } = await import("../src/sessionDigest.js");
+    const slug = path.basename(projectDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+    // today returns nothing; yesterday has a matching entry with a digestLine
+    readDayMock.mockImplementation((date: string) => {
+      const today = new Date().toISOString().slice(0, 10);
+      if (date === today) return {};
+      return {
+        "s1": { digestLine: "Shipped the widget auth flow", routedRelPaths: ["projects/my-widget/auth.md"], alsoDid: [], openThreads: [], project: slug },
+      };
+    });
+
+    const parts: string[] = [];
+    await appendDigest(parts, { cwd: projectDir });
+
+    const brief = parts[0];
+    expect(brief).toBeDefined();
+    expect(brief).toContain("widget auth flow");
+    expect(brief).toMatch(/SuperBrain/);
+    // Brief must be first
+    expect(parts.indexOf(brief)).toBe(0);
+  });
+
+  it("includes recent routed note slugs in the brief when available", async () => {
+    const { appendDigest } = await import("../src/sessionDigest.js");
+    const slug = path.basename(projectDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+    readDayMock.mockImplementation((date: string) => {
+      const today = new Date().toISOString().slice(0, 10);
+      if (date === today) return {};
+      return {
+        "s1": {
+          digestLine: "Refactored widget pipeline",
+          routedRelPaths: ["projects/my-widget/pipeline.md", "projects/my-widget/types.md"],
+          alsoDid: [], openThreads: [], project: slug,
+        },
+      };
+    });
+
+    const parts: string[] = [];
+    await appendDigest(parts, { cwd: projectDir });
+
+    const brief = parts[0];
+    expect(brief).toBeDefined();
+    expect(brief).toContain("pipeline");
+  });
+
+  it("emits no brief when cwd is not a known project", async () => {
+    const { appendDigest } = await import("../src/sessionDigest.js");
+    delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+
+    readDayMock.mockReturnValue({});
+
+    const parts: string[] = [];
+    await appendDigest(parts, { cwd: os.homedir() });
+
+    const brief = parts.find(p => p.startsWith("SuperBrain —") && p.includes("Last session:"));
+    expect(brief).toBeUndefined();
+  });
+
+  it("emits no brief when no prior digestLine is found for this project", async () => {
+    const { appendDigest } = await import("../src/sessionDigest.js");
+    const slug = path.basename(projectDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+    // All days have entries but none have a digestLine for this project
+    readDayMock.mockImplementation((_date: string) => ({
+      "s1": { digestLine: "", routedRelPaths: [], alsoDid: [], openThreads: [], project: slug },
+      "s2": { digestLine: "Other project work", routedRelPaths: [], alsoDid: [], openThreads: [], project: "completely-different" },
+    }));
+
+    const parts: string[] = [];
+    await appendDigest(parts, { cwd: projectDir });
+
+    const brief = parts.find(p => p.includes("Last session:"));
+    expect(brief).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Open-threads scoping tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Part 4 of v0.7.0 (final). Stacked on parts 1-3, which are merged to main.

## User-visible session-start brief (PR-7)
When a session opens in a known project, SuperBrain leads its SessionStart context with a compact, project-scoped brief: the last session's one-line summary for this project plus a few recent note slugs, and a directive so the assistant visibly tells you it loaded the project's context. Budget-capped; degrades silently when there is no project or no prior activity. The scan includes today, so an earlier-today session in the same project is surfaced as the last session.

## Lesson-recovery migration (PR-2)
- Factors `distillFromEvents(sid, events)` out of `runDistill` (cursor and lock handling stay in runDistill; normal behavior unchanged) so a session's full event log can be re-distilled on demand.
- Adds `scripts/recover-lessons.ts`: a manual, idempotent recovery that re-distills sessions on/after a `--since` date (default 2026-05-22) through the now-fixed gate, recovering lessons and captures lost to the pre-0.7 reject regression. Dry-run by default; `--apply` to write; deduped against the vault so re-runs are no-ops; never advances live cursors.

## Tests
Full suite green (typecheck, build, tests, freshCloneE2E); dist in sync. New tests cover the brief and its silent degradation, and the recovery (window filter, ordering, idempotence, cursor protection).
