### PR TITLE
fix: bm25-only recall in short-lived hooks (session brief works on any Node version)

### DIFF
--- a/bin/sb-recall.ts
+++ b/bin/sb-recall.ts
@@ -28,7 +28,7 @@ async function main() {
       }
     }
     const { hybridRecall } = await import("../src/recall.js"); // deferred: only after deps check
-    const hits = await hybridRecall(prompt, 5, { projectSlug, excludeSlugs });
+    const hits = await hybridRecall(prompt, 5, { projectSlug, excludeSlugs, bm25Only: true });
     if (hits.length) {
       // Record newly injected paths so subsequent UserPromptSubmit calls also exclude them.
       if (sid) {

--- a/dist/bin/sb-recall.js
+++ b/dist/bin/sb-recall.js
@@ -40,7 +40,7 @@ async function main() {
             }
         }
         const { hybridRecall } = await import("../src/recall.js"); // deferred: only after deps check
-        const hits = await hybridRecall(prompt, 5, { projectSlug, excludeSlugs });
+        const hits = await hybridRecall(prompt, 5, { projectSlug, excludeSlugs, bm25Only: true });
         if (hits.length) {
             // Record newly injected paths so subsequent UserPromptSubmit calls also exclude them.
             if (sid) {

--- a/dist/src/recall.js
+++ b/dist/src/recall.js
@@ -30,12 +30,17 @@ export async function hybridRecall(query, k, opts) {
         ix = openIndex();
         const bm = ix.bm25(query, k * 2);
         let vec = [];
-        try {
-            const [qv] = await embed([query]);
-            const raw = ix.vectorKNN(qv, k * 2);
-            vec = raw.filter((h) => h.distance == null || h.distance <= VECTOR_DISTANCE_CUTOFF);
+        // bm25Only skips the embedding model entirely. Short-lived hooks (SessionStart,
+        // UserPromptSubmit) must exit cleanly; loading onnxruntime there aborts the
+        // process on teardown under some Node runtimes, so they pass bm25Only.
+        if (!opts?.bm25Only) {
+            try {
+                const [qv] = await embed([query]);
+                const raw = ix.vectorKNN(qv, k * 2);
+                vec = raw.filter((h) => h.distance == null || h.distance <= VECTOR_DISTANCE_CUTOFF);
+            }
+            catch { /* degrade to bm25-only */ }
         }
-        catch { /* degrade to bm25-only */ }
         // INTENTIONAL precision gate: if BM25 has zero lexical hits we return nothing
         // rather than vector-only neighbours, preventing constant noise injection.
         if (bm.length === 0)

--- a/dist/src/sessionDigest.js
+++ b/dist/src/sessionDigest.js
@@ -50,7 +50,7 @@ export async function appendDigest(parts, h) {
             }
             if (lastDigestLine) {
                 const lines = [
-                    `Tell the user in one sentence that SuperBrain has loaded context for this project.`,
+                    `At the start of your first reply, tell the user in one sentence that SuperBrain loaded this project's recent context, citing the "Last session" summary below.`,
                     `SuperBrain — ${currentProjectSlug}`,
                     `Last session: ${lastDigestLine}`,
                 ];
@@ -66,19 +66,19 @@ export async function appendDigest(parts, h) {
     // Hybrid recall digest: project-slug filtered when cwd resolves to a known project.
     try {
         let query;
-        let recallOpts;
+        // bm25Only: this SessionStart hook must exit cleanly; loading the embedding
+        // model here aborts the process on teardown under some Node runtimes.
+        const recallOpts = { bm25Only: true };
         if (currentProjectKnown && currentProjectSlug) {
             query = currentProjectSlug;
-            recallOpts = { projectSlug: currentProjectSlug };
+            recallOpts.projectSlug = currentProjectSlug;
         }
         else if (cwd) {
             // blocked or skip — fall back to bare basename, no project filter
             query = path.basename(cwd);
-            recallOpts = undefined;
         }
         else {
             query = "";
-            recallOpts = undefined;
         }
         const hits = await hybridRecall(query, 5, recallOpts);
         if (hits.length) {

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -27,18 +27,23 @@ export async function bm25Recall(query: string, k: number): Promise<Pointer[]> {
 export async function hybridRecall(
   query: string,
   k: number,
-  opts?: { projectSlug?: string; excludeSlugs?: string[] },
+  opts?: { projectSlug?: string; excludeSlugs?: string[]; bm25Only?: boolean },
 ): Promise<Pointer[]> {
   let ix: Index | undefined;
   try {
     ix = openIndex();
     const bm = ix.bm25(query, k * 2);
     let vec: Hit[] = [];
-    try {
-      const [qv] = await embed([query]);
-      const raw = ix.vectorKNN(qv, k * 2);
-      vec = raw.filter((h) => h.distance == null || h.distance <= VECTOR_DISTANCE_CUTOFF);
-    } catch { /* degrade to bm25-only */ }
+    // bm25Only skips the embedding model entirely. Short-lived hooks (SessionStart,
+    // UserPromptSubmit) must exit cleanly; loading onnxruntime there aborts the
+    // process on teardown under some Node runtimes, so they pass bm25Only.
+    if (!opts?.bm25Only) {
+      try {
+        const [qv] = await embed([query]);
+        const raw = ix.vectorKNN(qv, k * 2);
+        vec = raw.filter((h) => h.distance == null || h.distance <= VECTOR_DISTANCE_CUTOFF);
+      } catch { /* degrade to bm25-only */ }
+    }
     // INTENTIONAL precision gate: if BM25 has zero lexical hits we return nothing
     // rather than vector-only neighbours, preventing constant noise injection.
     if (bm.length === 0) return [];

--- a/src/sessionDigest.ts
+++ b/src/sessionDigest.ts
@@ -51,7 +51,7 @@ export async function appendDigest(parts: string[], h: any): Promise<void> {
 
       if (lastDigestLine) {
         const lines = [
-          `Tell the user in one sentence that SuperBrain has loaded context for this project.`,
+          `At the start of your first reply, tell the user in one sentence that SuperBrain loaded this project's recent context, citing the "Last session" summary below.`,
           `SuperBrain — ${currentProjectSlug}`,
           `Last session: ${lastDigestLine}`,
         ];
@@ -65,18 +65,18 @@ export async function appendDigest(parts: string[], h: any): Promise<void> {
   // Hybrid recall digest: project-slug filtered when cwd resolves to a known project.
   try {
     let query: string;
-    let recallOpts: { projectSlug?: string } | undefined;
+    // bm25Only: this SessionStart hook must exit cleanly; loading the embedding
+    // model here aborts the process on teardown under some Node runtimes.
+    const recallOpts: { projectSlug?: string; bm25Only: boolean } = { bm25Only: true };
 
     if (currentProjectKnown && currentProjectSlug) {
       query = currentProjectSlug;
-      recallOpts = { projectSlug: currentProjectSlug };
+      recallOpts.projectSlug = currentProjectSlug;
     } else if (cwd) {
       // blocked or skip — fall back to bare basename, no project filter
       query = path.basename(cwd);
-      recallOpts = undefined;
     } else {
       query = "";
-      recallOpts = undefined;
     }
 
     const hits = await hybridRecall(query, 5, recallOpts);

--- a/tests/recall.test.ts
+++ b/tests/recall.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { openIndex } from "../src/searchIndex";
 import { bm25Recall, hybridRecall } from "../src/recall";
+import * as embedMod from "../src/embed";
 
 let TMP: string;
 
@@ -41,6 +42,21 @@ describe("recall", () => {
     const r = await hybridRecall("sqlite-vec", 3);
     expect(r[0].relPath).toBe("decisions/2026-05-01-vec.md");
     delete process.env.SUPERBRAIN_EMBED_FORCE_FAIL;
+  });
+
+  it("hybridRecall with bm25Only never loads the embedding model and still returns results", async () => {
+    const spy = vi.spyOn(embedMod, "embed");
+    const r = await hybridRecall("sqlite-vec", 3, { bm25Only: true });
+    expect(spy).not.toHaveBeenCalled();
+    expect(r[0].relPath).toBe("decisions/2026-05-01-vec.md");
+    spy.mockRestore();
+  });
+
+  it("hybridRecall without bm25Only does invoke embed (guards the spy is wired)", async () => {
+    const spy = vi.spyOn(embedMod, "embed");
+    await hybridRecall("local vector database", 3);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 });
 

--- a/tests/sessionStartDigest.test.ts
+++ b/tests/sessionStartDigest.test.ts
@@ -58,6 +58,8 @@ describe("appendDigest — project-aware seed", () => {
     // Must pass projectSlug option
     expect(opts).toBeDefined();
     expect(opts.projectSlug).toBeTruthy();
+    // Must request bm25Only so the SessionStart hook never loads the embedding model
+    expect(opts.bm25Only).toBe(true);
   });
 
   it("falls back to cwd basename with no projectSlug when path is blocked", async () => {


### PR DESCRIPTION
## Problem
After updating to 0.7.0, the user-visible session-start brief never showed. Root cause: the short-lived `SessionStart` (and `UserPromptSubmit`) hooks call `hybridRecall`, which loads the MiniLM embedding model (`onnxruntime-node` via `@huggingface/transformers`). When the hook then exits, onnxruntime aborts the process on teardown under **Node 25.x** (`libc++abi … mutex lock failed`, SIGABRT → exit 134). A hook that dies on a signal has its `additionalContext` dropped by Claude Code, so the brief (and recall) never reach the model. Proven: identical hook exits 0 under Node 22 LTS, and `EMBED_STUB=1` → clean exit isolates the embedding teardown as the cause.

## Fix
The brief needs no embeddings (it reads daily state); only the "relevant notes" recall pulled in onnxruntime. Now the short-lived hooks run **BM25-only**:
- `hybridRecall` gains a `bm25Only` option that skips `embed()` entirely and uses the existing BM25-degraded arm — **project scoping (`isCrossProject`), recency decay, and exclude-slugs are all preserved**, so the #42 cross-project guarantee still holds.
- `sessionDigest` and `bin/sb-recall` pass `bm25Only: true`. This also makes session start faster (no 90MB model load) and matches the README's "BM25 pointers on every prompt, no model load".
- Embeddings remain in the **long-lived MCP server** (doesn't exit between calls) and the **detached distiller/reconcile** (exit after work is flushed), where a teardown abort is harmless.
- Brief surfacing instruction strengthened so it reliably leads the first reply.

Net: the brief works on **any Node version** — no node downgrade, no rebuild.

## Verification
- Rebuilt `SessionStart` hook run under Node v25.2.1 → **exit 0**, brief present, clean stderr (was exit 134 / mutex crash).
- New `recall` tests: `bm25Only` never invokes `embed` (spy asserts 0 calls) yet returns scoped results; control test asserts the non-`bm25Only` path still embeds.
- `sessionStartDigest` test asserts the hook passes `bm25Only: true`.
- Full gate: typecheck 0, build 0, 638/638 tests, dist in sync.
