### PR TITLE
fix(distill): harden coercers + per-item isolation to stop session-zeroing (v1 Wave A)

### DIFF
--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -26,7 +26,7 @@ import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
 import { classifyPath, basenameSlug } from "./projectDetect.js";
-import { slug } from "./router.js";
+import { slug, asText } from "./router.js";
 export function resolveSessionProject(events) {
     const countBySlug = new Map();
     for (const e of events) {
@@ -53,7 +53,7 @@ export function resolveSessionProject(events) {
     return { dominant, all };
 }
 function shortTitle(raw, fallbackBody) {
-    const src = (raw || fallbackBody).trim();
+    const src = (asText(raw) || asText(fallbackBody)).trim();
     const words = src.split(/\s+/).filter(Boolean);
     const taken = words.slice(0, 8).join(" ").replace(/\.+$/, "");
     return taken || "Captured note";
@@ -72,8 +72,8 @@ function trimToWordCeiling(text, ceiling) {
     return words.slice(0, ceiling).join(" ");
 }
 export function coerceCapture(item, routedBody) {
-    const title = shortTitle(item.title, item.body || "");
-    const rawBody = (item.body || routedBody || "").trim();
+    const title = shortTitle(asText(item.title), asText(item.body));
+    const rawBody = (asText(item.body) || asText(routedBody)).trim();
     const words = rawBody.split(/\s+/).filter(Boolean);
     const maxWhat = 180;
     const whatContent = words.length > maxWhat
@@ -84,10 +84,10 @@ export function coerceCapture(item, routedBody) {
     return `# ${title}\n\n## What\n\n${whatContent}\n\n## Why it matters\n\n${whyContent}\n`;
 }
 export function coerceLesson(item, routedBody) {
-    const title = (item.title || "Lesson").trim();
-    const ruleText = (item.rule || "").trim() || trimToWordCeiling((item.body || routedBody || "").trim(), 30);
-    const whyText = (item.why || item.body || routedBody || "").trim() || "See session context.";
-    const whenText = (item.whenApplies || "").trim() || "In relevant future situations.";
+    const title = (asText(item.title) || "Lesson").trim();
+    const ruleText = asText(item.rule).trim() || trimToWordCeiling((asText(item.body) || asText(routedBody)).trim(), 30);
+    const whyText = (asText(item.why) || asText(item.body) || asText(routedBody)).trim() || "See session context.";
+    const whenText = asText(item.whenApplies).trim() || "In relevant future situations.";
     return `# ${title}\n\n## Rule\n\n${ruleText}\n\n## Why\n\n${whyText}\n\n## When this applies\n\n${whenText}\n`;
 }
 export function parseEnvelope(raw) {
@@ -225,125 +225,137 @@ export async function distillFromEvents(sid, events) {
     const routedByDate = {};
     let notesWritten = 0;
     for (const it of items) {
-        if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.all.length === 1 && sessionProj.dominant) {
-            it.project = sessionProj.dominant;
-        }
-        else if (it.project) {
-            it.project = slug(it.project);
-        }
-        it.links = resolveLinks(it.links || [], vaultPath());
-        const r = route(it);
-        if (r.mode !== "create") {
-            const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
-            if (res0.ok && res0.reason !== "duplicate-skipped") {
+        try {
+            if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.all.length === 1 && sessionProj.dominant) {
+                it.project = sessionProj.dominant;
+            }
+            else if (it.project) {
+                it.project = slug(it.project);
+            }
+            it.links = resolveLinks(it.links || [], vaultPath());
+            const r = route(it);
+            if (r.mode !== "create") {
+                const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
+                if (res0.ok && res0.reason !== "duplicate-skipped") {
+                    try {
+                        await indexNote(r.relPath);
+                    }
+                    catch (e) {
+                        writeFailure(`index failed: ${e?.message || e}`);
+                    }
+                    (routedByDate[it.date] ||= []).push(r.relPath);
+                    notesWritten++;
+                }
+                continue;
+            }
+            {
+                let vaultDedupSkip = false;
                 try {
-                    await indexNote(r.relPath);
+                    const vaultSearchFn = async (query, _opts) => {
+                        let ix;
+                        try {
+                            ix = openIndex();
+                            const [qv] = await embed([query]);
+                            const hits = ix.vectorKNN(qv, 1);
+                            if (!hits.length)
+                                return [];
+                            const [hv] = await embed([hits[0].text]);
+                            let dot = 0, na = 0, nb = 0;
+                            const n = Math.min(qv.length, hv.length);
+                            for (let i = 0; i < n; i++) {
+                                dot += qv[i] * hv[i];
+                                na += qv[i] ** 2;
+                                nb += hv[i] ** 2;
+                            }
+                            const sim = (na && nb) ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0;
+                            return [{ path: hits[0].relPath, score: sim }];
+                        }
+                        catch {
+                            return [];
+                        }
+                        finally {
+                            ix?.close();
+                        }
+                    };
+                    const vaultMatch = await dedupAgainstVault({ title: it.title, body: r.body, project: it.project, type: r.frontmatter.type }, vaultSearchFn);
+                    if (vaultMatch.match) {
+                        recordRejection(vaultPath(), {
+                            type: r.frontmatter.type ?? it.kind,
+                            reason: `dedup vs ${vaultMatch.match} (score ${vaultMatch.score?.toFixed(2)})`,
+                            sessionId: sid,
+                            title: it.title,
+                            excerpt: r.body.slice(0, 500),
+                        });
+                        vaultDedupSkip = true;
+                    }
+                }
+                catch (e) {
+                    writeFailure(`vault dedup error: ${e?.message || e}`);
+                }
+                if (vaultDedupSkip)
+                    continue;
+            }
+            const classifiableKinds = new Set(["decision", "lesson", "capture", "project", "daily", "person"]);
+            let writeBody = r.body;
+            let writeRelPath = r.relPath;
+            let writeFrontmatter = r.frontmatter;
+            if (classifiableKinds.has(it.kind)) {
+                try {
+                    const classifyFm = it.project
+                        ? { ...r.frontmatter, project: it.project }
+                        : r.frontmatter;
+                    const candidateDoc = serializeNote(classifyFm, r.body);
+                    const cr = classify({ proposedType: it.kind, title: it.title, body: candidateDoc });
+                    if (!cr.accepted) {
+                        recordRejection(vaultPath(), {
+                            type: it.kind,
+                            reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
+                            sessionId: sid,
+                            title: it.title,
+                            excerpt: candidateDoc.slice(0, 500),
+                        });
+                        const targetKind = cr.suggestedType ?? it.kind;
+                        if (targetKind === "lesson") {
+                            const reItem = { ...it, kind: "lesson" };
+                            const r2 = route(reItem);
+                            writeFrontmatter = r2.frontmatter;
+                            writeRelPath = r2.relPath;
+                            writeBody = coerceLesson(reItem, r.body);
+                        }
+                        else {
+                            const reItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
+                            const r2 = route(reItem);
+                            writeFrontmatter = r2.frontmatter;
+                            writeRelPath = r2.relPath;
+                            writeBody = coerceCapture(reItem, r.body);
+                        }
+                    }
+                }
+                catch (e) {
+                    writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
+                }
+            }
+            const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
+            if (res.ok && res.reason !== "duplicate-skipped") {
+                try {
+                    await indexNote(writeRelPath);
                 }
                 catch (e) {
                     writeFailure(`index failed: ${e?.message || e}`);
                 }
-                (routedByDate[it.date] ||= []).push(r.relPath);
+                (routedByDate[it.date] ||= []).push(writeRelPath);
                 notesWritten++;
             }
-            continue;
         }
-        {
-            let vaultDedupSkip = false;
-            try {
-                const vaultSearchFn = async (query, _opts) => {
-                    let ix;
-                    try {
-                        ix = openIndex();
-                        const [qv] = await embed([query]);
-                        const hits = ix.vectorKNN(qv, 1);
-                        if (!hits.length)
-                            return [];
-                        const [hv] = await embed([hits[0].text]);
-                        let dot = 0, na = 0, nb = 0;
-                        const n = Math.min(qv.length, hv.length);
-                        for (let i = 0; i < n; i++) {
-                            dot += qv[i] * hv[i];
-                            na += qv[i] ** 2;
-                            nb += hv[i] ** 2;
-                        }
-                        const sim = (na && nb) ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0;
-                        return [{ path: hits[0].relPath, score: sim }];
-                    }
-                    catch {
-                        return [];
-                    }
-                    finally {
-                        ix?.close();
-                    }
-                };
-                const vaultMatch = await dedupAgainstVault({ title: it.title, body: r.body, project: it.project, type: r.frontmatter.type }, vaultSearchFn);
-                if (vaultMatch.match) {
-                    recordRejection(vaultPath(), {
-                        type: r.frontmatter.type ?? it.kind,
-                        reason: `dedup vs ${vaultMatch.match} (score ${vaultMatch.score?.toFixed(2)})`,
-                        sessionId: sid,
-                        title: it.title,
-                        excerpt: r.body.slice(0, 500),
-                    });
-                    vaultDedupSkip = true;
-                }
-            }
-            catch (e) {
-                writeFailure(`vault dedup error: ${e?.message || e}`);
-            }
-            if (vaultDedupSkip)
-                continue;
-        }
-        const classifiableKinds = new Set(["decision", "lesson", "capture", "project", "daily", "person"]);
-        let writeBody = r.body;
-        let writeRelPath = r.relPath;
-        let writeFrontmatter = r.frontmatter;
-        if (classifiableKinds.has(it.kind)) {
-            try {
-                const classifyFm = it.project
-                    ? { ...r.frontmatter, project: it.project }
-                    : r.frontmatter;
-                const candidateDoc = serializeNote(classifyFm, r.body);
-                const cr = classify({ proposedType: it.kind, title: it.title, body: candidateDoc });
-                if (!cr.accepted) {
-                    recordRejection(vaultPath(), {
-                        type: it.kind,
-                        reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
-                        sessionId: sid,
-                        title: it.title,
-                        excerpt: candidateDoc.slice(0, 500),
-                    });
-                    const targetKind = cr.suggestedType ?? it.kind;
-                    if (targetKind === "lesson") {
-                        const reItem = { ...it, kind: "lesson" };
-                        const r2 = route(reItem);
-                        writeFrontmatter = r2.frontmatter;
-                        writeRelPath = r2.relPath;
-                        writeBody = coerceLesson(reItem, r.body);
-                    }
-                    else {
-                        const reItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
-                        const r2 = route(reItem);
-                        writeFrontmatter = r2.frontmatter;
-                        writeRelPath = r2.relPath;
-                        writeBody = coerceCapture(reItem, r.body);
-                    }
-                }
-            }
-            catch (e) {
-                writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
-            }
-        }
-        const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
-        if (res.ok && res.reason !== "duplicate-skipped") {
-            try {
-                await indexNote(writeRelPath);
-            }
-            catch (e) {
-                writeFailure(`index failed: ${e?.message || e}`);
-            }
-            (routedByDate[it.date] ||= []).push(writeRelPath);
-            notesWritten++;
+        catch (e) {
+            recordRejection(vaultPath(), {
+                type: asText(it?.kind) || "unknown",
+                reason: `item dropped (routing error): ${e?.message || e}`,
+                sessionId: sid,
+                title: asText(it?.title),
+                excerpt: asText(it?.body).slice(0, 500),
+            });
+            writeFailure(`item dropped: ${e?.message || e}`);
         }
     }
     try {

--- a/dist/src/router.js
+++ b/dist/src/router.js
@@ -1,14 +1,27 @@
+export function asText(v) {
+    if (typeof v === "string")
+        return v;
+    if (v === null || v === undefined)
+        return "";
+    if (typeof v === "object") {
+        try {
+            return JSON.stringify(v);
+        }
+        catch {
+            return String(v);
+        }
+    }
+    return String(v);
+}
 export function slug(s) {
-    return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "untitled";
+    return asText(s).toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "untitled";
 }
 function withLinks(body, links) {
     const wl = links.filter(Boolean).map((l) => `[[${l}]]`);
     return wl.length ? `${body}\n\nRelated: ${wl.join(" ")}` : body;
 }
-// Helper: emit "## Heading\n\ncontent" only when content is non-empty. Lets the
-// router omit sections the distiller chose not to fill.
 function section(heading, content) {
-    const v = (content || "").trim();
+    const v = asText(content).trim();
     return v ? `## ${heading}\n\n${v}` : "";
 }
 function joinSections(parts) {
@@ -24,11 +37,11 @@ export function route(item) {
                 section("Alternatives considered", item.alternatives),
                 section("Consequences", item.consequences),
             ]);
-            const inner = structured || (item.body || "").trim();
+            const inner = structured || asText(item.body).trim();
             return {
                 relPath: `decisions/${item.date}-${slug(item.title)}.md`,
                 frontmatter: { type: "decision", status: "active", ...(item.project ? { project: slug(item.project) } : {}), ...base },
-                body: withLinks(`# ${item.date} — ${item.title}\n\n${inner}`, item.links),
+                body: withLinks(`# ${item.date} — ${asText(item.title)}\n\n${inner}`, item.links),
                 mode: "create",
             };
         }
@@ -36,14 +49,14 @@ export function route(item) {
             return {
                 relPath: `projects/${slug(item.project || "unknown")}.md`,
                 frontmatter: { type: "project", status: "active", project: slug(item.project || "unknown"), ...base },
-                body: withLinks(`**${item.title}** — ${(item.body || "").trim()}`, item.links),
+                body: withLinks(`**${asText(item.title)}** — ${asText(item.body).trim()}`, item.links),
                 mode: "append",
             };
         case "person":
             return {
                 relPath: `people/${slug(item.person || "unknown")}.md`,
                 frontmatter: { type: "person", status: "active", ...base },
-                body: withLinks((item.body || "").trim(), item.links),
+                body: withLinks(asText(item.body).trim(), item.links),
                 mode: "append",
             };
         case "gotcha": {
@@ -53,20 +66,16 @@ export function route(item) {
                 section("Fix", item.fix),
                 section("Prevention", item.prevention),
             ]);
-            const inner = structured || (item.body || "").trim();
+            const inner = structured || asText(item.body).trim();
             return {
                 relPath: `projects/${slug(item.project || "unknown")}.md`,
                 frontmatter: { type: "project", status: "active", project: slug(item.project || "unknown"), ...base },
-                body: withLinks(`## Gotcha — ${item.title}\n\n${inner}`, item.links),
+                body: withLinks(`## Gotcha — ${asText(item.title)}\n\n${inner}`, item.links),
                 mode: "append",
             };
         }
         case "lesson": {
-            // "Structured" means the distiller filled one of the NEW lesson sections
-            // (why / whenApplies). The legacy shape is { body, rule } — that path
-            // must keep producing `**Why:** body` + `**Rule:** rule` for back-compat
-            // with existing fixtures and any in-flight ndjson stubs.
-            const hasStructured = !!((item.why || "").trim() || (item.whenApplies || "").trim());
+            const hasStructured = !!(asText(item.why).trim() || asText(item.whenApplies).trim());
             let inner;
             if (hasStructured) {
                 inner = joinSections([
@@ -76,14 +85,15 @@ export function route(item) {
                 ]);
             }
             else {
-                const why = item.body ? `**Why:** ${item.body.trim()}` : "";
-                const ruleLine = item.rule ? `\n\n**Rule:** ${item.rule}` : "";
+                const whyBody = asText(item.body).trim();
+                const why = whyBody ? `**Why:** ${whyBody}` : "";
+                const ruleLine = item.rule ? `\n\n**Rule:** ${asText(item.rule).trim()}` : "";
                 inner = `${why}${ruleLine}`.trim();
             }
             return {
                 relPath: `lessons/${item.date}-${slug(item.title)}.md`,
                 frontmatter: { type: "lesson", status: "active", ...base },
-                body: withLinks(`# ${item.title}\n\n${inner}`, item.links),
+                body: withLinks(`# ${asText(item.title)}\n\n${inner}`, item.links),
                 mode: "create",
             };
         }
@@ -91,40 +101,38 @@ export function route(item) {
             return {
                 relPath: `meta/preferences.md`,
                 frontmatter: { type: "preference", ...base },
-                body: (item.body || "").trim(),
+                body: asText(item.body).trim(),
                 mode: "replace",
             };
         case "daily":
             return {
                 relPath: `daily/${item.date}.md`,
                 frontmatter: { type: "daily", ...base },
-                body: withLinks((item.body || "").trim(), item.links),
+                body: withLinks(asText(item.body).trim(), item.links),
                 mode: "append",
             };
         default: {
-            // Re-route capture items whose title matches `daily-YYYY-MM-DD` — these
-            // are daily notes that were mis-classified as captures.
-            const dailyTitle = (item.title || "").match(/^daily-(\d{4}-\d{2}-\d{2})$/);
+            const dailyTitle = asText(item.title).match(/^daily-(\d{4}-\d{2}-\d{2})$/);
             if (dailyTitle) {
                 return {
                     relPath: `daily/${dailyTitle[1]}.md`,
                     frontmatter: { type: "daily", ...base },
-                    body: withLinks((item.body || "").trim(), item.links),
+                    body: withLinks(asText(item.body).trim(), item.links),
                     mode: "append",
                 };
             }
             {
-                const hasStructured = !!((item.what || "").trim() || (item.whyItMatters || "").trim());
+                const hasStructured = !!(asText(item.what).trim() || asText(item.whyItMatters).trim());
                 let captureBody;
                 if (hasStructured) {
                     captureBody = joinSections([
-                        `# ${item.title}`,
+                        `# ${asText(item.title)}`,
                         section("What", item.what),
                         section("Why it matters", item.whyItMatters),
                     ]);
                 }
                 else {
-                    captureBody = `# ${item.title}\n\n${(item.body || "").trim()}`;
+                    captureBody = `# ${asText(item.title)}\n\n${asText(item.body).trim()}`;
                 }
                 return {
                     relPath: `capture/${item.date}-${slug(item.title)}.md`,

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -250,106 +250,117 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
   const routedByDate: Record<string, string[]> = {};
   let notesWritten = 0;
   for (const it of items) {
-    if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.all.length === 1 && sessionProj.dominant) {
-      it.project = sessionProj.dominant;
-    } else if (it.project) {
-      it.project = slug(it.project);
-    }
-    it.links = resolveLinks(it.links || [], vaultPath());
-    const r = route(it);
-    if (r.mode !== "create") {
-      const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
-      if (res0.ok && res0.reason !== "duplicate-skipped") {
-        try { await indexNote(r.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
-        (routedByDate[it.date] ||= []).push(r.relPath);
+    try {
+      if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.all.length === 1 && sessionProj.dominant) {
+        it.project = sessionProj.dominant;
+      } else if (it.project) {
+        it.project = slug(it.project);
+      }
+      it.links = resolveLinks(it.links || [], vaultPath());
+      const r = route(it);
+      if (r.mode !== "create") {
+        const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
+        if (res0.ok && res0.reason !== "duplicate-skipped") {
+          try { await indexNote(r.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
+          (routedByDate[it.date] ||= []).push(r.relPath);
+          notesWritten++;
+        }
+        continue;
+      }
+      {
+        let vaultDedupSkip = false;
+        try {
+          const vaultSearchFn = async (
+            query: string,
+            _opts?: { k?: number; type?: string; project?: string },
+          ): Promise<Array<{ path: string; score: number }>> => {
+            let ix;
+            try {
+              ix = openIndex();
+              const [qv] = await embed([query]);
+              const hits = ix.vectorKNN(qv, 1);
+              if (!hits.length) return [];
+              const [hv] = await embed([hits[0].text]);
+              let dot = 0, na = 0, nb = 0;
+              const n = Math.min(qv.length, hv.length);
+              for (let i = 0; i < n; i++) { dot += qv[i] * hv[i]; na += qv[i] ** 2; nb += hv[i] ** 2; }
+              const sim = (na && nb) ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0;
+              return [{ path: hits[0].relPath, score: sim }];
+            } catch { return []; }
+            finally { ix?.close(); }
+          };
+          const vaultMatch = await dedupAgainstVault(
+            { title: it.title, body: r.body, project: it.project, type: r.frontmatter.type as string | undefined },
+            vaultSearchFn,
+          );
+          if (vaultMatch.match) {
+            recordRejection(vaultPath(), {
+              type: r.frontmatter.type as string ?? it.kind,
+              reason: `dedup vs ${vaultMatch.match} (score ${vaultMatch.score?.toFixed(2)})`,
+              sessionId: sid,
+              title: it.title,
+              excerpt: r.body.slice(0, 500),
+            });
+            vaultDedupSkip = true;
+          }
+        } catch (e: any) {
+          writeFailure(`vault dedup error: ${e?.message || e}`);
+        }
+        if (vaultDedupSkip) continue;
+      }
+      const classifiableKinds = new Set<string>(["decision", "lesson", "capture", "project", "daily", "person"]);
+      let writeBody = r.body;
+      let writeRelPath = r.relPath;
+      let writeFrontmatter = r.frontmatter;
+      if (classifiableKinds.has(it.kind)) {
+        try {
+          const classifyFm = it.project
+            ? { ...r.frontmatter, project: it.project }
+            : r.frontmatter;
+          const candidateDoc = serializeNote(classifyFm, r.body);
+          const cr = classify({ proposedType: it.kind as NoteType, title: it.title, body: candidateDoc });
+          if (!cr.accepted) {
+            recordRejection(vaultPath(), {
+              type: it.kind,
+              reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
+              sessionId: sid,
+              title: it.title,
+              excerpt: candidateDoc.slice(0, 500),
+            });
+            const targetKind = cr.suggestedType ?? (it.kind as NoteType);
+            if (targetKind === "lesson") {
+              const reItem: DistilledItem = { ...it, kind: "lesson" };
+              const r2 = route(reItem);
+              writeFrontmatter = r2.frontmatter;
+              writeRelPath = r2.relPath;
+              writeBody = coerceLesson(reItem, r.body);
+            } else {
+              const reItem: DistilledItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
+              const r2 = route(reItem);
+              writeFrontmatter = r2.frontmatter;
+              writeRelPath = r2.relPath;
+              writeBody = coerceCapture(reItem, r.body);
+            }
+          }
+        } catch (e: any) {
+          writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
+        }
+      }
+      const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
+      if (res.ok && res.reason !== "duplicate-skipped") {
+        try { await indexNote(writeRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
+        (routedByDate[it.date] ||= []).push(writeRelPath);
         notesWritten++;
       }
-      continue;
-    }
-    {
-      let vaultDedupSkip = false;
-      try {
-        const vaultSearchFn = async (
-          query: string,
-          _opts?: { k?: number; type?: string; project?: string },
-        ): Promise<Array<{ path: string; score: number }>> => {
-          let ix;
-          try {
-            ix = openIndex();
-            const [qv] = await embed([query]);
-            const hits = ix.vectorKNN(qv, 1);
-            if (!hits.length) return [];
-            const [hv] = await embed([hits[0].text]);
-            let dot = 0, na = 0, nb = 0;
-            const n = Math.min(qv.length, hv.length);
-            for (let i = 0; i < n; i++) { dot += qv[i] * hv[i]; na += qv[i] ** 2; nb += hv[i] ** 2; }
-            const sim = (na && nb) ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0;
-            return [{ path: hits[0].relPath, score: sim }];
-          } catch { return []; }
-          finally { ix?.close(); }
-        };
-        const vaultMatch = await dedupAgainstVault(
-          { title: it.title, body: r.body, project: it.project, type: r.frontmatter.type as string | undefined },
-          vaultSearchFn,
-        );
-        if (vaultMatch.match) {
-          recordRejection(vaultPath(), {
-            type: r.frontmatter.type as string ?? it.kind,
-            reason: `dedup vs ${vaultMatch.match} (score ${vaultMatch.score?.toFixed(2)})`,
-            sessionId: sid,
-            title: it.title,
-            excerpt: r.body.slice(0, 500),
-          });
-          vaultDedupSkip = true;
-        }
-      } catch (e: any) {
-        writeFailure(`vault dedup error: ${e?.message || e}`);
-      }
-      if (vaultDedupSkip) continue;
-    }
-    const classifiableKinds = new Set<string>(["decision", "lesson", "capture", "project", "daily", "person"]);
-    let writeBody = r.body;
-    let writeRelPath = r.relPath;
-    let writeFrontmatter = r.frontmatter;
-    if (classifiableKinds.has(it.kind)) {
-      try {
-        const classifyFm = it.project
-          ? { ...r.frontmatter, project: it.project }
-          : r.frontmatter;
-        const candidateDoc = serializeNote(classifyFm, r.body);
-        const cr = classify({ proposedType: it.kind as NoteType, title: it.title, body: candidateDoc });
-        if (!cr.accepted) {
-          recordRejection(vaultPath(), {
-            type: it.kind,
-            reason: `coerced (was: ${cr.reason ?? "rejected by classifier"})`,
-            sessionId: sid,
-            title: it.title,
-            excerpt: candidateDoc.slice(0, 500),
-          });
-          const targetKind = cr.suggestedType ?? (it.kind as NoteType);
-          if (targetKind === "lesson") {
-            const reItem: DistilledItem = { ...it, kind: "lesson" };
-            const r2 = route(reItem);
-            writeFrontmatter = r2.frontmatter;
-            writeRelPath = r2.relPath;
-            writeBody = coerceLesson(reItem, r.body);
-          } else {
-            const reItem: DistilledItem = { ...it, kind: "capture", title: shortTitle(it.title, it.body || "") };
-            const r2 = route(reItem);
-            writeFrontmatter = r2.frontmatter;
-            writeRelPath = r2.relPath;
-            writeBody = coerceCapture(reItem, r.body);
-          }
-        }
-      } catch (e: any) {
-        writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
-      }
-    }
-    const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
-    if (res.ok && res.reason !== "duplicate-skipped") {
-      try { await indexNote(writeRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
-      (routedByDate[it.date] ||= []).push(writeRelPath);
-      notesWritten++;
+    } catch (e: any) {
+      recordRejection(vaultPath(), {
+        type: asText((it as any)?.kind) || "unknown",
+        reason: `item dropped (routing error): ${e?.message || e}`,
+        sessionId: sid,
+        title: asText((it as any)?.title),
+        excerpt: asText((it as any)?.body).slice(0, 500),
+      });
+      writeFailure(`item dropped: ${e?.message || e}`);
     }
   }
   try {

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -29,7 +29,7 @@ import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
 import { classifyPath, basenameSlug } from "./projectDetect.js";
-import { slug } from "./router.js";
+import { slug, asText } from "./router.js";
 
 export interface SessionProjectResult {
   dominant: string | undefined;
@@ -57,7 +57,7 @@ export function resolveSessionProject(events: any[]): SessionProjectResult {
 }
 
 function shortTitle(raw: string, fallbackBody: string): string {
-  const src = (raw || fallbackBody).trim();
+  const src = (asText(raw) || asText(fallbackBody)).trim();
   const words = src.split(/\s+/).filter(Boolean);
   const taken = words.slice(0, 8).join(" ").replace(/\.+$/, "");
   return taken || "Captured note";
@@ -78,8 +78,8 @@ function trimToWordCeiling(text: string, ceiling: number): string {
 }
 
 export function coerceCapture(item: DistilledItem, routedBody: string): string {
-  const title = shortTitle(item.title, item.body || "");
-  const rawBody = (item.body || routedBody || "").trim();
+  const title = shortTitle(asText(item.title), asText(item.body));
+  const rawBody = (asText(item.body) || asText(routedBody)).trim();
   const words = rawBody.split(/\s+/).filter(Boolean);
   const maxWhat = 180;
   const whatContent = words.length > maxWhat
@@ -91,10 +91,10 @@ export function coerceCapture(item: DistilledItem, routedBody: string): string {
 }
 
 export function coerceLesson(item: DistilledItem, routedBody: string): string {
-  const title = (item.title || "Lesson").trim();
-  const ruleText = (item.rule || "").trim() || trimToWordCeiling((item.body || routedBody || "").trim(), 30);
-  const whyText = (item.why || item.body || routedBody || "").trim() || "See session context.";
-  const whenText = (item.whenApplies || "").trim() || "In relevant future situations.";
+  const title = (asText(item.title) || "Lesson").trim();
+  const ruleText = asText(item.rule).trim() || trimToWordCeiling((asText(item.body) || asText(routedBody)).trim(), 30);
+  const whyText = (asText(item.why) || asText(item.body) || asText(routedBody)).trim() || "See session context.";
+  const whenText = asText(item.whenApplies).trim() || "In relevant future situations.";
   return `# ${title}\n\n## Rule\n\n${ruleText}\n\n## Why\n\n${whyText}\n\n## When this applies\n\n${whenText}\n`;
 }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -45,18 +45,25 @@ export interface RouteResult {
   mode: "create" | "append" | "replace";
 }
 
+export function asText(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (v === null || v === undefined) return "";
+  if (typeof v === "object") {
+    try { return JSON.stringify(v); } catch { return String(v); }
+  }
+  return String(v);
+}
+
 export function slug(s: string): string {
-  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "untitled";
+  return asText(s).toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "untitled";
 }
 function withLinks(body: string, links: string[]): string {
   const wl = links.filter(Boolean).map((l) => `[[${l}]]`);
   return wl.length ? `${body}\n\nRelated: ${wl.join(" ")}` : body;
 }
 
-// Helper: emit "## Heading\n\ncontent" only when content is non-empty. Lets the
-// router omit sections the distiller chose not to fill.
 function section(heading: string, content: string | undefined): string {
-  const v = (content || "").trim();
+  const v = asText(content).trim();
   return v ? `## ${heading}\n\n${v}` : "";
 }
 function joinSections(parts: string[]): string {
@@ -73,11 +80,11 @@ export function route(item: DistilledItem): RouteResult {
         section("Alternatives considered", item.alternatives),
         section("Consequences", item.consequences),
       ]);
-      const inner = structured || (item.body || "").trim();
+      const inner = structured || asText(item.body).trim();
       return {
         relPath: `decisions/${item.date}-${slug(item.title)}.md`,
         frontmatter: { type: "decision", status: "active", ...(item.project ? { project: slug(item.project) } : {}), ...base },
-        body: withLinks(`# ${item.date} — ${item.title}\n\n${inner}`, item.links),
+        body: withLinks(`# ${item.date} — ${asText(item.title)}\n\n${inner}`, item.links),
         mode: "create",
       };
     }
@@ -85,14 +92,14 @@ export function route(item: DistilledItem): RouteResult {
       return {
         relPath: `projects/${slug(item.project || "unknown")}.md`,
         frontmatter: { type: "project", status: "active", project: slug(item.project || "unknown"), ...base },
-        body: withLinks(`**${item.title}** — ${(item.body || "").trim()}`, item.links),
+        body: withLinks(`**${asText(item.title)}** — ${asText(item.body).trim()}`, item.links),
         mode: "append",
       };
     case "person":
       return {
         relPath: `people/${slug(item.person || "unknown")}.md`,
         frontmatter: { type: "person", status: "active", ...base },
-        body: withLinks((item.body || "").trim(), item.links),
+        body: withLinks(asText(item.body).trim(), item.links),
         mode: "append",
       };
     case "gotcha": {
@@ -102,20 +109,16 @@ export function route(item: DistilledItem): RouteResult {
         section("Fix", item.fix),
         section("Prevention", item.prevention),
       ]);
-      const inner = structured || (item.body || "").trim();
+      const inner = structured || asText(item.body).trim();
       return {
         relPath: `projects/${slug(item.project || "unknown")}.md`,
         frontmatter: { type: "project", status: "active", project: slug(item.project || "unknown"), ...base },
-        body: withLinks(`## Gotcha — ${item.title}\n\n${inner}`, item.links),
+        body: withLinks(`## Gotcha — ${asText(item.title)}\n\n${inner}`, item.links),
         mode: "append",
       };
     }
     case "lesson": {
-      // "Structured" means the distiller filled one of the NEW lesson sections
-      // (why / whenApplies). The legacy shape is { body, rule } — that path
-      // must keep producing `**Why:** body` + `**Rule:** rule` for back-compat
-      // with existing fixtures and any in-flight ndjson stubs.
-      const hasStructured = !!((item.why || "").trim() || (item.whenApplies || "").trim());
+      const hasStructured = !!(asText(item.why).trim() || asText(item.whenApplies).trim());
       let inner: string;
       if (hasStructured) {
         inner = joinSections([
@@ -124,14 +127,15 @@ export function route(item: DistilledItem): RouteResult {
           section("When this applies", item.whenApplies),
         ]);
       } else {
-        const why = item.body ? `**Why:** ${item.body.trim()}` : "";
-        const ruleLine = item.rule ? `\n\n**Rule:** ${item.rule}` : "";
+        const whyBody = asText(item.body).trim();
+        const why = whyBody ? `**Why:** ${whyBody}` : "";
+        const ruleLine = item.rule ? `\n\n**Rule:** ${asText(item.rule).trim()}` : "";
         inner = `${why}${ruleLine}`.trim();
       }
       return {
         relPath: `lessons/${item.date}-${slug(item.title)}.md`,
         frontmatter: { type: "lesson", status: "active", ...base },
-        body: withLinks(`# ${item.title}\n\n${inner}`, item.links),
+        body: withLinks(`# ${asText(item.title)}\n\n${inner}`, item.links),
         mode: "create",
       };
     }
@@ -139,39 +143,37 @@ export function route(item: DistilledItem): RouteResult {
       return {
         relPath: `meta/preferences.md`,
         frontmatter: { type: "preference", ...base },
-        body: (item.body || "").trim(),
+        body: asText(item.body).trim(),
         mode: "replace",
       };
     case "daily":
       return {
         relPath: `daily/${item.date}.md`,
         frontmatter: { type: "daily", ...base },
-        body: withLinks((item.body || "").trim(), item.links),
+        body: withLinks(asText(item.body).trim(), item.links),
         mode: "append",
       };
     default: {
-      // Re-route capture items whose title matches `daily-YYYY-MM-DD` — these
-      // are daily notes that were mis-classified as captures.
-      const dailyTitle = (item.title || "").match(/^daily-(\d{4}-\d{2}-\d{2})$/);
+      const dailyTitle = asText(item.title).match(/^daily-(\d{4}-\d{2}-\d{2})$/);
       if (dailyTitle) {
         return {
           relPath: `daily/${dailyTitle[1]}.md`,
           frontmatter: { type: "daily", ...base },
-          body: withLinks((item.body || "").trim(), item.links),
+          body: withLinks(asText(item.body).trim(), item.links),
           mode: "append",
         };
       }
       {
-        const hasStructured = !!((item.what || "").trim() || (item.whyItMatters || "").trim());
+        const hasStructured = !!(asText(item.what).trim() || asText(item.whyItMatters).trim());
         let captureBody: string;
         if (hasStructured) {
           captureBody = joinSections([
-            `# ${item.title}`,
+            `# ${asText(item.title)}`,
             section("What", item.what),
             section("Why it matters", item.whyItMatters),
           ]);
         } else {
-          captureBody = `# ${item.title}\n\n${(item.body || "").trim()}`;
+          captureBody = `# ${asText(item.title)}\n\n${asText(item.body).trim()}`;
         }
         return {
           relPath: `capture/${item.date}-${slug(item.title)}.md`,

--- a/tests/distillItemIsolation.test.ts
+++ b/tests/distillItemIsolation.test.ts
@@ -1,0 +1,93 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-iso-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-iso-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+it("one malformed item drops only itself; the good item still writes and the cursor advances", () => {
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(
+    path.join(TMP_DATA, "sessions/ISO.ndjson"),
+    JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n",
+  );
+
+  const stub = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(stub, JSON.stringify([
+    { kind: "capture", title: "Bad item with object body", date: "2026-06-05", links: [], body: { not: "a string" } },
+    {
+      kind: "lesson",
+      title: "Verify live data dir before diagnosing",
+      date: "2026-06-05",
+      rule: "Resolve the actual data path before inspecting on-disk state.",
+      why: "On 2026-05-20 a full misdiagnosis was produced because the source fallback was inspected instead of the live path.",
+      whenApplies: "Any time a plugin appears to not be writing data.",
+      links: [],
+    },
+  ]));
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/ISO.prompt.json"), "{}");
+
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+      SUPERBRAIN_DISTILL_STUB: stub,
+      SUPERBRAIN_SESSION_ID: "ISO",
+      SUPERBRAIN_EMBED_STUB: "1",
+    },
+    encoding: "utf8",
+  });
+
+  const lessonsDir = path.join(TMP_VAULT, "lessons");
+  expect(fs.existsSync(lessonsDir)).toBe(true);
+  expect(fs.readdirSync(lessonsDir).filter((f) => f.endsWith(".md")).length).toBeGreaterThan(0);
+
+  expect(Number(fs.readFileSync(path.join(TMP_DATA, "sessions/ISO.cursor"), "utf8"))).toBeGreaterThan(0);
+});
+
+it("an item that throws during routing is dropped and does not abort siblings", () => {
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(
+    path.join(TMP_DATA, "sessions/ISO2.ndjson"),
+    JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n",
+  );
+  const stub = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(stub, JSON.stringify([
+    { kind: "capture", title: "Throwing item", date: "2026-06-05", links: { bogus: true }, body: "x" },
+    { kind: "capture", title: "Good sibling capture note", date: "2026-06-05", links: [], body: "this should still be written" },
+  ]));
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/ISO2.prompt.json"), "{}");
+
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+      SUPERBRAIN_DISTILL_STUB: stub,
+      SUPERBRAIN_SESSION_ID: "ISO2",
+      SUPERBRAIN_EMBED_STUB: "1",
+    },
+    encoding: "utf8",
+  });
+
+  const captureDir = path.join(TMP_VAULT, "capture");
+  expect(fs.existsSync(captureDir)).toBe(true);
+  const written = fs.readdirSync(captureDir).filter((f) => f.endsWith(".md"));
+  expect(written.some((f) => f.includes("good-sibling"))).toBe(true);
+  expect(Number(fs.readFileSync(path.join(TMP_DATA, "sessions/ISO2.cursor"), "utf8"))).toBeGreaterThan(0);
+});

--- a/tests/distillItemIsolation.test.ts
+++ b/tests/distillItemIsolation.test.ts
@@ -65,6 +65,13 @@ it("an item that throws during routing is dropped and does not abort siblings", 
     path.join(TMP_DATA, "sessions/ISO2.ndjson"),
     JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n",
   );
+
+  // Seed the vault with one real note so buildIndex's byRelPath.size > 0.
+  // Without this, resolveLinks short-circuits before iterating `links` and
+  // the bogus object never triggers the TypeError that exercises the catch branch.
+  fs.mkdirSync(path.join(TMP_VAULT, "capture"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_VAULT, "capture", "seed-note.md"), "# Seed\n");
+
   const stub = path.join(TMP_DATA, "stub.json");
   fs.writeFileSync(stub, JSON.stringify([
     { kind: "capture", title: "Throwing item", date: "2026-06-05", links: { bogus: true }, body: "x" },
@@ -86,8 +93,13 @@ it("an item that throws during routing is dropped and does not abort siblings", 
   });
 
   const captureDir = path.join(TMP_VAULT, "capture");
-  expect(fs.existsSync(captureDir)).toBe(true);
-  const written = fs.readdirSync(captureDir).filter((f) => f.endsWith(".md"));
+  const written = fs.readdirSync(captureDir).filter((f) => f.endsWith(".md") && f !== "seed-note.md");
   expect(written.some((f) => f.includes("good-sibling"))).toBe(true);
+
+  const rejectsFile = path.join(TMP_VAULT, "meta", "distill-rejects.md");
+  expect(fs.existsSync(rejectsFile)).toBe(true);
+  const rejectsContent = fs.readFileSync(rejectsFile, "utf8");
+  expect(rejectsContent).toContain("item dropped (routing error)");
+
   expect(Number(fs.readFileSync(path.join(TMP_DATA, "sessions/ISO2.cursor"), "utf8"))).toBeGreaterThan(0);
 });

--- a/tests/distillTrimCrash.test.ts
+++ b/tests/distillTrimCrash.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { route, asText } from "../src/router.js";
+import type { DistilledItem } from "../src/router.js";
+
+describe("asText", () => {
+  it("returns strings unchanged", () => {
+    expect(asText("hello")).toBe("hello");
+    expect(asText("")).toBe("");
+  });
+  it("coerces null/undefined to empty string", () => {
+    expect(asText(null)).toBe("");
+    expect(asText(undefined)).toBe("");
+  });
+  it("coerces numbers and booleans via String", () => {
+    expect(asText(5)).toBe("5");
+    expect(asText(0)).toBe("0");
+    expect(asText(true)).toBe("true");
+  });
+  it("coerces objects and arrays via JSON.stringify (never throws)", () => {
+    expect(asText({ a: 1 })).toBe('{"a":1}');
+    expect(asText([1, 2])).toBe("[1,2]");
+  });
+});
+
+describe("route() survives non-string body/title", () => {
+  it("does not throw when capture body is a number", () => {
+    const item = { kind: "capture", title: "T", date: "2026-06-05", links: [], body: 5 } as unknown as DistilledItem;
+    expect(() => route(item)).not.toThrow();
+    const r = route(item);
+    expect(r.body).toContain("5");
+  });
+  it("does not throw when a decision body is an object", () => {
+    const item = { kind: "decision", title: "D", date: "2026-06-05", links: [], body: { x: 1 } } as unknown as DistilledItem;
+    expect(() => route(item)).not.toThrow();
+  });
+  it("does not throw when a lesson legacy body is an array", () => {
+    const item = { kind: "lesson", title: "L", date: "2026-06-05", links: [], body: [1, 2] } as unknown as DistilledItem;
+    expect(() => route(item)).not.toThrow();
+    expect(route(item).body).toContain("**Why:**");
+  });
+  it("does not throw when the title is a number (slug path)", () => {
+    const item = { kind: "capture", title: 42, date: "2026-06-05", links: [] } as unknown as DistilledItem;
+    expect(() => route(item)).not.toThrow();
+    expect(route(item).relPath).toBe("capture/2026-06-05-42.md");
+  });
+  it("leaves normal string output unchanged (regression guard)", () => {
+    const r = route({ kind: "capture", title: "Note title here", date: "2026-06-05", links: [], body: "plain body" });
+    expect(r.body).toContain("# Note title here");
+    expect(r.body).toContain("plain body");
+  });
+});
+
+import { coerceCapture, coerceLesson } from "../src/distillRun.js";
+
+describe("coercers survive non-string body", () => {
+  it("coerceCapture does not throw when body is a number", () => {
+    const item = { kind: "capture", title: "T", date: "2026-06-05", links: [], body: 7 } as unknown as DistilledItem;
+    expect(() => coerceCapture(item, "")).not.toThrow();
+    expect(coerceCapture(item, "")).toContain("## What");
+  });
+  it("coerceCapture falls back to routedBody when title is an object", () => {
+    const item = { kind: "capture", title: { x: 1 }, date: "2026-06-05", links: [] } as unknown as DistilledItem;
+    expect(() => coerceCapture(item, "routed text here")).not.toThrow();
+  });
+  it("coerceLesson does not throw when rule/why are non-strings", () => {
+    const item = { kind: "lesson", title: "L", date: "2026-06-05", links: [], rule: 1, why: [2], body: { a: 1 } } as unknown as DistilledItem;
+    expect(() => coerceLesson(item, "")).not.toThrow();
+    expect(coerceLesson(item, "")).toContain("## Rule");
+  });
+});


### PR DESCRIPTION
SuperBrain v1 Wave A. A non-string note body crashed the distiller (.trim is not a function) and zeroed whole sessions. Adds asText() normalization at every trim/slug site and wraps each item routing in its own try/catch so one malformed item is dropped (logged to meta/distill-rejects.md) rather than aborting the envelope. Consolidation-floor honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)