### PR TITLE
chore: release 0.7.1 (ships the bm25-only hook fix as a detectable update)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ behavior may change without notice.
 
 ## [Unreleased]
 
+## 0.7.1: session brief reliability (Node-version-independent hooks)
+
+The session-start brief and per-prompt recall hooks no longer load the embedding model. On some Node runtimes (observed on Node 25.x) the native embedding library aborted the process on exit, so the SessionStart hook crashed and Claude Code dropped its injected context, and the brief never appeared. The short-lived hooks now use lexical (BM25) recall only and always exit cleanly; embedding-based search keeps running in the long-lived MCP server and the background distiller. Session start is also faster (no model load), and project scoping is unchanged.
+
 ## 0.7.0: cross-project isolation, lossless capture, and the session brief
 
 **Cross-project isolation.** Recall is now scoped to the project you are working in. The session-start brief, the per-prompt BM25 pointers, and inject-time recall all filter to the current repo, so one project's notes never surface in another. This closes the cross-project contamination reported in #42.

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -13,7 +13,7 @@ async function main() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
-  const server = new McpServer({ name: "superbrain", version: "0.7.0" });
+  const server = new McpServer({ name: "superbrain", version: "0.7.1" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).",

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -12,7 +12,7 @@ async function main() {
     const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
-    const server = new McpServer({ name: "superbrain", version: "0.7.0" });
+    const server = new McpServer({ name: "superbrain", version: "0.7.1" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).", { query: z.string(), k: z.number().optional() }, async ({ query, k }) => (await handleSearch({ query, k })));
     const transport = new StdioServerTransport();
     server.connect(transport).catch(() => process.exit(1));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump to 0.7.1 (lockstep: package.json / plugin.json / marketplace.json / MCP server) + CHANGELOG entry, so #51 reaches users via `/plugin update` (Claude Code keys updates on the version number). No behavior change beyond the version-gated reindex/upgrade sentinels re-arming for 0.7.1 (idempotent). Gate green: typecheck, build, 638 tests, dist in sync.