### PR TITLE
v0.7.0 closeout: upgrade migration + multi-cwd attribution

### DIFF
--- a/bin/sb-doctor.ts
+++ b/bin/sb-doctor.ts
@@ -88,6 +88,9 @@ const MIGRATION_STEPS: MigrationStep[] = [
   { name: "retro-collapse-duplicates",   script: "scripts/retro-collapse-duplicates.ts" },
   { name: "migrate-vault",               script: "scripts/migrate-vault.ts" },
   { name: "retro-prune-preferences",     script: "scripts/retro-prune-preferences.ts" },
+  { name: "reattribute-from-history",    script: "scripts/reattribute-from-history.ts" },
+  { name: "cleanup-daily-mirrors",       script: "scripts/cleanup-daily-mirrors.ts" },
+  { name: "recover-lessons",             script: "scripts/recover-lessons.ts" },
 ];
 
 function pluginRoot(): string {
@@ -132,7 +135,7 @@ async function migrateAll(): Promise<void> {
 
   // Prompt for confirmation
   const answer = await new Promise<string>((resolve) => {
-    process.stdout.write("Apply all 4 steps? [y/N]: ");
+    process.stdout.write(`Apply all ${MIGRATION_STEPS.length} steps? [y/N]: `);
     let buf = "";
     let resolved = false;
     function onData(chunk: Buffer | string) {

--- a/bin/sb-reconcile.ts
+++ b/bin/sb-reconcile.ts
@@ -24,6 +24,11 @@ async function main() {
   await forcedReindexIfNeeded(version).catch(
     (e: any) => writeFailure(`forced reindex failed: ${e?.message || e}`)
   );
+  const { runCheapUpgradeSteps } = await import("../src/autoUpgrade.js");
+  const { dataDir } = await import("../src/paths.js");
+  await runCheapUpgradeSteps(dataDir(), version).catch(
+    (e: any) => writeFailure(`auto-upgrade failed: ${e?.message || e}`)
+  );
   await reconcile().catch((e: any) => writeFailure(`reconcile failed: ${e?.message || e}`));
   process.exit(0);
 }

--- a/dist/bin/sb-doctor.js
+++ b/dist/bin/sb-doctor.js
@@ -76,6 +76,9 @@ const MIGRATION_STEPS = [
     { name: "retro-collapse-duplicates", script: "scripts/retro-collapse-duplicates.ts" },
     { name: "migrate-vault", script: "scripts/migrate-vault.ts" },
     { name: "retro-prune-preferences", script: "scripts/retro-prune-preferences.ts" },
+    { name: "reattribute-from-history", script: "scripts/reattribute-from-history.ts" },
+    { name: "cleanup-daily-mirrors", script: "scripts/cleanup-daily-mirrors.ts" },
+    { name: "recover-lessons", script: "scripts/recover-lessons.ts" },
 ];
 function pluginRoot() {
     // dist/bin/sb-doctor.js → plugin root is 2 dirs up
@@ -119,7 +122,7 @@ async function migrateAll() {
     }
     // Prompt for confirmation
     const answer = await new Promise((resolve) => {
-        process.stdout.write("Apply all 4 steps? [y/N]: ");
+        process.stdout.write(`Apply all ${MIGRATION_STEPS.length} steps? [y/N]: `);
         let buf = "";
         let resolved = false;
         function onData(chunk) {

--- a/dist/bin/sb-reconcile.js
+++ b/dist/bin/sb-reconcile.js
@@ -21,6 +21,9 @@ async function main() {
     const version = process.env.npm_package_version || resolveVersion();
     const { reconcile, forcedReindexIfNeeded } = await import("../src/indexer.js");
     await forcedReindexIfNeeded(version).catch((e) => writeFailure(`forced reindex failed: ${e?.message || e}`));
+    const { runCheapUpgradeSteps } = await import("../src/autoUpgrade.js");
+    const { dataDir } = await import("../src/paths.js");
+    await runCheapUpgradeSteps(dataDir(), version).catch((e) => writeFailure(`auto-upgrade failed: ${e?.message || e}`));
     await reconcile().catch((e) => writeFailure(`reconcile failed: ${e?.message || e}`));
     process.exit(0);
 }

--- a/dist/scripts/cleanup-daily-mirrors.js
+++ b/dist/scripts/cleanup-daily-mirrors.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env -S node --experimental-strip-types
+// scripts/cleanup-daily-mirrors.ts
+//
+// Non-destructive migration: remove legacy "daily-mirror" capture notes left
+// by the now-removed daily-rollup synthesizer, and strip dangling links to them.
+//
+// Mirror notes match the pattern: capture/<YYYY-MM-DD>-daily-<YYYY-MM-DD>.md
+//
+// Usage:
+//   npx tsx scripts/cleanup-daily-mirrors.ts <vault-dir>          # dry-run
+//   npx tsx scripts/cleanup-daily-mirrors.ts <vault-dir> --apply  # write
+import fs from "node:fs";
+import path from "node:path";
+// ---------------------------------------------------------------------------
+// Mirror detection
+// ---------------------------------------------------------------------------
+const MIRROR_BASENAME_RE = /^\d{4}-\d{2}-\d{2}-daily-\d{4}-\d{2}-\d{2}$/;
+const SKIP_DIRS = new Set([".trash", ".obsidian", ".git", "node_modules"]);
+export function isMirrorNote(relPath) {
+    const parts = relPath.split("/");
+    if (parts.length < 2)
+        return false;
+    if (parts[0] !== "capture")
+        return false;
+    const basename = path.basename(relPath, ".md");
+    return MIRROR_BASENAME_RE.test(basename);
+}
+// ---------------------------------------------------------------------------
+// Vault walker
+// ---------------------------------------------------------------------------
+function walkVault(vaultDir) {
+    const files = [];
+    function walk(dir) {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            if (entry.isDirectory()) {
+                if (SKIP_DIRS.has(entry.name))
+                    continue;
+                walk(path.join(dir, entry.name));
+            }
+            else if (entry.isFile() && entry.name.endsWith(".md")) {
+                files.push(path.join(dir, entry.name));
+            }
+        }
+    }
+    walk(vaultDir);
+    return files;
+}
+// ---------------------------------------------------------------------------
+// Link removal
+// ---------------------------------------------------------------------------
+function buildLinkPattern(mirrorSlugs) {
+    if (mirrorSlugs.length === 0)
+        return null;
+    const escaped = mirrorSlugs.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    const inner = escaped.join("|");
+    return new RegExp(`\\[\\[(${inner})(?:[#|][^\\]]*)?\\]\\]`, "g");
+}
+// ---------------------------------------------------------------------------
+// Plan
+// ---------------------------------------------------------------------------
+export function planCleanup(vaultDir) {
+    const allFiles = walkVault(vaultDir);
+    const mirrors = [];
+    for (const file of allFiles) {
+        const relPath = path.relative(vaultDir, file).replace(/\\/g, "/");
+        if (isMirrorNote(relPath)) {
+            mirrors.push({ file, relPath, basename: path.basename(relPath, ".md") });
+        }
+    }
+    const mirrorSlugs = mirrors.map(m => `capture/${m.basename}`);
+    const linkPattern = buildLinkPattern(mirrorSlugs);
+    const linkPatches = [];
+    if (linkPattern) {
+        for (const file of allFiles) {
+            const relPath = path.relative(vaultDir, file).replace(/\\/g, "/");
+            if (mirrors.some(m => m.file === file))
+                continue;
+            const content = fs.readFileSync(file, "utf8");
+            if (!linkPattern.test(content))
+                continue;
+            linkPattern.lastIndex = 0;
+            const newContent = content.replace(linkPattern, "");
+            linkPatches.push({ file, relPath, newContent });
+        }
+    }
+    return { mirrors, linkPatches };
+}
+// ---------------------------------------------------------------------------
+// Apply
+// ---------------------------------------------------------------------------
+export function applyCleanup(vaultDir, plan) {
+    const trashDir = path.join(vaultDir, ".trash");
+    fs.mkdirSync(trashDir, { recursive: true });
+    const timestamp = Date.now();
+    for (const mirror of plan.mirrors) {
+        const dest = path.join(trashDir, `${timestamp}-${mirror.basename}.md`);
+        fs.renameSync(mirror.file, dest);
+    }
+    for (const patch of plan.linkPatches) {
+        fs.writeFileSync(patch.file, patch.newContent, "utf8");
+    }
+}
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+function main() {
+    const args = process.argv.slice(2);
+    const apply = args.includes("--apply");
+    const vault = args.find(a => !a.startsWith("--")) || process.env["SUPERBRAIN_VAULT_DIR"];
+    if (!vault) {
+        console.error("usage: cleanup-daily-mirrors.ts <vault-dir> [--apply]");
+        process.exit(1);
+    }
+    if (!fs.existsSync(vault)) {
+        console.error(`Vault not found: ${vault}`);
+        process.exit(1);
+    }
+    const plan = planCleanup(vault);
+    if (plan.mirrors.length === 0 && plan.linkPatches.length === 0) {
+        console.log("No daily-mirror notes found. Nothing to do.");
+        return;
+    }
+    if (!apply) {
+        console.log(`Dry-run: would soft-delete ${plan.mirrors.length} mirror note(s) and patch ${plan.linkPatches.length} file(s)`);
+        for (const m of plan.mirrors) {
+            console.log(`  trash: ${m.relPath}`);
+        }
+        for (const p of plan.linkPatches) {
+            console.log(`  patch: ${p.relPath}`);
+        }
+        console.log("\n(Dry-run. Use --apply to write changes.)");
+    }
+    else {
+        applyCleanup(vault, plan);
+        console.log(`Soft-deleted ${plan.mirrors.length} mirror note(s), patched ${plan.linkPatches.length} file(s).`);
+    }
+}
+if (process.argv[1]?.endsWith("cleanup-daily-mirrors.ts") ||
+    process.argv[1]?.endsWith("cleanup-daily-mirrors.js")) {
+    main();
+}

--- a/dist/src/autoUpgrade.js
+++ b/dist/src/autoUpgrade.js
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+import { vaultPath } from "./paths.js";
+import { planReattribution, applyReattribution } from "./reattributeFromHistory.js";
+import { planCleanup, applyCleanup } from "../scripts/cleanup-daily-mirrors.js";
+import { writeFailure } from "./sentinel.js";
+export function upgradeSentinelPath(dataDir, version) {
+    return path.join(dataDir, `upgraded-${version}`);
+}
+export async function runCheapUpgradeSteps(dataDir, version) {
+    const sentinel = upgradeSentinelPath(dataDir, version);
+    if (fs.existsSync(sentinel))
+        return;
+    try {
+        const reattribPlan = planReattribution(dataDir);
+        applyReattribution(reattribPlan);
+    }
+    catch (e) {
+        writeFailure(`auto-upgrade reattribute failed: ${e?.message || e}`);
+    }
+    try {
+        const vault = vaultPath();
+        if (fs.existsSync(vault)) {
+            const mirrorPlan = planCleanup(vault);
+            applyCleanup(vault, mirrorPlan);
+        }
+    }
+    catch (e) {
+        writeFailure(`auto-upgrade cleanup-daily-mirrors failed: ${e?.message || e}`);
+    }
+    try {
+        fs.mkdirSync(path.dirname(sentinel), { recursive: true });
+        fs.writeFileSync(sentinel, new Date().toISOString() + "\n", "utf8");
+    }
+    catch (e) {
+        writeFailure(`auto-upgrade sentinel write failed: ${e?.message || e}`);
+    }
+}

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -168,6 +168,10 @@ EXAMPLE lesson (structured fields, traced to an incident, with whenApplies):
 
 {"items": [ <items as above> ], "digest"?: "<=1 sentence of the session's arc", "openThreads"?: ["unfinished/deferred work"], "alsoDid"?: ["notable work that did not become a knowledge item"]}
 
+# Multi-repo sessions
+
+When the events span more than one repo (multiple distinct cwd values), set each item's "project" to the repo its work belongs to — the events carry cwd so the correct repo is usually clear. Do not leave "project" unset when the repo is identifiable from the events. A wrong label is worse than a null one, so if the item's repo is genuinely ambiguous, omit "project" rather than guessing.
+
 # Events
 
 `;
@@ -221,7 +225,7 @@ export async function distillFromEvents(sid, events) {
     const routedByDate = {};
     let notesWritten = 0;
     for (const it of items) {
-        if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.dominant) {
+        if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.all.length === 1 && sessionProj.dominant) {
             it.project = sessionProj.dominant;
         }
         else if (it.project) {

--- a/dist/src/reattributeFromHistory.js
+++ b/dist/src/reattributeFromHistory.js
@@ -1,0 +1,162 @@
+import fs from "node:fs";
+import path from "node:path";
+import { vaultPath } from "./paths.js";
+import { parseNote, serializeNote } from "./frontmatter.js";
+import { classifyPath, basenameSlug } from "./projectDetect.js";
+const SKIP_DIRS = new Set([".trash", ".obsidian", ".git", "node_modules"]);
+function walkVault(vaultDir) {
+    const files = [];
+    function walk(dir) {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            if (entry.isDirectory()) {
+                if (SKIP_DIRS.has(entry.name))
+                    continue;
+                walk(path.join(dir, entry.name));
+            }
+            else if (entry.isFile() && entry.name.endsWith(".md")) {
+                files.push(path.join(dir, entry.name));
+            }
+        }
+    }
+    walk(vaultDir);
+    return files;
+}
+function knownProjectSlugs(vaultDir) {
+    const projectsDir = path.join(vaultDir, "projects");
+    const slugs = new Set();
+    if (!fs.existsSync(projectsDir))
+        return slugs;
+    for (const entry of fs.readdirSync(projectsDir, { withFileTypes: true })) {
+        if (entry.isFile() && entry.name.endsWith(".md")) {
+            slugs.add(path.basename(entry.name, ".md"));
+        }
+    }
+    return slugs;
+}
+const VALID_SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+function isJunkProject(project, validSlugs) {
+    if (project === undefined || project === null || project === "")
+        return true;
+    if (project === "global")
+        return false;
+    if (project.includes("/") || project.includes(","))
+        return true;
+    if (validSlugs.has(project))
+        return false;
+    if (VALID_SLUG_RE.test(project))
+        return false;
+    return true;
+}
+function resolveProjectFromSessions(sessionIds, sessionsDir) {
+    const countBySlug = new Map();
+    for (const sid of sessionIds) {
+        const ndjsonPath = path.join(sessionsDir, `${sid}.ndjson`);
+        if (!fs.existsSync(ndjsonPath))
+            continue;
+        let raw;
+        try {
+            raw = fs.readFileSync(ndjsonPath, "utf8");
+        }
+        catch {
+            continue;
+        }
+        for (const line of raw.split("\n").filter(Boolean)) {
+            let event;
+            try {
+                event = JSON.parse(line);
+            }
+            catch {
+                continue;
+            }
+            const cwd = event?.cwd;
+            if (!cwd || typeof cwd !== "string")
+                continue;
+            const c = classifyPath(cwd);
+            if (c.kind === "blocked" || c.kind === "skip")
+                continue;
+            const s = basenameSlug(c.projectDir);
+            countBySlug.set(s, (countBySlug.get(s) ?? 0) + 1);
+        }
+    }
+    if (countBySlug.size === 0)
+        return undefined;
+    let dominant;
+    let max = 0;
+    for (const [s, count] of countBySlug) {
+        if (count > max) {
+            dominant = s;
+            max = count;
+        }
+    }
+    return dominant;
+}
+export function planReattribution(dataDir) {
+    const vault = vaultPath();
+    const dailyDir = path.join(dataDir, "daily");
+    const sessionsDir = path.join(dataDir, "sessions");
+    const noteToSessions = new Map();
+    if (fs.existsSync(dailyDir)) {
+        for (const entry of fs.readdirSync(dailyDir)) {
+            if (!entry.endsWith(".json"))
+                continue;
+            let state;
+            try {
+                state = JSON.parse(fs.readFileSync(path.join(dailyDir, entry), "utf8"));
+            }
+            catch {
+                continue;
+            }
+            for (const [sid, dayEntry] of Object.entries(state)) {
+                for (const relPath of dayEntry?.routedRelPaths ?? []) {
+                    const existing = noteToSessions.get(relPath) ?? [];
+                    existing.push(sid);
+                    noteToSessions.set(relPath, existing);
+                }
+            }
+        }
+    }
+    const validSlugs = knownProjectSlugs(vault);
+    const fixes = [];
+    if (!fs.existsSync(vault))
+        return { fixes };
+    for (const absPath of walkVault(vault)) {
+        const relPath = path.relative(vault, absPath).replace(/\\/g, "/");
+        let raw;
+        try {
+            raw = fs.readFileSync(absPath, "utf8");
+        }
+        catch {
+            continue;
+        }
+        const { data } = parseNote(raw);
+        const project = typeof data.project === "string" ? data.project : undefined;
+        if (!isJunkProject(project, validSlugs))
+            continue;
+        const sessionIds = noteToSessions.get(relPath) ?? [];
+        if (sessionIds.length === 0)
+            continue;
+        const newProject = resolveProjectFromSessions(sessionIds, sessionsDir);
+        if (!newProject)
+            continue;
+        fixes.push({ relPath, absPath, oldProject: project, newProject });
+    }
+    return { fixes };
+}
+export function applyReattribution(plan) {
+    for (const fix of plan.fixes) {
+        let raw;
+        try {
+            raw = fs.readFileSync(fix.absPath, "utf8");
+        }
+        catch {
+            continue;
+        }
+        const { data, content } = parseNote(raw);
+        data.project = fix.newProject;
+        const newRaw = serializeNote(data, content);
+        try {
+            fs.writeFileSync(fix.absPath, newRaw, "utf8");
+        }
+        catch { /* best-effort */ }
+    }
+}

--- a/scripts/reattribute-from-history.ts
+++ b/scripts/reattribute-from-history.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env -S node --experimental-strip-types
+// scripts/reattribute-from-history.ts
+//
+// Migration: re-derive the project field on vault notes whose project frontmatter
+// is missing or junk, using cwd recorded in the session ndjson files that wrote
+// those notes.
+//
+// Usage:
+//   npx tsx scripts/reattribute-from-history.ts [--data-dir <path>]          # dry-run
+//   npx tsx scripts/reattribute-from-history.ts [--data-dir <path>] --apply  # write
+
+import fs from "node:fs";
+import path from "node:path";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+
+  const dataDirIdx = args.indexOf("--data-dir");
+  let resolvedDataDir: string;
+  if (dataDirIdx >= 0 && args[dataDirIdx + 1]) {
+    resolvedDataDir = args[dataDirIdx + 1];
+  } else {
+    const { dataDir } = await import("../src/paths.js");
+    resolvedDataDir = dataDir();
+  }
+
+  if (!fs.existsSync(resolvedDataDir)) {
+    console.log(`Data dir not found: ${resolvedDataDir}. Nothing to do.`);
+    return;
+  }
+
+  const { planReattribution, applyReattribution } = await import("../src/reattributeFromHistory.js");
+  const plan = planReattribution(resolvedDataDir);
+
+  if (plan.fixes.length === 0) {
+    console.log("No notes with missing or junk project found. Nothing to do.");
+    return;
+  }
+
+  if (!apply) {
+    console.log(`Dry-run: would re-attribute ${plan.fixes.length} note(s)`);
+    for (const fix of plan.fixes) {
+      const was = fix.oldProject === undefined ? "(missing)" : `"${fix.oldProject}"`;
+      console.log(`  ${fix.relPath}: ${was} → "${fix.newProject}"`);
+    }
+    console.log("\n(Dry-run. Use --apply to write changes.)");
+  } else {
+    applyReattribution(plan);
+    console.log(`Re-attributed ${plan.fixes.length} note(s).`);
+    for (const fix of plan.fixes) {
+      const was = fix.oldProject === undefined ? "(missing)" : `"${fix.oldProject}"`;
+      console.log(`  ${fix.relPath}: ${was} → "${fix.newProject}"`);
+    }
+  }
+}
+
+if (
+  process.argv[1]?.endsWith("reattribute-from-history.ts") ||
+  process.argv[1]?.endsWith("reattribute-from-history.js")
+) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/src/autoUpgrade.ts
+++ b/src/autoUpgrade.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+import { vaultPath } from "./paths.js";
+import { planReattribution, applyReattribution } from "./reattributeFromHistory.js";
+import { planCleanup, applyCleanup } from "../scripts/cleanup-daily-mirrors.js";
+import { writeFailure } from "./sentinel.js";
+
+export function upgradeSentinelPath(dataDir: string, version: string): string {
+  return path.join(dataDir, `upgraded-${version}`);
+}
+
+export async function runCheapUpgradeSteps(dataDir: string, version: string): Promise<void> {
+  const sentinel = upgradeSentinelPath(dataDir, version);
+  if (fs.existsSync(sentinel)) return;
+
+  try {
+    const reattribPlan = planReattribution(dataDir);
+    applyReattribution(reattribPlan);
+  } catch (e: any) {
+    writeFailure(`auto-upgrade reattribute failed: ${e?.message || e}`);
+  }
+
+  try {
+    const vault = vaultPath();
+    if (fs.existsSync(vault)) {
+      const mirrorPlan = planCleanup(vault);
+      applyCleanup(vault, mirrorPlan);
+    }
+  } catch (e: any) {
+    writeFailure(`auto-upgrade cleanup-daily-mirrors failed: ${e?.message || e}`);
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(sentinel), { recursive: true });
+    fs.writeFileSync(sentinel, new Date().toISOString() + "\n", "utf8");
+  } catch (e: any) {
+    writeFailure(`auto-upgrade sentinel write failed: ${e?.message || e}`);
+  }
+}

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -180,6 +180,10 @@ EXAMPLE lesson (structured fields, traced to an incident, with whenApplies):
 
 {"items": [ <items as above> ], "digest"?: "<=1 sentence of the session's arc", "openThreads"?: ["unfinished/deferred work"], "alsoDid"?: ["notable work that did not become a knowledge item"]}
 
+# Multi-repo sessions
+
+When the events span more than one repo (multiple distinct cwd values), set each item's "project" to the repo its work belongs to — the events carry cwd so the correct repo is usually clear. Do not leave "project" unset when the repo is identifiable from the events. A wrong label is worse than a null one, so if the item's repo is genuinely ambiguous, omit "project" rather than guessing.
+
 # Events
 
 `;
@@ -246,7 +250,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
   const routedByDate: Record<string, string[]> = {};
   let notesWritten = 0;
   for (const it of items) {
-    if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.dominant) {
+    if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.all.length === 1 && sessionProj.dominant) {
       it.project = sessionProj.dominant;
     } else if (it.project) {
       it.project = slug(it.project);

--- a/src/reattributeFromHistory.ts
+++ b/src/reattributeFromHistory.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs";
+import path from "node:path";
+import { vaultPath } from "./paths.js";
+import { parseNote, serializeNote } from "./frontmatter.js";
+import { classifyPath, basenameSlug } from "./projectDetect.js";
+
+export interface ReattributionFix {
+  relPath: string;
+  absPath: string;
+  oldProject: string | undefined;
+  newProject: string;
+}
+
+export interface ReattributionPlan {
+  fixes: ReattributionFix[];
+}
+
+const SKIP_DIRS = new Set([".trash", ".obsidian", ".git", "node_modules"]);
+
+function walkVault(vaultDir: string): string[] {
+  const files: string[] = [];
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        walk(path.join(dir, entry.name));
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        files.push(path.join(dir, entry.name));
+      }
+    }
+  }
+  walk(vaultDir);
+  return files;
+}
+
+function knownProjectSlugs(vaultDir: string): Set<string> {
+  const projectsDir = path.join(vaultDir, "projects");
+  const slugs = new Set<string>();
+  if (!fs.existsSync(projectsDir)) return slugs;
+  for (const entry of fs.readdirSync(projectsDir, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      slugs.add(path.basename(entry.name, ".md"));
+    }
+  }
+  return slugs;
+}
+
+const VALID_SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+function isJunkProject(project: string | undefined, validSlugs: Set<string>): boolean {
+  if (project === undefined || project === null || project === "") return true;
+  if (project === "global") return false;
+  if (project.includes("/") || project.includes(",")) return true;
+  if (validSlugs.has(project)) return false;
+  if (VALID_SLUG_RE.test(project)) return false;
+  return true;
+}
+
+function resolveProjectFromSessions(
+  sessionIds: string[],
+  sessionsDir: string,
+): string | undefined {
+  const countBySlug: Map<string, number> = new Map();
+  for (const sid of sessionIds) {
+    const ndjsonPath = path.join(sessionsDir, `${sid}.ndjson`);
+    if (!fs.existsSync(ndjsonPath)) continue;
+    let raw: string;
+    try { raw = fs.readFileSync(ndjsonPath, "utf8"); } catch { continue; }
+    for (const line of raw.split("\n").filter(Boolean)) {
+      let event: any;
+      try { event = JSON.parse(line); } catch { continue; }
+      const cwd = event?.cwd;
+      if (!cwd || typeof cwd !== "string") continue;
+      const c = classifyPath(cwd);
+      if (c.kind === "blocked" || c.kind === "skip") continue;
+      const s = basenameSlug(c.projectDir);
+      countBySlug.set(s, (countBySlug.get(s) ?? 0) + 1);
+    }
+  }
+  if (countBySlug.size === 0) return undefined;
+  let dominant: string | undefined;
+  let max = 0;
+  for (const [s, count] of countBySlug) {
+    if (count > max) { dominant = s; max = count; }
+  }
+  return dominant;
+}
+
+export function planReattribution(dataDir: string): ReattributionPlan {
+  const vault = vaultPath();
+  const dailyDir = path.join(dataDir, "daily");
+  const sessionsDir = path.join(dataDir, "sessions");
+
+  const noteToSessions: Map<string, string[]> = new Map();
+
+  if (fs.existsSync(dailyDir)) {
+    for (const entry of fs.readdirSync(dailyDir)) {
+      if (!entry.endsWith(".json")) continue;
+      let state: Record<string, { routedRelPaths?: string[] }>;
+      try {
+        state = JSON.parse(fs.readFileSync(path.join(dailyDir, entry), "utf8"));
+      } catch { continue; }
+      for (const [sid, dayEntry] of Object.entries(state)) {
+        for (const relPath of dayEntry?.routedRelPaths ?? []) {
+          const existing = noteToSessions.get(relPath) ?? [];
+          existing.push(sid);
+          noteToSessions.set(relPath, existing);
+        }
+      }
+    }
+  }
+
+  const validSlugs = knownProjectSlugs(vault);
+  const fixes: ReattributionFix[] = [];
+
+  if (!fs.existsSync(vault)) return { fixes };
+
+  for (const absPath of walkVault(vault)) {
+    const relPath = path.relative(vault, absPath).replace(/\\/g, "/");
+    let raw: string;
+    try { raw = fs.readFileSync(absPath, "utf8"); } catch { continue; }
+    const { data } = parseNote(raw);
+    const project = typeof data.project === "string" ? data.project : undefined;
+    if (!isJunkProject(project, validSlugs)) continue;
+
+    const sessionIds = noteToSessions.get(relPath) ?? [];
+    if (sessionIds.length === 0) continue;
+
+    const newProject = resolveProjectFromSessions(sessionIds, sessionsDir);
+    if (!newProject) continue;
+
+    fixes.push({ relPath, absPath, oldProject: project, newProject });
+  }
+
+  return { fixes };
+}
+
+export function applyReattribution(plan: ReattributionPlan): void {
+  for (const fix of plan.fixes) {
+    let raw: string;
+    try { raw = fs.readFileSync(fix.absPath, "utf8"); } catch { continue; }
+    const { data, content } = parseNote(raw);
+    data.project = fix.newProject;
+    const newRaw = serializeNote(data, content);
+    try { fs.writeFileSync(fix.absPath, newRaw, "utf8"); } catch { /* best-effort */ }
+  }
+}

--- a/tests/autoUpgrade.test.ts
+++ b/tests/autoUpgrade.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runCheapUpgradeSteps, upgradeSentinelPath } from "../src/autoUpgrade.js";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-au-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-au-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+  process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+});
+
+describe("upgradeSentinelPath", () => {
+  it("returns a path under dataDir containing the version", () => {
+    const p = upgradeSentinelPath(TMP_DATA, "0.7.0");
+    expect(p).toContain(TMP_DATA);
+    expect(p).toContain("0.7.0");
+  });
+});
+
+describe("runCheapUpgradeSteps", () => {
+  it("runs once on first call and creates the sentinel", async () => {
+    const version = "0.7.0";
+    const sentinel = upgradeSentinelPath(TMP_DATA, version);
+    expect(fs.existsSync(sentinel)).toBe(false);
+
+    await runCheapUpgradeSteps(TMP_DATA, version);
+
+    expect(fs.existsSync(sentinel)).toBe(true);
+  });
+
+  it("is a no-op on the second call (sentinel already exists)", async () => {
+    const version = "0.7.0";
+    await runCheapUpgradeSteps(TMP_DATA, version);
+
+    const sentinel = upgradeSentinelPath(TMP_DATA, version);
+    const mtime1 = fs.statSync(sentinel).mtimeMs;
+
+    await runCheapUpgradeSteps(TMP_DATA, version);
+
+    const mtime2 = fs.statSync(sentinel).mtimeMs;
+    expect(mtime2).toBe(mtime1);
+  });
+
+  it("runs again for a different version (different sentinel)", async () => {
+    await runCheapUpgradeSteps(TMP_DATA, "0.6.0");
+    const sentinel07 = upgradeSentinelPath(TMP_DATA, "0.7.0");
+    expect(fs.existsSync(sentinel07)).toBe(false);
+
+    await runCheapUpgradeSteps(TMP_DATA, "0.7.0");
+    expect(fs.existsSync(sentinel07)).toBe(true);
+  });
+});

--- a/tests/distillCwdAttribution.test.ts
+++ b/tests/distillCwdAttribution.test.ts
@@ -164,6 +164,132 @@ describe("cwd-authoritative project attribution", () => {
     expect(entry.project).toBeUndefined();
   });
 
+  it("multi-cwd session: item with no explicit project is NOT tagged with the dominant slug", () => {
+    const repoDirA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-dom-"));
+    const repoDirB = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-min-"));
+    try {
+      fs.writeFileSync(path.join(repoDirA, "package.json"), JSON.stringify({ name: "repo-dominant" }));
+      fs.writeFileSync(path.join(repoDirB, "package.json"), JSON.stringify({ name: "repo-minority" }));
+
+      const slugA = path.basename(repoDirA).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      makeSessionNdjson("MM", [
+        { type: "tool", tool: "Write", file: "a.ts", cwd: repoDirA, ts: "t1" },
+        { type: "tool", tool: "Write", file: "a2.ts", cwd: repoDirA, ts: "t2" },
+        { type: "tool", tool: "Write", file: "a3.ts", cwd: repoDirA, ts: "t3" },
+        { type: "tool", tool: "Write", file: "b.ts", cwd: repoDirB, ts: "t4" },
+      ]);
+
+      const stubPath = makeStub({
+        items: [
+          {
+            kind: "project_fact",
+            title: "No-project fact in multi-cwd session",
+            date: "2026-05-28",
+            body: "A fact with no explicit project field.",
+            links: [],
+          },
+        ],
+        digest: "multi-repo work",
+        openThreads: [],
+        alsoDid: [],
+      });
+
+      runDistill(stubPath, "MM");
+
+      const projectAFile = path.join(TMP_VAULT, "projects", `${slugA}.md`);
+      expect(fs.existsSync(projectAFile)).toBe(false);
+    } finally {
+      fs.rmSync(repoDirA, { recursive: true, force: true });
+      fs.rmSync(repoDirB, { recursive: true, force: true });
+    }
+  });
+
+  it("single-cwd session: item with no explicit project is tagged with the dominant slug", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-sing-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "single-repo" }));
+
+      const slugSingle = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      makeSessionNdjson("SS", [
+        { type: "tool", tool: "Write", file: "a.ts", cwd: repoDir, ts: "t1" },
+        { type: "tool", tool: "Write", file: "b.ts", cwd: repoDir, ts: "t2" },
+        { type: "prompt", prompt: "work in single repo", cwd: repoDir, ts: "t3" },
+      ]);
+
+      const stubPath = makeStub({
+        items: [
+          {
+            kind: "project_fact",
+            title: "Single-repo fact",
+            date: "2026-05-28",
+            body: "A fact with no explicit project field in a single-repo session.",
+            links: [],
+          },
+        ],
+        digest: "single-repo work",
+        openThreads: [],
+        alsoDid: [],
+      });
+
+      runDistill(stubPath, "SS");
+
+      const projectFile = path.join(TMP_VAULT, "projects", `${slugSingle}.md`);
+      expect(fs.existsSync(projectFile)).toBe(true);
+      const content = fs.readFileSync(projectFile, "utf8");
+      expect(content).toContain("Single-repo fact");
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("multi-cwd session: explicit per-item project wins over no-dominant fallback", () => {
+    const repoDirA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-xa-"));
+    const repoDirB = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-xb-"));
+    try {
+      fs.writeFileSync(path.join(repoDirA, "package.json"), JSON.stringify({ name: "repo-xa" }));
+      fs.writeFileSync(path.join(repoDirB, "package.json"), JSON.stringify({ name: "repo-xb" }));
+
+      const slugA = path.basename(repoDirA).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      makeSessionNdjson("MX", [
+        { type: "tool", tool: "Write", file: "a.ts", cwd: repoDirA, ts: "t1" },
+        { type: "tool", tool: "Write", file: "a2.ts", cwd: repoDirA, ts: "t2" },
+        { type: "tool", tool: "Write", file: "b.ts", cwd: repoDirB, ts: "t3" },
+      ]);
+
+      const stubPath = makeStub({
+        items: [
+          {
+            kind: "project_fact",
+            title: "Explicitly labeled fact",
+            date: "2026-05-28",
+            project: "explicit-multi-project",
+            body: "A fact with explicit project in a multi-cwd session.",
+            links: [],
+          },
+        ],
+        digest: "multi-repo with explicit item",
+        openThreads: [],
+        alsoDid: [],
+      });
+
+      runDistill(stubPath, "MX");
+
+      const explicitFile = path.join(TMP_VAULT, "projects", "explicit-multi-project.md");
+      expect(fs.existsSync(explicitFile)).toBe(true);
+      const content = fs.readFileSync(explicitFile, "utf8");
+      expect(content).toContain("Explicitly labeled fact");
+
+      const projectAFile = path.join(TMP_VAULT, "projects", `${slugA}.md`);
+      expect(fs.existsSync(projectAFile)).toBe(false);
+    } finally {
+      fs.rmSync(repoDirA, { recursive: true, force: true });
+      fs.rmSync(repoDirB, { recursive: true, force: true });
+    }
+  });
+
   it("multi-cwd session: B-scoped items are not tagged as A; explicit per-item project wins", () => {
     const repoDirA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-aa-"));
     const repoDirB = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-bb-"));

--- a/tests/doctorMigrate.test.ts
+++ b/tests/doctorMigrate.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
 
-const doctorBin = path.resolve("dist/bin/sb-doctor.js");
+const doctorSrc = path.resolve("bin/sb-doctor.ts");
 
 // Fake vault with some notes so migrate-all has a vault path that exists.
 function makeFakeVault(): string {
@@ -21,7 +21,7 @@ describe("sb-doctor migrate-all", () => {
   it("shows dry-run output and exits 0 when user types N", () => {
     const vault = makeFakeVault();
     try {
-      const r = spawnSync("node", [doctorBin, "migrate-all"], {
+      const r = spawnSync("npx", ["tsx", doctorSrc, "migrate-all"], {
         input: "N\n",
         encoding: "utf8",
         env: {
@@ -34,11 +34,11 @@ describe("sb-doctor migrate-all", () => {
       expect(r.status).toBe(0);
       expect(r.stdout).toMatch(/SuperBrain migrate-all/);
       expect(r.stdout).toMatch(/Vault:/);
-      expect(r.stdout).toMatch(/Step 1\/4: backfill-frontmatter/);
-      expect(r.stdout).toMatch(/Step 2\/4: retro-collapse-duplicates/);
-      expect(r.stdout).toMatch(/Step 3\/4: migrate-vault/);
-      expect(r.stdout).toMatch(/Step 4\/4: retro-prune-preferences/);
-      expect(r.stdout).toMatch(/Apply all 4 steps\? \[y\/N\]/);
+      expect(r.stdout).toMatch(/Step 1\/7: backfill-frontmatter/);
+      expect(r.stdout).toMatch(/Step 2\/7: retro-collapse-duplicates/);
+      expect(r.stdout).toMatch(/Step 3\/7: migrate-vault/);
+      expect(r.stdout).toMatch(/Step 4\/7: retro-prune-preferences/);
+      expect(r.stdout).toMatch(/Apply all 7 steps\? \[y\/N\]/);
       expect(r.stdout).toMatch(/Aborted/);
     } finally {
       fs.rmSync(vault, { recursive: true, force: true });
@@ -48,7 +48,7 @@ describe("sb-doctor migrate-all", () => {
   it("applies all steps and exits 0 when user types y (fake mode)", () => {
     const vault = makeFakeVault();
     try {
-      const r = spawnSync("node", [doctorBin, "migrate-all"], {
+      const r = spawnSync("npx", ["tsx", doctorSrc, "migrate-all"], {
         input: "y\n",
         encoding: "utf8",
         env: {
@@ -60,7 +60,7 @@ describe("sb-doctor migrate-all", () => {
       });
       expect(r.status).toBe(0);
       expect(r.stdout).toMatch(/Applying/);
-      expect(r.stdout).toMatch(/Step 1\/4: backfill-frontmatter --apply/);
+      expect(r.stdout).toMatch(/Step 1\/7: backfill-frontmatter --apply/);
       expect(r.stdout).toMatch(/\[fake\] applied/);
       expect(r.stdout).toMatch(/migrate-all complete/);
     } finally {
@@ -71,7 +71,7 @@ describe("sb-doctor migrate-all", () => {
   it("exits 0 when user presses enter (defaults to N)", () => {
     const vault = makeFakeVault();
     try {
-      const r = spawnSync("node", [doctorBin, "migrate-all"], {
+      const r = spawnSync("npx", ["tsx", doctorSrc, "migrate-all"], {
         input: "\n",
         encoding: "utf8",
         env: {
@@ -89,7 +89,7 @@ describe("sb-doctor migrate-all", () => {
   });
 
   it("help updated to include migrate-all", () => {
-    const r = spawnSync("node", [doctorBin, "--help"], { encoding: "utf8" });
+    const r = spawnSync("npx", ["tsx", doctorSrc, "--help"], { encoding: "utf8" });
     expect(r.stdout).toMatch(/migrate-all/);
   });
 });

--- a/tests/doctorMigrateSteps.test.ts
+++ b/tests/doctorMigrateSteps.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+
+const doctorSrc = path.resolve("bin/sb-doctor.ts");
+
+function makeFakeVault(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-migrate-steps-"));
+  fs.mkdirSync(path.join(dir, "decisions"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "decisions", "test.md"),
+    "---\ntype: decision\nproject: global\n---\n\nbody\n",
+  );
+  return dir;
+}
+
+function runDoctor(vault: string): ReturnType<typeof spawnSync> {
+  return spawnSync("npx", ["tsx", doctorSrc, "migrate-all"], {
+    input: "N\n",
+    encoding: "utf8",
+    env: { ...process.env, SUPERBRAIN_VAULT_DIR: vault, SUPERBRAIN_FAKE_MIGRATE: "1" },
+    timeout: 30000,
+  });
+}
+
+describe("sb-doctor migrate-all MIGRATION_STEPS wiring", () => {
+  it("includes cleanup-daily-mirrors in the step list", () => {
+    const vault = makeFakeVault();
+    try {
+      const r = runDoctor(vault);
+      expect(r.stdout).toMatch(/cleanup-daily-mirrors/);
+    } finally {
+      fs.rmSync(vault, { recursive: true, force: true });
+    }
+  });
+
+  it("includes recover-lessons in the step list", () => {
+    const vault = makeFakeVault();
+    try {
+      const r = runDoctor(vault);
+      expect(r.stdout).toMatch(/recover-lessons/);
+    } finally {
+      fs.rmSync(vault, { recursive: true, force: true });
+    }
+  });
+
+  it("includes reattribute-from-history in the step list", () => {
+    const vault = makeFakeVault();
+    try {
+      const r = runDoctor(vault);
+      expect(r.stdout).toMatch(/reattribute-from-history/);
+    } finally {
+      fs.rmSync(vault, { recursive: true, force: true });
+    }
+  });
+
+  it("reattribute-from-history step appears before recover-lessons (order check)", () => {
+    const vault = makeFakeVault();
+    try {
+      const r = runDoctor(vault);
+      const reattributionIdx = r.stdout.indexOf("reattribute-from-history");
+      const recoverIdx = r.stdout.indexOf("recover-lessons");
+      expect(reattributionIdx).toBeGreaterThan(-1);
+      expect(recoverIdx).toBeGreaterThan(-1);
+      expect(reattributionIdx).toBeLessThan(recoverIdx);
+    } finally {
+      fs.rmSync(vault, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/reattributeFromHistory.test.ts
+++ b/tests/reattributeFromHistory.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  planReattribution,
+  applyReattribution,
+  type ReattributionPlan,
+} from "../src/reattributeFromHistory.js";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-reattr-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-reattr-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+function writeSession(sid: string, cwd: string): void {
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  const event = { type: "tool", tool: "Write", file: "a.ts", cwd, ts: "2026-05-28T10:00:00.000Z" };
+  fs.writeFileSync(
+    path.join(TMP_DATA, "sessions", `${sid}.ndjson`),
+    JSON.stringify(event) + "\n",
+  );
+}
+
+function writeDaily(date: string, entries: Record<string, { routedRelPaths: string[] }>): void {
+  fs.mkdirSync(path.join(TMP_DATA, "daily"), { recursive: true });
+  const state: Record<string, any> = {};
+  for (const [sid, entry] of Object.entries(entries)) {
+    state[sid] = { digestLine: "", alsoDid: [], openThreads: [], ...entry };
+  }
+  fs.writeFileSync(path.join(TMP_DATA, "daily", `${date}.json`), JSON.stringify(state));
+}
+
+function writeVaultNote(relPath: string, frontmatterLines: string, body = "some body\n"): void {
+  const abs = path.join(TMP_VAULT, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, `---\n${frontmatterLines}\n---\n\n${body}`);
+}
+
+function readVaultNote(relPath: string): string {
+  return fs.readFileSync(path.join(TMP_VAULT, relPath), "utf8");
+}
+
+describe("planReattribution", () => {
+  it("fixes a note whose project is MISSING when history maps it to a valid cwd", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-fix-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      writeSession("S1", repoDir);
+      const noteRel = "capture/2026-05-28-some-note.md";
+      writeDaily("2026-05-28", { S1: { routedRelPaths: [noteRel] } });
+      writeVaultNote(noteRel, "type: capture\nstatus: active");
+
+      process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+      process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+      try {
+        const plan = planReattribution(TMP_DATA);
+        const fix = plan.fixes.find(f => f.relPath === noteRel);
+        expect(fix).toBeDefined();
+        expect(fix!.newProject).toBe(expectedSlug);
+      } finally {
+        delete process.env.SUPERBRAIN_DATA_DIR;
+        delete process.env.SUPERBRAIN_VAULT_DIR;
+        delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+      }
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fixes a note whose project is JUNK (contains /)", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-junk-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      writeSession("S2", repoDir);
+      const noteRel = "capture/2026-05-28-junk-note.md";
+      writeDaily("2026-05-28", { S2: { routedRelPaths: [noteRel] } });
+      writeVaultNote(noteRel, "type: capture\nstatus: active\nproject: /bad/path");
+
+      process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+      process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+      try {
+        const plan = planReattribution(TMP_DATA);
+        const fix = plan.fixes.find(f => f.relPath === noteRel);
+        expect(fix).toBeDefined();
+        expect(fix!.newProject).toBe(expectedSlug);
+      } finally {
+        delete process.env.SUPERBRAIN_DATA_DIR;
+        delete process.env.SUPERBRAIN_VAULT_DIR;
+        delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+      }
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fixes a note whose project is JUNK (contains ,)", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-comma-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      writeSession("S3", repoDir);
+      const noteRel = "capture/2026-05-28-comma-note.md";
+      writeDaily("2026-05-28", { S3: { routedRelPaths: [noteRel] } });
+      writeVaultNote(noteRel, "type: capture\nstatus: active\nproject: foo,bar");
+
+      process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+      process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+      try {
+        const plan = planReattribution(TMP_DATA);
+        const fix = plan.fixes.find(f => f.relPath === noteRel);
+        expect(fix).toBeDefined();
+        expect(fix!.newProject).toBe(expectedSlug);
+      } finally {
+        delete process.env.SUPERBRAIN_DATA_DIR;
+        delete process.env.SUPERBRAIN_VAULT_DIR;
+        delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+      }
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fixes a note whose project contains uppercase (not a valid slug)", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-stray-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      writeSession("S4", repoDir);
+      const noteRel = "capture/2026-05-28-stray-note.md";
+      writeDaily("2026-05-28", { S4: { routedRelPaths: [noteRel] } });
+      writeVaultNote(noteRel, "type: capture\nstatus: active\nproject: MyBadProject");
+
+      process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+      process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+      try {
+        const plan = planReattribution(TMP_DATA);
+        const fix = plan.fixes.find(f => f.relPath === noteRel);
+        expect(fix).toBeDefined();
+        expect(fix!.newProject).toBe(expectedSlug);
+      } finally {
+        delete process.env.SUPERBRAIN_DATA_DIR;
+        delete process.env.SUPERBRAIN_VAULT_DIR;
+        delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+      }
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves a note with a valid project (global) untouched", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-valid-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+
+      writeSession("S5", repoDir);
+      const noteRel = "capture/2026-05-28-valid-note.md";
+      writeDaily("2026-05-28", { S5: { routedRelPaths: [noteRel] } });
+      writeVaultNote(noteRel, "type: capture\nstatus: active\nproject: global");
+
+      process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+      process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+      try {
+        const plan = planReattribution(TMP_DATA);
+        const fix = plan.fixes.find(f => f.relPath === noteRel);
+        expect(fix).toBeUndefined();
+      } finally {
+        delete process.env.SUPERBRAIN_DATA_DIR;
+        delete process.env.SUPERBRAIN_VAULT_DIR;
+        delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+      }
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves a note with an existing projects/<slug>.md untouched", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-existing-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+
+      writeSession("S6", repoDir);
+      const noteRel = "capture/2026-05-28-known-project-note.md";
+      writeDaily("2026-05-28", { S6: { routedRelPaths: [noteRel] } });
+      writeVaultNote(noteRel, "type: capture\nstatus: active\nproject: real-project");
+      writeVaultNote("projects/real-project.md", "type: project\nstatus: active\nproject: real-project");
+
+      process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+      process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+      try {
+        const plan = planReattribution(TMP_DATA);
+        const fix = plan.fixes.find(f => f.relPath === noteRel);
+        expect(fix).toBeUndefined();
+      } finally {
+        delete process.env.SUPERBRAIN_DATA_DIR;
+        delete process.env.SUPERBRAIN_VAULT_DIR;
+        delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+      }
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("applyReattribution", () => {
+  it("rewrites frontmatter project field for a note with missing project", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-apply-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      writeSession("SA", repoDir);
+      const noteRel = "capture/2026-05-28-apply-note.md";
+      writeDaily("2026-05-28", { SA: { routedRelPaths: [noteRel] } });
+      writeVaultNote(noteRel, "type: capture\nstatus: active");
+
+      process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+      process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+      try {
+        const plan = planReattribution(TMP_DATA);
+        applyReattribution(plan);
+
+        const content = readVaultNote(noteRel);
+        expect(content).toMatch(new RegExp(`^project: ${expectedSlug}$`, "m"));
+      } finally {
+        delete process.env.SUPERBRAIN_DATA_DIR;
+        delete process.env.SUPERBRAIN_VAULT_DIR;
+        delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+      }
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("is idempotent: second run produces no new fixes", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-idem-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+      const expectedSlug = path.basename(repoDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+
+      writeSession("SI", repoDir);
+      const noteRel = "capture/2026-05-28-idem-note.md";
+      writeDaily("2026-05-28", { SI: { routedRelPaths: [noteRel] } });
+      writeVaultNote(noteRel, "type: capture\nstatus: active");
+
+      process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+      process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+      try {
+        const plan1 = planReattribution(TMP_DATA);
+        expect(plan1.fixes.length).toBeGreaterThan(0);
+        applyReattribution(plan1);
+
+        const content1 = readVaultNote(noteRel);
+        expect(content1).toMatch(new RegExp(`^project: ${expectedSlug}$`, "m"));
+
+        const plan2 = planReattribution(TMP_DATA);
+        const fix = plan2.fixes.find(f => f.relPath === noteRel);
+        expect(fix).toBeUndefined();
+      } finally {
+        delete process.env.SUPERBRAIN_DATA_DIR;
+        delete process.env.SUPERBRAIN_VAULT_DIR;
+        delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+      }
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not touch notes with valid project", () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-repo-notouch-"));
+    try {
+      fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "my-app" }));
+
+      writeSession("SV", repoDir);
+      const noteRel = "capture/2026-05-28-valid-proj.md";
+      const originalContent = `---\ntype: capture\nstatus: active\nproject: global\n---\n\nsome body\n`;
+      const abs = path.join(TMP_VAULT, noteRel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, originalContent);
+      writeDaily("2026-05-28", { SV: { routedRelPaths: [noteRel] } });
+
+      process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+      process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+      process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST = "1";
+      try {
+        const plan = planReattribution(TMP_DATA);
+        applyReattribution(plan);
+
+        const content = readVaultNote(noteRel);
+        expect(content).toBe(originalContent);
+      } finally {
+        delete process.env.SUPERBRAIN_DATA_DIR;
+        delete process.env.SUPERBRAIN_VAULT_DIR;
+        delete process.env.SUPERBRAIN_TEST_BYPASS_BLOCKLIST;
+      }
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closeout part 2 of 3: the upgrade migration and multi-cwd attribution (conformance-review P1 items).

## Upgrade migration (self-healing for existing vaults)
- `src/reattributeFromHistory.ts`: re-derives a note's project from recorded session cwd history (daily routedRelPaths -> session ndjson cwd -> classifyPath dominant) for notes whose `project` is missing or junk (a path, comma-joined, or invalid-slug-shaped). Valid-but-orphaned slugs are left alone (fixing slug fragmentation needs a human canonical map; not generalizable). Idempotent; non-destructive.
- `src/autoUpgrade.ts`: version-gated (sentinel) one-shot that, on the first session after an upgrade, auto-runs the cheap non-LLM steps (re-attribution + daily-mirror cleanup); force-reindex already runs. Wired into the detached `sb-reconcile` behind the `depsPresent` gate, non-blocking, errors to the sentinel. `recover-lessons` (LLM cost) stays manual.
- `sb-doctor migrate-all` now lists `reattribute-from-history`, `cleanup-daily-mirrors`, and `recover-lessons` (4 -> 7 steps), so the recovery + cleanup are user-discoverable.

## Multi-cwd attribution
- In a session spanning multiple repos, a project-scoped item with no explicit project is no longer tagged with the session-dominant project (a confident-but-possibly-wrong label). It stays unattributed (project-required kinds fall to the honest `unknown` bucket; project-optional kinds go null/recall-eligible-everywhere). The distiller prompt now instructs attribution by cwd.

## Tests
Full suite green (typecheck, build, tests, freshCloneE2E); dist in sync. New tests: re-attribution (junk/missing fixes, valid untouched, idempotent), auto-upgrade gating, sb-doctor step list, multi-cwd no-mis-tag.
