### PR TITLE
v0.7.0 closeout (1/3): complete recall scoping + remove misattribution root cause + sb-reconcile import-safety

### DIFF
--- a/bin/sb-inject.ts
+++ b/bin/sb-inject.ts
@@ -66,7 +66,7 @@ async function main() {
   }
   try {
     const mod = await import("../src/injectRun.js");
-    const result = await mod.runInject(text, opts);
+    const result = await mod.runInject(text, { ...opts, cwd: process.cwd() });
     if (!result.ok) {
       process.stderr.write(`inject: ${result.message || "failed"}\n`);
       process.exit(2);

--- a/bin/sb-recall.ts
+++ b/bin/sb-recall.ts
@@ -6,6 +6,7 @@ import { pluginRoot } from "../src/paths.js";
 import { getInjectedSlugs, appendInjectedSlugs } from "../src/sessionInjected.js";
 import { logInject } from "../src/injectTelemetry.js";
 import { estimateTokens } from "../src/injectBudget.js";
+import { classifyPath, basenameSlug } from "../src/projectDetect.js";
 
 function readStdin(): string { try { return fs.readFileSync(0, "utf8"); } catch { return ""; } }
 
@@ -17,9 +18,17 @@ async function main() {
     const prompt = (h?.prompt || "").trim();
     if (!prompt) process.exit(0);
     const sid: string = h?.session_id || "";
+    const cwd: string = h?.cwd || "";
     const excludeSlugs = sid ? getInjectedSlugs(sid) : [];
+    let projectSlug: string | undefined;
+    if (cwd) {
+      const classification = classifyPath(cwd);
+      if (classification.kind === "single" || classification.kind === "umbrella") {
+        projectSlug = basenameSlug(classification.projectDir);
+      }
+    }
     const { hybridRecall } = await import("../src/recall.js"); // deferred: only after deps check
-    const hits = await hybridRecall(prompt, 5, { excludeSlugs });
+    const hits = await hybridRecall(prompt, 5, { projectSlug, excludeSlugs });
     if (hits.length) {
       // Record newly injected paths so subsequent UserPromptSubmit calls also exclude them.
       if (sid) {

--- a/bin/sb-reconcile.ts
+++ b/bin/sb-reconcile.ts
@@ -2,9 +2,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { reconcile, forcedReindexIfNeeded } from "../src/indexer.js";
 import { writeFailure } from "../src/sentinel.js";
-import { dataDir } from "../src/paths.js";
+import { depsPresent } from "../src/bootstrap.js";
+import { pluginRoot } from "../src/paths.js";
 
 function resolveVersion(): string {
   try {
@@ -16,11 +16,16 @@ function resolveVersion(): string {
 }
 
 async function main() {
+  if (!depsPresent(pluginRoot())) {
+    process.exit(0);
+  }
   const version = process.env.npm_package_version || resolveVersion();
-  await forcedReindexIfNeeded(version, dataDir()).catch(
+  const { reconcile, forcedReindexIfNeeded } = await import("../src/indexer.js");
+  await forcedReindexIfNeeded(version).catch(
     (e: any) => writeFailure(`forced reindex failed: ${e?.message || e}`)
   );
   await reconcile().catch((e: any) => writeFailure(`reconcile failed: ${e?.message || e}`));
+  process.exit(0);
 }
 
-main().finally(() => process.exit(0));
+main();

--- a/dist/bin/sb-inject.js
+++ b/dist/bin/sb-inject.js
@@ -76,7 +76,7 @@ async function main() {
     }
     try {
         const mod = await import("../src/injectRun.js");
-        const result = await mod.runInject(text, opts);
+        const result = await mod.runInject(text, { ...opts, cwd: process.cwd() });
         if (!result.ok) {
             process.stderr.write(`inject: ${result.message || "failed"}\n`);
             process.exit(2);

--- a/dist/bin/sb-recall.js
+++ b/dist/bin/sb-recall.js
@@ -6,6 +6,7 @@ import { pluginRoot } from "../src/paths.js";
 import { getInjectedSlugs, appendInjectedSlugs } from "../src/sessionInjected.js";
 import { logInject } from "../src/injectTelemetry.js";
 import { estimateTokens } from "../src/injectBudget.js";
+import { classifyPath, basenameSlug } from "../src/projectDetect.js";
 function readStdin() { try {
     return fs.readFileSync(0, "utf8");
 }
@@ -29,9 +30,17 @@ async function main() {
         if (!prompt)
             process.exit(0);
         const sid = h?.session_id || "";
+        const cwd = h?.cwd || "";
         const excludeSlugs = sid ? getInjectedSlugs(sid) : [];
+        let projectSlug;
+        if (cwd) {
+            const classification = classifyPath(cwd);
+            if (classification.kind === "single" || classification.kind === "umbrella") {
+                projectSlug = basenameSlug(classification.projectDir);
+            }
+        }
         const { hybridRecall } = await import("../src/recall.js"); // deferred: only after deps check
-        const hits = await hybridRecall(prompt, 5, { excludeSlugs });
+        const hits = await hybridRecall(prompt, 5, { projectSlug, excludeSlugs });
         if (hits.length) {
             // Record newly injected paths so subsequent UserPromptSubmit calls also exclude them.
             if (sid) {

--- a/dist/bin/sb-reconcile.js
+++ b/dist/bin/sb-reconcile.js
@@ -2,9 +2,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { reconcile, forcedReindexIfNeeded } from "../src/indexer.js";
 import { writeFailure } from "../src/sentinel.js";
-import { dataDir } from "../src/paths.js";
+import { depsPresent } from "../src/bootstrap.js";
+import { pluginRoot } from "../src/paths.js";
 function resolveVersion() {
     try {
         const pkg = JSON.parse(fs.readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "package.json"), "utf8"));
@@ -15,8 +15,13 @@ function resolveVersion() {
     }
 }
 async function main() {
+    if (!depsPresent(pluginRoot())) {
+        process.exit(0);
+    }
     const version = process.env.npm_package_version || resolveVersion();
-    await forcedReindexIfNeeded(version, dataDir()).catch((e) => writeFailure(`forced reindex failed: ${e?.message || e}`));
+    const { reconcile, forcedReindexIfNeeded } = await import("../src/indexer.js");
+    await forcedReindexIfNeeded(version).catch((e) => writeFailure(`forced reindex failed: ${e?.message || e}`));
     await reconcile().catch((e) => writeFailure(`reconcile failed: ${e?.message || e}`));
+    process.exit(0);
 }
-main().finally(() => process.exit(0));
+main();

--- a/dist/src/injectRun.js
+++ b/dist/src/injectRun.js
@@ -13,6 +13,7 @@ import { buildInjectPrompt } from "./injectPrompt.js";
 import { acquireLock, releaseLock } from "./lockfile.js";
 import { resolveLinks } from "./wikilink.js";
 import { claudeP } from "./claudeCli.js";
+import { classifyPath, basenameSlug } from "./projectDetect.js";
 const MAX_INPUT_BYTES = 32 * 1024;
 export function sanityCheck(raw) {
     const stripped = raw.replace(/\0/g, "");
@@ -122,9 +123,16 @@ function callClaudeInject(prompt) {
         return fs.readFileSync(stub, "utf8");
     return claudeP(prompt);
 }
-async function gatherRecall(text) {
+async function gatherRecall(text, cwd) {
     try {
-        return await hybridRecall(text, 5);
+        let projectSlug;
+        if (cwd) {
+            const classification = classifyPath(cwd);
+            if (classification.kind === "single" || classification.kind === "umbrella") {
+                projectSlug = basenameSlug(classification.projectDir);
+            }
+        }
+        return await hybridRecall(text, 5, projectSlug ? { projectSlug } : undefined);
     }
     catch {
         return [];
@@ -205,7 +213,7 @@ export async function runInject(raw, opts = {}) {
             return { ok: true, mode, notes: [rel] };
         }
         // distill mode
-        const recallHits = await gatherRecall(sane.text);
+        const recallHits = await gatherRecall(sane.text, opts.cwd);
         const projectSlugs = listProjectSlugs();
         const prompt = buildInjectPrompt(sane.text, recallHits, projectSlugs);
         let envelope;

--- a/scripts/backfill-frontmatter.ts
+++ b/scripts/backfill-frontmatter.ts
@@ -68,21 +68,19 @@ export function inferType(relPath: string): string | null {
  * Infer the project slug for a note.
  *
  * Rules:
- *   - projects/<name>.md          → <name>
- *   - projects/_archive/<name>-<YYYY>-Q<n>.md → prefix before -<YYYY>
- *   - daily/, people/, meta/      → null (no project)
- *   - others: scan body for a known project name (case-insensitive slug match)
- *   - fallback                    → "global"
+ *   - projects/<name>.md                        → <name>
+ *   - projects/_archive/<name>-<YYYY>-Q<n>.md   → prefix before -<YYYY>
+ *   - daily/, people/, meta/                    → null (no project)
+ *   - all other folders (decisions, lessons, capture, …) → "global"
  */
 export function inferProject(
   relPath: string,
-  body: string,
-  knownProjects: string[]
+  _body: string,
+  _knownProjects: string[]
 ): string | null {
   const parts = relPath.split("/");
   const topFolder = parts[0];
 
-  // No project for these folders
   if (NO_PROJECT_FOLDERS.has(topFolder)) return null;
 
   if (topFolder === "projects") {
@@ -90,25 +88,11 @@ export function inferProject(
 
     // _archive/<name>-<YYYY>-Q<n>.md  or  _archive/<name>-<YYYY>-Q<n>
     if (parts[1] === "_archive") {
-      // Strip suffix: -YYYY-Qn or -YYYY at end
       const slug = basename.replace(/-\d{4}-Q\d+$/, "").replace(/-\d{4}$/, "");
       return slug || basename;
     }
 
     return basename;
-  }
-
-  // For other folders: try to match body against known project slugs
-  if (knownProjects.length > 0) {
-    const lowerBody = body.toLowerCase();
-    for (const proj of knownProjects) {
-      // Match slug as a word boundary (handle hyphens in slug)
-      const pattern = proj.toLowerCase().replace(/-/g, "[- ]");
-      const re = new RegExp(`(?<![a-z0-9])${pattern}(?![a-z0-9])`, "i");
-      if (re.test(lowerBody)) {
-        return proj;
-      }
-    }
   }
 
   return "global";
@@ -283,13 +267,7 @@ export function planBackfill(vaultDir: string): BackfillProposal[] {
     const needsProject = !NO_PROJECT_FOLDERS.has(effectiveFolder) && effectiveType !== "daily";
 
     if (needsProject && !fm?.["project"]) {
-      // Extract body content (after frontmatter)
-      let body = "";
-      if (raw.startsWith("---")) {
-        const endIdx = raw.indexOf("\n---", 3);
-        if (endIdx !== -1) body = raw.slice(endIdx + 4);
-      }
-      const inferredProject = inferProject(relPath, body, knownProjects);
+      const inferredProject = inferProject(relPath, "", knownProjects);
       if (inferredProject !== null) {
         changes.push({ field: "project", value: inferredProject });
       }

--- a/src/injectRun.ts
+++ b/src/injectRun.ts
@@ -13,11 +13,13 @@ import { buildInjectPrompt } from "./injectPrompt.js";
 import { acquireLock, releaseLock } from "./lockfile.js";
 import { resolveLinks } from "./wikilink.js";
 import { claudeP } from "./claudeCli.js";
+import { classifyPath, basenameSlug } from "./projectDetect.js";
 
 export interface InjectOpts {
   verbatim?: boolean;
   distill?: boolean;
   project?: string;
+  cwd?: string;
 }
 
 export type SanityResult =
@@ -143,8 +145,17 @@ function callClaudeInject(prompt: string): string {
   return claudeP(prompt);
 }
 
-async function gatherRecall(text: string): Promise<Pointer[]> {
-  try { return await hybridRecall(text, 5); } catch { return []; }
+async function gatherRecall(text: string, cwd?: string): Promise<Pointer[]> {
+  try {
+    let projectSlug: string | undefined;
+    if (cwd) {
+      const classification = classifyPath(cwd);
+      if (classification.kind === "single" || classification.kind === "umbrella") {
+        projectSlug = basenameSlug(classification.projectDir);
+      }
+    }
+    return await hybridRecall(text, 5, projectSlug ? { projectSlug } : undefined);
+  } catch { return []; }
 }
 
 function buildVerbatimItem(text: string, opts: InjectOpts): DistilledItem {
@@ -229,7 +240,7 @@ export async function runInject(raw: string, opts: InjectOpts = {}): Promise<Inj
     }
 
     // distill mode
-    const recallHits = await gatherRecall(sane.text);
+    const recallHits = await gatherRecall(sane.text, opts.cwd);
     const projectSlugs = listProjectSlugs();
     const prompt = buildInjectPrompt(sane.text, recallHits, projectSlugs);
     let envelope;

--- a/tests/backfillFrontmatter.test.ts
+++ b/tests/backfillFrontmatter.test.ts
@@ -86,27 +86,24 @@ describe("inferProject", () => {
     expect(inferProject("meta/preferences.md", "", knownProjects)).toBeNull();
   });
 
-  it("decisions/ with body mentioning a known project → that project", () => {
-    const body = "We decided to use TypeScript for theweproject frontend.";
-    expect(inferProject("decisions/2026-05-20-foo.md", body, knownProjects)).toBe("theweproject");
+  it("decisions/ → global (not derived from body)", () => {
+    const bodyWithSlug = "We decided to use TypeScript for theweproject frontend.";
+    expect(inferProject("decisions/2026-05-20-foo.md", bodyWithSlug, knownProjects)).toBe("global");
   });
 
-  it("decisions/ with body mentioning project in different case → that project", () => {
-    const body = "Related to Superbrain indexing pipeline.";
-    expect(inferProject("decisions/2026-05-20-foo.md", body, knownProjects)).toBe("superbrain");
+  it("lessons/ → global regardless of body content", () => {
+    const bodyWithSlug = "Related to Superbrain indexing pipeline.";
+    expect(inferProject("lessons/some-lesson.md", bodyWithSlug, knownProjects)).toBe("global");
   });
 
-  it("decisions/ with no body match → global", () => {
-    expect(inferProject("decisions/2026-05-20-foo.md", "generic content here", knownProjects)).toBe("global");
+  it("capture/ body mentioning a slug → global (no body scan)", () => {
+    const bodyWithSlug = "Working on lean-ctx today, got some ideas.";
+    expect(inferProject("capture/idea.md", bodyWithSlug, knownProjects)).toBe("global");
   });
 
-  it("lessons/ with no body match → global", () => {
-    expect(inferProject("lessons/some-lesson.md", "some content", knownProjects)).toBe("global");
-  });
-
-  it("capture/ with body matching a known project → that project", () => {
-    const body = "Working on lean-ctx today, got some ideas.";
-    expect(inferProject("capture/idea.md", body, knownProjects)).toBe("lean-ctx");
+  it("capture/ body containing inject marker mentioning a project → global, not that project", () => {
+    const bodyWithMarker = "<!-- superbrain:inject project=superbrain -->\nsome content about lean-ctx";
+    expect(inferProject("capture/idea.md", bodyWithMarker, knownProjects)).toBe("global");
   });
 
   it("empty knownProjects → global", () => {
@@ -258,13 +255,24 @@ describe("planBackfill", () => {
     }
   });
 
-  it("infers project from body mention for capture/ note", () => {
+  it("capture/ body mentioning a known project slug → project is global, not the slug", () => {
     writeNote("projects/superbrain.md", `---\ntype: project\nproject: superbrain\n---\n\n`);
     writeNote("capture/idea.md", `---\n---\n\nIdeas for Superbrain indexing.\n`);
     const proposals = planBackfill(tmpDir);
     const p = proposals.find(p => p.file.includes("idea.md"));
     expect(p).toBeDefined();
-    expect(p!.changes.some(c => c.field === "project" && c.value === "superbrain")).toBe(true);
+    expect(p!.changes.some(c => c.field === "project" && c.value === "global")).toBe(true);
+    expect(p!.changes.some(c => c.field === "project" && c.value === "superbrain")).toBe(false);
+  });
+
+  it("capture/ body containing inject marker → project is global, not the marker's project", () => {
+    writeNote("projects/superbrain.md", `---\ntype: project\nproject: superbrain\n---\n\n`);
+    writeNote("capture/injected.md", `---\n---\n\n<!-- superbrain:inject project=superbrain -->\nsome content\n`);
+    const proposals = planBackfill(tmpDir);
+    const p = proposals.find(p => p.file.includes("injected.md"));
+    expect(p).toBeDefined();
+    expect(p!.changes.some(c => c.field === "project" && c.value === "global")).toBe(true);
+    expect(p!.changes.some(c => c.field === "project" && c.value === "superbrain")).toBe(false);
   });
 
   it("returns no proposals for an empty vault", () => {

--- a/tests/freshCloneE2E.test.ts
+++ b/tests/freshCloneE2E.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 it("every hook entrypoint loads + exits 0 with NO node_modules; SessionStart bootstraps", () => {
   const env = { ...process.env, CLAUDE_PLUGIN_ROOT: CLONE, SUPERBRAIN_DATA_DIR: TMP_DATA,
     SUPERBRAIN_BOOTSTRAP_FAKE: "1", SUPERBRAIN_FAKE_DISTILLER: "1" };
-  for (const b of ["sb-observe", "sb-checkpoint", "sb-recall", "sb-distill"]) {
+  for (const b of ["sb-observe", "sb-checkpoint", "sb-recall", "sb-distill", "sb-reconcile"]) {
     const r = execFileSync(process.execPath, [path.join(CLONE, "dist/bin", `${b}.js`)], {
       input: JSON.stringify({ session_id: "S", prompt: "x", hook_event_name: "Stop" }),
       env, encoding: "utf8" }); // must not throw

--- a/tests/injectRunRecallScope.test.ts
+++ b/tests/injectRunRecallScope.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../src/recall.js", () => ({
+  hybridRecall: vi.fn().mockResolvedValue([]),
+}));
+
+// Keep other injectRun deps quiet
+vi.mock("../src/preferences.js", () => ({ compileInjectionBlock: vi.fn().mockReturnValue("") }));
+vi.mock("../src/dailyState.js", () => ({ readDay: vi.fn().mockReturnValue({}), upsertDay: vi.fn() }));
+
+let TMP: string;
+let PROJECT_DIR: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-inject-scope-"));
+  fs.mkdirSync(path.join(TMP, "data"), { recursive: true });
+  fs.mkdirSync(path.join(TMP, "vault"), { recursive: true });
+
+  process.env.SUPERBRAIN_DATA_DIR = path.join(TMP, "data");
+  process.env.SUPERBRAIN_VAULT_DIR = path.join(TMP, "vault");
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+  process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+
+  PROJECT_DIR = path.join(TMP, "alpha-svc");
+  fs.mkdirSync(PROJECT_DIR, { recursive: true });
+  fs.writeFileSync(path.join(PROJECT_DIR, "package.json"), '{"name":"alpha-svc"}');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+  delete process.env.SUPERBRAIN_DISTILL_STUB;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("runInject — gatherRecall project scoping", () => {
+  it("passes projectSlug to hybridRecall when opts.cwd resolves to a known project", async () => {
+    const { hybridRecall } = await import("../src/recall.js");
+    const { runInject } = await import("../src/injectRun.js");
+
+    // Short text → verbatim mode (no recall call). Use long text to trigger distill,
+    // but stub the LLM so it returns quickly.
+    const stub = path.join(TMP, "data", "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({ items: [] }));
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const longText = "alpha-svc recall scoping test " + "x".repeat(200);
+    await runInject(longText, { cwd: PROJECT_DIR });
+
+    expect(hybridRecall).toHaveBeenCalled();
+    const calls = (hybridRecall as ReturnType<typeof vi.fn>).mock.calls;
+    const recallCall = calls.find(([_text, _k, opts]: any[]) => opts !== undefined);
+    expect(recallCall).toBeDefined();
+    const opts = recallCall![2];
+    expect(opts?.projectSlug).toBe("alpha-svc");
+  });
+
+  it("omits projectSlug from hybridRecall when opts.cwd has no strong project signal", async () => {
+    const { hybridRecall } = await import("../src/recall.js");
+    const { runInject } = await import("../src/injectRun.js");
+
+    const stub = path.join(TMP, "data", "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({ items: [] }));
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const noProjectDir = path.join(TMP, "no-manifest");
+    fs.mkdirSync(noProjectDir, { recursive: true });
+
+    const longText = "cross-project recall test " + "y".repeat(200);
+    await runInject(longText, { cwd: noProjectDir });
+
+    if ((hybridRecall as ReturnType<typeof vi.fn>).mock.calls.length > 0) {
+      const calls = (hybridRecall as ReturnType<typeof vi.fn>).mock.calls;
+      for (const call of calls) {
+        const opts = call[2];
+        expect(opts?.projectSlug).toBeUndefined();
+      }
+    }
+  });
+
+  it("omits projectSlug from hybridRecall when no cwd provided", async () => {
+    const { hybridRecall } = await import("../src/recall.js");
+    const { runInject } = await import("../src/injectRun.js");
+
+    const stub = path.join(TMP, "data", "stub.json");
+    fs.writeFileSync(stub, JSON.stringify({ items: [] }));
+    process.env.SUPERBRAIN_DISTILL_STUB = stub;
+
+    const longText = "no-cwd recall test " + "z".repeat(200);
+    await runInject(longText, {});
+
+    if ((hybridRecall as ReturnType<typeof vi.fn>).mock.calls.length > 0) {
+      const calls = (hybridRecall as ReturnType<typeof vi.fn>).mock.calls;
+      for (const call of calls) {
+        const opts = call[2];
+        expect(opts?.projectSlug).toBeUndefined();
+      }
+    }
+  });
+});

--- a/tests/sbRecallProjectScope.test.ts
+++ b/tests/sbRecallProjectScope.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { openIndex } from "../src/searchIndex";
+
+let TMP: string;
+let PROJECT_DIR: string;
+let OTHER_DIR: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-recall-scope-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+  process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+
+  // Two temp project dirs each with a strong-signal file so classifyPath sees them
+  PROJECT_DIR = path.join(TMP, "my-project");
+  OTHER_DIR = path.join(TMP, "other-project");
+  fs.mkdirSync(PROJECT_DIR, { recursive: true });
+  fs.mkdirSync(OTHER_DIR, { recursive: true });
+  fs.writeFileSync(path.join(PROJECT_DIR, "package.json"), '{"name":"my-project"}');
+  fs.writeFileSync(path.join(OTHER_DIR, "package.json"), '{"name":"other-project"}');
+
+  // Seed: one note scoped to "my-project", one scoped to "other-project"
+  const ix = openIndex();
+  ix.upsertNote(
+    "projects/my-project.md", 1, "h-mp",
+    [{ headingPath: "", anchor: "root", text: "hybrid recall fusion RRF my-project specifics" }],
+    [Float32Array.from(Array(384).fill(0.4))],
+    "my-project",
+  );
+  ix.upsertNote(
+    "projects/other-project.md", 1, "h-op",
+    [{ headingPath: "", anchor: "root", text: "hybrid recall fusion RRF other-project specifics" }],
+    [Float32Array.from(Array(384).fill(0.4))],
+    "other-project",
+  );
+  ix.close();
+});
+
+afterEach(() => {
+  delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+function run(hook: object) {
+  return execFileSync("npx", ["tsx", "bin/sb-recall.ts"], {
+    input: JSON.stringify(hook),
+    env: { ...process.env },
+    encoding: "utf8",
+  });
+}
+
+describe("sb-recall project scoping", () => {
+  it("injects only the current-project note when cwd resolves to a known project", () => {
+    const out = run({
+      session_id: "S1",
+      hook_event_name: "UserPromptSubmit",
+      cwd: PROJECT_DIR,
+      prompt: "hybrid recall fusion RRF",
+    });
+    expect(out).toMatch(/my-project/);
+    expect(out).not.toMatch(/other-project/);
+  });
+
+  it("does not filter cross-project notes when cwd has no project signal", () => {
+    const noProjectDir = path.join(TMP, "no-manifest");
+    fs.mkdirSync(noProjectDir, { recursive: true });
+    const out = run({
+      session_id: "S2",
+      hook_event_name: "UserPromptSubmit",
+      cwd: noProjectDir,
+      prompt: "hybrid recall fusion RRF",
+    });
+    // Both notes should appear since no project slug is resolved
+    expect(out).toMatch(/my-project|other-project/);
+  });
+
+  it("exits cleanly with no output when cwd field is missing and prompt has no index match", () => {
+    const out = run({
+      session_id: "S3",
+      hook_event_name: "UserPromptSubmit",
+      prompt: "zzz-no-match-xyz-unique-1234",
+    });
+    expect(out.trim()).toBe("");
+  });
+});

--- a/tests/sbReconcileNoDeps.test.ts
+++ b/tests/sbReconcileNoDeps.test.ts
@@ -1,0 +1,28 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP_DATA: string;
+let TMP_EMPTY: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rnd-data-"));
+  TMP_EMPTY = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rnd-empty-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_EMPTY, { recursive: true, force: true });
+});
+
+it("sb-reconcile exits 0 cleanly when deps absent", () => {
+  execFileSync("npx", ["tsx", "bin/sb-reconcile.ts"], {
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA,
+      CLAUDE_PLUGIN_ROOT: TMP_EMPTY },
+    encoding: "utf8",
+  });
+  // no sentinel written when deps simply absent
+  expect(fs.existsSync(path.join(TMP_DATA, "last-failure.txt"))).toBe(false);
+});


### PR DESCRIPTION
Closeout part 1 of 3, addressing the conformance review's P0 and two P1 items.

## Complete project-scoped recall (P0)
Recall scoping was wired into SessionStart only; the per-prompt recall (`bin/sb-recall.ts`) and inject recall (`src/injectRun.ts`) called `hybridRecall` without `projectSlug`, so cross-project notes could still leak mid-session. Both now resolve the cwd's project via `classifyPath` and pass `projectSlug` (`bin/sb-inject.ts` passes `process.cwd()`). The MCP `superbrain_search` stays vault-wide (user-initiated, intentional). This completes the #42 cross-project fix beyond session start.

## Remove the misattribution root cause (P1)
`scripts/backfill-frontmatter.ts` no longer infers a note's project by scanning its body (which matched the `<!-- superbrain:inject -->` provenance marker and incidental mentions). Path-derivable projects are kept; other notes default to `global` instead of a body guess. Tests confirm the inject marker no longer mislabels.

## sb-reconcile import-safety (P1)
`bin/sb-reconcile.ts` now follows the `sb-distill` idiom: only light modules at the top level, a `depsPresent()` gate first, then a dynamic import of the indexer. Added to `freshCloneE2E` plus a dedicated no-deps test.

## Tests
614 pass (101 files); typecheck clean; build clean; `dist` in sync; `freshCloneE2E` green.
