### PR TITLE
fix(writer): one capped project writer with a hard byte ceiling (v1 Wave A)

### DIFF
--- a/dist/src/projectWriter.js
+++ b/dist/src/projectWriter.js
@@ -1,68 +1,89 @@
 const DEFAULT_SIZE_CAP = 20480;
+const HARD_CEILING_BYTES = Number(process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES) || 32 * 1024;
+const LOW_WATER_RATIO = 0.8;
 const RECENT_HEADING = "## Recent activity";
+const STRUCTURAL_HEADINGS = new Set([
+    "## What it is",
+    "## Status",
+    "## Architecture",
+    "## Recent activity",
+    "## Gotchas",
+]);
+function collectArchivableSections(body) {
+    const headingRe = /\n(#{2,3}) (.+)\n/g;
+    const heads = [];
+    let m;
+    while ((m = headingRe.exec(body)) !== null) {
+        heads.push({ idx: m.index, level: m[1].length, text: m[2].trim() });
+    }
+    const sections = [];
+    for (let i = 0; i < heads.length; i++) {
+        const h = heads[i];
+        const fullHeading = `${"#".repeat(h.level)} ${h.text}`;
+        if (h.level === 2 && STRUCTURAL_HEADINGS.has(`## ${h.text}`))
+            continue;
+        const dateM = h.text.match(/^(\d{4}-\d{2}-\d{2})/);
+        const isGotcha = /^Gotcha\b/.test(h.text);
+        if (!dateM && !isGotcha)
+            continue;
+        const start = h.idx;
+        const end = i + 1 < heads.length ? heads[i + 1].idx : body.length;
+        sections.push({
+            date: dateM ? dateM[1] : "0000-00-00",
+            start,
+            end,
+            heading: fullHeading,
+        });
+    }
+    return sections;
+}
+function findOldestArchivableSection(body) {
+    const secs = collectArchivableSections(body);
+    if (secs.length === 0)
+        return null;
+    let oldest = secs[0];
+    for (const s of secs) {
+        if (s.date < oldest.date || (s.date === oldest.date && s.start < oldest.start))
+            oldest = s;
+    }
+    const block = body.slice(oldest.start, oldest.end);
+    const headingEnd = block.indexOf("\n", 1) + 1;
+    const content = block.slice(headingEnd).replace(/^\s+|\s+$/g, "");
+    return { date: oldest.date, content, start: oldest.start, end: oldest.end };
+}
 export function appendDatedSection(body, date, content) {
     if (!body.includes(`\n${RECENT_HEADING}\n`) &&
         !body.endsWith(RECENT_HEADING) &&
         !body.startsWith(`${RECENT_HEADING}\n`)) {
         throw new Error(`project body missing '${RECENT_HEADING}' section`);
     }
-    if (new RegExp(`(^|\\n)### ${escapeRegex(date)}\\n`).test(body)) {
-        throw new Error(`duplicate heading: ### ${date}`);
+    const dupRe = new RegExp(`((?:^|\\n)### ${escapeRegex(date)}\\n)`);
+    if (dupRe.test(body)) {
+        return body.replace(dupRe, `$1\n${content}\n\n`).replace(/\n{3,}/g, "\n\n");
     }
     const newSection = `### ${date}\n\n${content}\n\n`;
-    // Insert immediately after "## Recent activity\n"
     const updated = body.replace(`${RECENT_HEADING}\n`, `${RECENT_HEADING}\n\n${newSection}`);
-    // Normalize excessive blank lines (3+ newlines -> 2)
     return updated.replace(/\n{3,}/g, "\n\n");
 }
 export function appendDatedSectionWithArchive(body, date, content, opts = {}) {
-    const cap = opts.sizeCap ?? DEFAULT_SIZE_CAP;
+    const cap = opts.sizeCap ?? HARD_CEILING_BYTES;
+    const lowWater = Math.floor(cap * LOW_WATER_RATIO);
     let updated = appendDatedSection(body, date, content);
     const archived = [];
-    while (Buffer.byteLength(updated, "utf8") > cap) {
-        const oldest = findOldestSubsection(updated);
-        if (!oldest)
-            break;
-        archived.push({ date: oldest.date, content: oldest.content });
-        updated = updated.slice(0, oldest.start) + updated.slice(oldest.end);
-        updated = updated.replace(/\n{3,}/g, "\n\n");
+    if (Buffer.byteLength(updated, "utf8") > cap) {
+        let target = lowWater;
+        while (Buffer.byteLength(updated, "utf8") > target) {
+            const oldest = findOldestArchivableSection(updated);
+            if (!oldest)
+                break;
+            archived.push({ date: oldest.date, content: oldest.content });
+            updated = updated.slice(0, oldest.start) + updated.slice(oldest.end);
+            updated = updated.replace(/\n{3,}/g, "\n\n");
+            if (Buffer.byteLength(updated, "utf8") <= cap && archived.length > 0)
+                target = cap;
+        }
     }
     return { body: updated, archived };
-}
-function findOldestSubsection(body) {
-    const recentIdx = body.indexOf(`\n${RECENT_HEADING}\n`);
-    const recentStart = recentIdx >= 0 ? recentIdx : body.startsWith(`${RECENT_HEADING}\n`) ? 0 : -1;
-    if (recentStart < 0)
-        return null;
-    const afterHeadingIdx = recentStart + (recentIdx >= 0 ? 1 : 0);
-    // Find boundary: next "## " heading (NOT "###") after Recent activity, or end of file
-    const afterRecent = body.slice(afterHeadingIdx + RECENT_HEADING.length);
-    const nextSectionMatch = afterRecent.match(/\n## [^#]/);
-    const recentEnd = nextSectionMatch
-        ? afterHeadingIdx + RECENT_HEADING.length + nextSectionMatch.index
-        : body.length;
-    // Find all "### YYYY-MM-DD" subsections within the Recent activity block
-    const ra = body.slice(afterHeadingIdx, recentEnd);
-    const offset = afterHeadingIdx;
-    const subSectionRegex = /\n### (\d{4}-\d{2}-\d{2})\n/g;
-    let match;
-    const subs = [];
-    while ((match = subSectionRegex.exec(ra)) !== null) {
-        subs.push({ date: match[1], start: match.index + offset, end: -1 });
-    }
-    if (subs.length === 0)
-        return null;
-    // Compute end for each: start of next sub, or recentEnd
-    for (let i = 0; i < subs.length; i++) {
-        subs[i].end = i + 1 < subs.length ? subs[i + 1].start : recentEnd;
-    }
-    // Oldest = LAST sub (since they're most-recent-first)
-    const oldest = subs[subs.length - 1];
-    const block = body.slice(oldest.start, oldest.end);
-    // Skip past "\n### date\n"
-    const headingEnd = block.indexOf("\n", 1) + 1;
-    const content = block.slice(headingEnd).replace(/^\s+|\s+$/g, "");
-    return { date: oldest.date, content, start: oldest.start, end: oldest.end };
 }
 /**
  * Build a minimal project note body when the file does not yet exist.

--- a/dist/src/vaultWriter.js
+++ b/dist/src/vaultWriter.js
@@ -72,17 +72,27 @@ export function writeNote(rel, args) {
                 !currentBody.startsWith("## Recent activity\n")) {
                 currentBody = currentBody.replace(/\s+$/, "") + "\n\n## Recent activity\n";
             }
-            const r = appendDatedSectionWithArchive(currentBody, date, args.body);
             const mergedFm = { ...baseFm, ...args.frontmatter, updated: stamp };
+            const fmOverhead = Buffer.byteLength(serializeNote(mergedFm, ""), "utf8");
+            const r = appendDatedSectionWithArchive(currentBody, date, args.body, {
+                sizeCap: Math.max(8192, (Number(process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES) || 32 * 1024) - fmOverhead),
+            });
             atomicWrite(abs, serializeNote(mergedFm, r.body));
-            // Persist archived sections to projects/_archive/<slug>-<year>-Q<n>.md
             for (const a of r.archived) {
-                const year = a.date.slice(0, 4);
-                const month = parseInt(a.date.slice(5, 7), 10);
+                const year = a.date === "0000-00-00"
+                    ? new Date().toISOString().slice(0, 4)
+                    : a.date.slice(0, 4);
+                const month = a.date === "0000-00-00"
+                    ? new Date().getMonth() + 1
+                    : parseInt(a.date.slice(5, 7), 10);
                 const q = Math.ceil(month / 3);
                 const slug = path.basename(abs, ".md");
                 const archivePath = path.join(path.resolve(vaultPath()), "projects", "_archive", `${slug}-${year}-Q${q}.md`);
                 fs.mkdirSync(path.dirname(archivePath), { recursive: true });
+                if (!fs.existsSync(archivePath)) {
+                    const afm = serializeNote({ type: "summary", project: slug, archived_from: `projects/${slug}.md` }, `# ${slug} - archive ${year} Q${q}\n`);
+                    fs.writeFileSync(archivePath, afm);
+                }
                 const archiveBlock = `\n### ${a.date}\n\n${a.content}\n`;
                 fs.appendFileSync(archivePath, archiveBlock);
             }

--- a/scripts/rollup-runaway-notes.ts
+++ b/scripts/rollup-runaway-notes.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env -S node --experimental-strip-types
+import fs from "node:fs";
+import path from "node:path";
+import { parseNote, serializeNote } from "../src/frontmatter.js";
+
+const DEFAULT_CAP = Number(process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES) || 32 * 1024;
+const LOW_WATER_RATIO = 0.8;
+
+const STRUCTURAL = new Set([
+  "## What it is",
+  "## Status",
+  "## Architecture",
+  "## Recent activity",
+  "## Gotchas",
+]);
+
+const normBody = (s: string): string => s.replace(/\s+/g, " ").trim();
+
+export interface ArchivedBlock { date: string; content: string }
+export interface RollupNote {
+  file: string;
+  slug: string;
+  oldBytes: number;
+  newBody: string;
+  frontmatter: Record<string, any>;
+  archived: ArchivedBlock[];
+  archivedSectionCount: number;
+}
+export interface RollupPlan { notes: RollupNote[]; cap: number }
+
+interface RawSection { date: string; start: number; end: number }
+
+function collectArchivable(body: string): RawSection[] {
+  const headingRe = /\n(#{2,3}) (.+)\n/g;
+  const heads: Array<{ idx: number; level: number; text: string }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = headingRe.exec(body)) !== null) {
+    heads.push({ idx: m.index, level: m[1].length, text: m[2].trim() });
+  }
+  const out: RawSection[] = [];
+  for (let i = 0; i < heads.length; i++) {
+    const h = heads[i];
+    if (h.level === 2 && STRUCTURAL.has(`## ${h.text}`)) continue;
+    const dateM = h.text.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (!dateM && !/^Gotcha\b/.test(h.text)) continue;
+    out.push({
+      date: dateM ? dateM[1] : "0000-00-00",
+      start: h.idx,
+      end: i + 1 < heads.length ? heads[i + 1].idx : body.length,
+    });
+  }
+  return out;
+}
+
+function sectionContent(body: string, s: RawSection): string {
+  const block = body.slice(s.start, s.end);
+  const headingEnd = block.indexOf("\n", 1) + 1;
+  return block.slice(headingEnd).replace(/^\s+|\s+$/g, "");
+}
+
+function rollupBody(body: string, cap: number): { newBody: string; archived: ArchivedBlock[] } {
+  let updated = body;
+  const archived: ArchivedBlock[] = [];
+  const lowWater = Math.floor(cap * LOW_WATER_RATIO);
+  const seen = new Set<string>();
+  let secs = collectArchivable(updated);
+  for (let i = secs.length - 1; i >= 0; i--) {
+    const c = normBody(sectionContent(updated, secs[i]));
+    if (c.length >= 40 && seen.has(c)) {
+      archived.push({ date: secs[i].date, content: sectionContent(updated, secs[i]) });
+      updated = updated.slice(0, secs[i].start) + updated.slice(secs[i].end);
+      updated = updated.replace(/\n{3,}/g, "\n\n");
+      secs = collectArchivable(updated);
+    } else if (c.length >= 40) {
+      seen.add(c);
+    }
+  }
+  let target = lowWater;
+  while (Buffer.byteLength(updated, "utf8") > target) {
+    const list = collectArchivable(updated);
+    if (list.length === 0) break;
+    let oldest = list[0];
+    for (const s of list) {
+      if (s.date < oldest.date || (s.date === oldest.date && s.start < oldest.start)) oldest = s;
+    }
+    archived.push({ date: oldest.date, content: sectionContent(updated, oldest) });
+    updated = updated.slice(0, oldest.start) + updated.slice(oldest.end);
+    updated = updated.replace(/\n{3,}/g, "\n\n");
+    if (Buffer.byteLength(updated, "utf8") <= cap) target = cap;
+  }
+  return { newBody: updated, archived };
+}
+
+function walkProjects(vaultDir: string): string[] {
+  const dir = path.join(vaultDir, "projects");
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith(".md"))
+    .map((e) => path.join(dir, e.name));
+}
+
+export function planRollup(vaultDir: string, cap: number = DEFAULT_CAP): RollupPlan {
+  const notes: RollupNote[] = [];
+  for (const file of walkProjects(vaultDir)) {
+    const raw = fs.readFileSync(file, "utf8");
+    const oldBytes = Buffer.byteLength(raw, "utf8");
+    if (oldBytes <= cap) continue;
+    const parsed = parseNote(raw);
+    const { newBody, archived } = rollupBody(parsed.content, cap);
+    notes.push({
+      file,
+      slug: path.basename(file, ".md"),
+      oldBytes,
+      newBody,
+      frontmatter: parsed.data,
+      archived,
+      archivedSectionCount: archived.length,
+    });
+  }
+  return { notes, cap };
+}
+
+export function applyRollup(vaultDir: string, plan: RollupPlan): void {
+  const trashDir = path.join(vaultDir, ".trash");
+  fs.mkdirSync(trashDir, { recursive: true });
+  const ts = Date.now();
+  for (const n of plan.notes) {
+    fs.copyFileSync(n.file, path.join(trashDir, `${ts}-${n.slug}.md`));
+    for (const a of n.archived) {
+      const year = a.date === "0000-00-00" ? new Date().toISOString().slice(0, 4) : a.date.slice(0, 4);
+      const month = a.date === "0000-00-00" ? new Date().getMonth() + 1 : parseInt(a.date.slice(5, 7), 10);
+      const q = Math.ceil(month / 3);
+      const ap = path.join(vaultDir, "projects", "_archive", `${n.slug}-${year}-Q${q}.md`);
+      fs.mkdirSync(path.dirname(ap), { recursive: true });
+      if (!fs.existsSync(ap)) {
+        fs.writeFileSync(ap, serializeNote(
+          { type: "summary", project: n.slug, archived_from: `projects/${n.slug}.md` },
+          `# ${n.slug} — archive ${year} Q${q}\n`,
+        ));
+      }
+      fs.appendFileSync(ap, `\n### ${a.date}\n\n${a.content}\n`);
+    }
+    fs.writeFileSync(n.file, serializeNote(n.frontmatter, n.newBody));
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const vault = args.find((a) => !a.startsWith("--")) || process.env["SUPERBRAIN_VAULT_DIR"];
+  if (!vault) { console.error("usage: rollup-runaway-notes.ts <vault-dir> [--apply]"); process.exit(1); }
+  if (!fs.existsSync(vault)) { console.error(`Vault not found: ${vault}`); process.exit(1); }
+
+  const plan = planRollup(vault);
+  if (plan.notes.length === 0) { console.log("No project notes over cap. Nothing to do."); return; }
+
+  for (const n of plan.notes) {
+    const newBytes = Buffer.byteLength(serializeNote(n.frontmatter, n.newBody), "utf8");
+    console.log(`${n.slug}: ${n.oldBytes} -> ${newBytes} bytes, archiving ${n.archivedSectionCount} section(s)`);
+  }
+  if (!apply) {
+    console.log("\n(Dry-run. Use --apply to write changes. Originals are snapshotted to .trash.)");
+  } else {
+    applyRollup(vault, plan);
+    console.log(`\nApplied. ${plan.notes.length} note(s) compacted; originals snapshotted to .trash.`);
+  }
+}
+
+if (
+  process.argv[1]?.endsWith("rollup-runaway-notes.ts") ||
+  process.argv[1]?.endsWith("rollup-runaway-notes.js")
+) {
+  main();
+}

--- a/scripts/rollup-runaway-notes.ts
+++ b/scripts/rollup-runaway-notes.ts
@@ -135,7 +135,7 @@ export function applyRollup(vaultDir: string, plan: RollupPlan): void {
       if (!fs.existsSync(ap)) {
         fs.writeFileSync(ap, serializeNote(
           { type: "summary", project: n.slug, archived_from: `projects/${n.slug}.md` },
-          `# ${n.slug} — archive ${year} Q${q}\n`,
+          `# ${n.slug} - archive ${year} Q${q}\n`,
         ));
       }
       fs.appendFileSync(ap, `\n### ${a.date}\n\n${a.content}\n`);

--- a/src/projectWriter.ts
+++ b/src/projectWriter.ts
@@ -1,24 +1,78 @@
 export interface AppendOpts {
-  sizeCap?: number; // bytes; default 20480
+  sizeCap?: number;
 }
 
 export interface ArchivedSection {
-  date: string; // YYYY-MM-DD extracted from the heading
-  content: string; // the content after the heading, up to (but not including) the next ### or ## boundary
+  date: string;
+  content: string;
 }
 
 export interface AppendResult {
-  body: string; // updated full body
-  archived: ArchivedSection[]; // sections that overflowed; caller persists them
+  body: string;
+  archived: ArchivedSection[];
 }
 
 const DEFAULT_SIZE_CAP = 20480;
+const HARD_CEILING_BYTES = Number(process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES) || 32 * 1024;
+const LOW_WATER_RATIO = 0.8;
 const RECENT_HEADING = "## Recent activity";
+
+const STRUCTURAL_HEADINGS = new Set([
+  "## What it is",
+  "## Status",
+  "## Architecture",
+  "## Recent activity",
+  "## Gotchas",
+]);
+
+interface RawSection { date: string; start: number; end: number; heading: string }
+
+function collectArchivableSections(body: string): RawSection[] {
+  const headingRe = /\n(#{2,3}) (.+)\n/g;
+  const heads: Array<{ idx: number; level: number; text: string }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = headingRe.exec(body)) !== null) {
+    heads.push({ idx: m.index, level: m[1].length, text: m[2].trim() });
+  }
+  const sections: RawSection[] = [];
+  for (let i = 0; i < heads.length; i++) {
+    const h = heads[i];
+    const fullHeading = `${"#".repeat(h.level)} ${h.text}`;
+    if (h.level === 2 && STRUCTURAL_HEADINGS.has(`## ${h.text}`)) continue;
+    const dateM = h.text.match(/^(\d{4}-\d{2}-\d{2})/);
+    const isGotcha = /^Gotcha\b/.test(h.text);
+    if (!dateM && !isGotcha) continue;
+    const start = h.idx;
+    const end = i + 1 < heads.length ? heads[i + 1].idx : body.length;
+    sections.push({
+      date: dateM ? dateM[1] : "0000-00-00",
+      start,
+      end,
+      heading: fullHeading,
+    });
+  }
+  return sections;
+}
+
+function findOldestArchivableSection(
+  body: string,
+): { date: string; content: string; start: number; end: number } | null {
+  const secs = collectArchivableSections(body);
+  if (secs.length === 0) return null;
+  let oldest = secs[0];
+  for (const s of secs) {
+    if (s.date < oldest.date || (s.date === oldest.date && s.start < oldest.start)) oldest = s;
+  }
+  const block = body.slice(oldest.start, oldest.end);
+  const headingEnd = block.indexOf("\n", 1) + 1;
+  const content = block.slice(headingEnd).replace(/^\s+|\s+$/g, "");
+  return { date: oldest.date, content, start: oldest.start, end: oldest.end };
+}
 
 export function appendDatedSection(
   body: string,
   date: string,
-  content: string
+  content: string,
 ): string {
   if (
     !body.includes(`\n${RECENT_HEADING}\n`) &&
@@ -31,12 +85,10 @@ export function appendDatedSection(
     throw new Error(`duplicate heading: ### ${date}`);
   }
   const newSection = `### ${date}\n\n${content}\n\n`;
-  // Insert immediately after "## Recent activity\n"
   const updated = body.replace(
     `${RECENT_HEADING}\n`,
-    `${RECENT_HEADING}\n\n${newSection}`
+    `${RECENT_HEADING}\n\n${newSection}`,
   );
-  // Normalize excessive blank lines (3+ newlines -> 2)
   return updated.replace(/\n{3,}/g, "\n\n");
 }
 
@@ -44,63 +96,26 @@ export function appendDatedSectionWithArchive(
   body: string,
   date: string,
   content: string,
-  opts: AppendOpts = {}
+  opts: AppendOpts = {},
 ): AppendResult {
-  const cap = opts.sizeCap ?? DEFAULT_SIZE_CAP;
+  const cap = opts.sizeCap ?? HARD_CEILING_BYTES;
+  const lowWater = Math.floor(cap * LOW_WATER_RATIO);
   let updated = appendDatedSection(body, date, content);
   const archived: ArchivedSection[] = [];
 
-  while (Buffer.byteLength(updated, "utf8") > cap) {
-    const oldest = findOldestSubsection(updated);
-    if (!oldest) break;
-    archived.push({ date: oldest.date, content: oldest.content });
-    updated = updated.slice(0, oldest.start) + updated.slice(oldest.end);
-    updated = updated.replace(/\n{3,}/g, "\n\n");
+  if (Buffer.byteLength(updated, "utf8") > cap) {
+    let target = lowWater;
+    while (Buffer.byteLength(updated, "utf8") > target) {
+      const oldest = findOldestArchivableSection(updated);
+      if (!oldest) break;
+      archived.push({ date: oldest.date, content: oldest.content });
+      updated = updated.slice(0, oldest.start) + updated.slice(oldest.end);
+      updated = updated.replace(/\n{3,}/g, "\n\n");
+      if (Buffer.byteLength(updated, "utf8") <= cap && archived.length > 0) target = cap;
+    }
   }
 
   return { body: updated, archived };
-}
-
-function findOldestSubsection(
-  body: string
-): { date: string; content: string; start: number; end: number } | null {
-  const recentIdx = body.indexOf(`\n${RECENT_HEADING}\n`);
-  const recentStart =
-    recentIdx >= 0 ? recentIdx : body.startsWith(`${RECENT_HEADING}\n`) ? 0 : -1;
-  if (recentStart < 0) return null;
-
-  const afterHeadingIdx = recentStart + (recentIdx >= 0 ? 1 : 0);
-  // Find boundary: next "## " heading (NOT "###") after Recent activity, or end of file
-  const afterRecent = body.slice(afterHeadingIdx + RECENT_HEADING.length);
-  const nextSectionMatch = afterRecent.match(/\n## [^#]/);
-  const recentEnd = nextSectionMatch
-    ? afterHeadingIdx + RECENT_HEADING.length + nextSectionMatch.index!
-    : body.length;
-
-  // Find all "### YYYY-MM-DD" subsections within the Recent activity block
-  const ra = body.slice(afterHeadingIdx, recentEnd);
-  const offset = afterHeadingIdx;
-  const subSectionRegex = /\n### (\d{4}-\d{2}-\d{2})\n/g;
-  let match: RegExpExecArray | null;
-  const subs: Array<{ date: string; start: number; end: number }> = [];
-
-  while ((match = subSectionRegex.exec(ra)) !== null) {
-    subs.push({ date: match[1], start: match.index + offset, end: -1 });
-  }
-  if (subs.length === 0) return null;
-
-  // Compute end for each: start of next sub, or recentEnd
-  for (let i = 0; i < subs.length; i++) {
-    subs[i].end = i + 1 < subs.length ? subs[i + 1].start : recentEnd;
-  }
-
-  // Oldest = LAST sub (since they're most-recent-first)
-  const oldest = subs[subs.length - 1];
-  const block = body.slice(oldest.start, oldest.end);
-  // Skip past "\n### date\n"
-  const headingEnd = block.indexOf("\n", 1) + 1;
-  const content = block.slice(headingEnd).replace(/^\s+|\s+$/g, "");
-  return { date: oldest.date, content, start: oldest.start, end: oldest.end };
 }
 
 /**
@@ -109,7 +124,7 @@ function findOldestSubsection(
  */
 export function initializeProjectNote(
   slug: string,
-  frontmatter: Record<string, any>
+  frontmatter: Record<string, any>,
 ): string {
   const title = frontmatter.title || slug;
   return `# ${title}\n\n## Recent activity\n`;

--- a/src/projectWriter.ts
+++ b/src/projectWriter.ts
@@ -81,8 +81,9 @@ export function appendDatedSection(
   ) {
     throw new Error(`project body missing '${RECENT_HEADING}' section`);
   }
-  if (new RegExp(`(^|\\n)### ${escapeRegex(date)}\\n`).test(body)) {
-    throw new Error(`duplicate heading: ### ${date}`);
+  const dupRe = new RegExp(`((?:^|\\n)### ${escapeRegex(date)}\\n)`);
+  if (dupRe.test(body)) {
+    return body.replace(dupRe, `$1\n${content}\n\n`).replace(/\n{3,}/g, "\n\n");
   }
   const newSection = `### ${date}\n\n${content}\n\n`;
   const updated = body.replace(

--- a/src/vaultWriter.ts
+++ b/src/vaultWriter.ts
@@ -81,13 +81,19 @@ export function writeNote(rel: string, args: WriteArgs): WriteResult {
       ) {
         currentBody = currentBody.replace(/\s+$/, "") + "\n\n## Recent activity\n";
       }
-      const r = appendDatedSectionWithArchive(currentBody, date, args.body);
       const mergedFm = { ...baseFm, ...args.frontmatter, updated: stamp };
+      const fmOverhead = Buffer.byteLength(serializeNote(mergedFm, ""), "utf8");
+      const r = appendDatedSectionWithArchive(currentBody, date, args.body, {
+        sizeCap: Math.max(8192, (Number(process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES) || 32 * 1024) - fmOverhead),
+      });
       atomicWrite(abs, serializeNote(mergedFm, r.body));
-      // Persist archived sections to projects/_archive/<slug>-<year>-Q<n>.md
       for (const a of r.archived) {
-        const year = a.date.slice(0, 4);
-        const month = parseInt(a.date.slice(5, 7), 10);
+        const year = a.date === "0000-00-00"
+          ? new Date().toISOString().slice(0, 4)
+          : a.date.slice(0, 4);
+        const month = a.date === "0000-00-00"
+          ? new Date().getMonth() + 1
+          : parseInt(a.date.slice(5, 7), 10);
         const q = Math.ceil(month / 3);
         const slug = path.basename(abs, ".md");
         const archivePath = path.join(
@@ -97,6 +103,13 @@ export function writeNote(rel: string, args: WriteArgs): WriteResult {
           `${slug}-${year}-Q${q}.md`,
         );
         fs.mkdirSync(path.dirname(archivePath), { recursive: true });
+        if (!fs.existsSync(archivePath)) {
+          const afm = serializeNote(
+            { type: "summary", project: slug, archived_from: `projects/${slug}.md` },
+            `# ${slug} — archive ${year} Q${q}\n`,
+          );
+          fs.writeFileSync(archivePath, afm);
+        }
         const archiveBlock = `\n### ${a.date}\n\n${a.content}\n`;
         fs.appendFileSync(archivePath, archiveBlock);
       }

--- a/src/vaultWriter.ts
+++ b/src/vaultWriter.ts
@@ -106,7 +106,7 @@ export function writeNote(rel: string, args: WriteArgs): WriteResult {
         if (!fs.existsSync(archivePath)) {
           const afm = serializeNote(
             { type: "summary", project: slug, archived_from: `projects/${slug}.md` },
-            `# ${slug} — archive ${year} Q${q}\n`,
+            `# ${slug} - archive ${year} Q${q}\n`,
           );
           fs.writeFileSync(archivePath, afm);
         }

--- a/tests/distillProjectWriter.test.ts
+++ b/tests/distillProjectWriter.test.ts
@@ -114,14 +114,13 @@ it("creates project note from scratch when file does not exist, with ## Recent a
   expect(content).toContain("Service owns auth");
 });
 
-it("archives oldest dated subsection to projects/_archive/<slug>-<year>-Q<n>.md when file exceeds 20KB", () => {
-  // Build a project note that's already >19KB so one more append tips it over
+it("archives oldest dated subsection to projects/_archive/<slug>-<year>-Q<n>.md when file exceeds 32KB ceiling", () => {
+  // Build a project note that's already >32KB so one more append tips it over
   const projectsDir = path.join(TMP_VAULT, "projects");
   fs.mkdirSync(projectsDir, { recursive: true });
 
-  // Fill ## Recent activity with content to push file size well over cap.
-  // The initial note alone must already exceed 20KB so any new append triggers archiving.
-  const bigChunk = "x".repeat(20_800);
+  // Fill ## Recent activity with content to push file size well over the 32KB ceiling.
+  const bigChunk = "x".repeat(33_000);
   const existingNote = [
     "---",
     "type: project",
@@ -153,6 +152,10 @@ it("archives oldest dated subsection to projects/_archive/<slug>-<year>-Q<n>.md 
   // At least one archive file for bigapp must exist
   const archiveFiles = fs.readdirSync(archiveDir).filter(f => f.startsWith("bigapp-"));
   expect(archiveFiles.length).toBeGreaterThan(0);
+
+  // Archive file must carry the project slug in frontmatter (never NULL-tagged)
+  const archived = fs.readFileSync(path.join(archiveDir, archiveFiles[0]), "utf8");
+  expect(archived).toContain("project: bigapp");
 
   // The main file must still contain Recent activity and the new fact
   const main = fs.readFileSync(path.join(projectsDir, "bigapp.md"), "utf8");

--- a/tests/projectWriter.test.ts
+++ b/tests/projectWriter.test.ts
@@ -44,8 +44,13 @@ describe("appendDatedSection", () => {
     expect(out).toMatch(/## Recent activity\n\n### 2026-05-23\n\nshipped Phase 4\.\n\n### 2026-05-22/);
   });
 
-  it("throws on duplicate date heading", () => {
-    expect(() => appendDatedSection(minimalBody, "2026-05-22", "extra")).toThrow(/duplicate heading/);
+  it("merges into the existing section on duplicate date heading", () => {
+    const out = appendDatedSection(minimalBody, "2026-05-22", "extra content");
+    expect(out).toContain("### 2026-05-22");
+    expect(out).toContain("shipped Phase 1.");
+    expect(out).toContain("extra content");
+    const matches = out.match(/### 2026-05-22/g);
+    expect(matches?.length).toBe(1);
   });
 
   it("throws when ## Recent activity section is absent", () => {
@@ -81,20 +86,20 @@ describe("appendDatedSectionWithArchive", () => {
     // Start with only ONE dated subsection. Archive it. Cannot archive further.
     const oneSub = minimalBody.replace(/### 2026-05-21\n\n[\s\S]*?(?=## Gotchas)/, "");
     const r = appendDatedSectionWithArchive(oneSub, "2026-05-23", "z".repeat(3000), { sizeCap: 100 });
-    // The newly-added one or the previous 2026-05-22 may be archived — but at most TWO subsections existed at any point.
+    // The newly-added one or the previous 2026-05-22 may be archived - but at most TWO subsections existed at any point.
     expect(r.archived.length).toBeLessThanOrEqual(2);
     // body may still be over cap because the new content itself is huge; that's expected
   });
 });
 
-describe("appendDatedSectionWithArchive — format-agnostic ceiling (A4)", () => {
+describe("appendDatedSectionWithArchive - format-agnostic ceiling (A4)", () => {
   function legacyShapedBody(sections: number): string {
     const head = `# SuperBrain\n\n## What it is\n\nA second brain.\n\n## Recent activity\n`;
     let out = head;
     for (let i = 0; i < sections; i++) {
       const day = String((i % 27) + 1).padStart(2, "0");
       out += `\n## 2026-05-${day} 12:0${i % 10}\n\n${"x".repeat(400)}\n`;
-      if (i % 3 === 0) out += `\n## Gotcha — issue ${i}\n\n${"y".repeat(200)}\n`;
+      if (i % 3 === 0) out += `\n## Gotcha - issue ${i}\n\n${"y".repeat(200)}\n`;
     }
     return out;
   }

--- a/tests/projectWriter.test.ts
+++ b/tests/projectWriter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { appendDatedSection, appendDatedSectionWithArchive } from "../src/projectWriter.js";
+import { appendDatedSection, appendDatedSectionWithArchive, type ArchivedSection } from "../src/projectWriter.js";
 
 const minimalBody = `---
 type: project
@@ -84,5 +84,40 @@ describe("appendDatedSectionWithArchive", () => {
     // The newly-added one or the previous 2026-05-22 may be archived — but at most TWO subsections existed at any point.
     expect(r.archived.length).toBeLessThanOrEqual(2);
     // body may still be over cap because the new content itself is huge; that's expected
+  });
+});
+
+describe("appendDatedSectionWithArchive — format-agnostic ceiling (A4)", () => {
+  function legacyShapedBody(sections: number): string {
+    const head = `# SuperBrain\n\n## What it is\n\nA second brain.\n\n## Recent activity\n`;
+    let out = head;
+    for (let i = 0; i < sections; i++) {
+      const day = String((i % 27) + 1).padStart(2, "0");
+      out += `\n## 2026-05-${day} 12:0${i % 10}\n\n${"x".repeat(400)}\n`;
+      if (i % 3 === 0) out += `\n## Gotcha — issue ${i}\n\n${"y".repeat(200)}\n`;
+    }
+    return out;
+  }
+
+  it("archives at least one legacy/gotcha H2 when a write exceeds the hard byte ceiling", () => {
+    const body = legacyShapedBody(120);
+    expect(Buffer.byteLength(body, "utf8")).toBeGreaterThan(32 * 1024);
+    const r = appendDatedSectionWithArchive(body, "2026-06-05", "new entry", { sizeCap: 32 * 1024 });
+    expect(r.archived.length).toBeGreaterThan(0);
+    expect(Buffer.byteLength(r.body, "utf8")).toBeLessThanOrEqual(32 * 1024);
+  });
+
+  it("preserves structural sections (## What it is) through archiving", () => {
+    const body = legacyShapedBody(120);
+    const r = appendDatedSectionWithArchive(body, "2026-06-05", "new entry", { sizeCap: 32 * 1024 });
+    expect(r.body).toContain("## What it is");
+    expect(r.body).toContain("## Recent activity");
+  });
+
+  it("the newest entry survives and the oldest dated H2 is the one evicted", () => {
+    const body = legacyShapedBody(120);
+    const r = appendDatedSectionWithArchive(body, "2026-06-05", "freshest fact", { sizeCap: 32 * 1024 });
+    expect(r.body).toContain("freshest fact");
+    expect(r.archived.some((a: ArchivedSection) => a.date.startsWith("2026-05-01"))).toBe(true);
   });
 });

--- a/tests/rollupRunawayNotes.test.ts
+++ b/tests/rollupRunawayNotes.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { planRollup, applyRollup, type RollupPlan } from "../scripts/rollup-runaway-notes.js";
+
+let TMP: string;
+const CAP = 32 * 1024;
+
+function bigLegacyNote(slug: string, sections: number): string {
+  let body = `---\ntype: project\nstatus: active\nproject: ${slug}\n---\n\n# ${slug}\n\n## What it is\n\nx\n\n## Recent activity\n`;
+  for (let i = 0; i < sections; i++) {
+    const day = String((i % 27) + 1).padStart(2, "0");
+    body += `\n## 2026-05-${day} 10:0${i % 10}\n\n${"z".repeat(500)}\n`;
+  }
+  return body;
+}
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rollup-"));
+  fs.mkdirSync(path.join(TMP, "projects"), { recursive: true });
+});
+afterEach(() => { fs.rmSync(TMP, { recursive: true, force: true }); });
+
+describe("planRollup", () => {
+  it("flags only project notes over the cap", () => {
+    fs.writeFileSync(path.join(TMP, "projects/huge.md"), bigLegacyNote("huge", 130));
+    fs.writeFileSync(path.join(TMP, "projects/small.md"), bigLegacyNote("small", 2));
+    const plan = planRollup(TMP, CAP);
+    const slugs = plan.notes.map((n) => n.slug);
+    expect(slugs).toContain("huge");
+    expect(slugs).not.toContain("small");
+  });
+
+  it("reports a non-empty archive payload and a projected size at or under cap", () => {
+    fs.writeFileSync(path.join(TMP, "projects/huge.md"), bigLegacyNote("huge", 130));
+    const plan = planRollup(TMP, CAP);
+    const note = plan.notes.find((n) => n.slug === "huge")!;
+    expect(note.archivedSectionCount).toBeGreaterThan(0);
+    expect(Buffer.byteLength(note.newBody, "utf8")).toBeLessThanOrEqual(CAP);
+  });
+
+  it("is a pure plan: planRollup does NOT modify any file", () => {
+    const p = path.join(TMP, "projects/huge.md");
+    fs.writeFileSync(p, bigLegacyNote("huge", 130));
+    const before = fs.readFileSync(p, "utf8");
+    planRollup(TMP, CAP);
+    expect(fs.readFileSync(p, "utf8")).toBe(before);
+  });
+});
+
+describe("applyRollup", () => {
+  it("rewrites the live note <= cap, writes a project-tagged archive, snapshots original to .trash", () => {
+    const p = path.join(TMP, "projects/huge.md");
+    fs.writeFileSync(p, bigLegacyNote("huge", 130));
+    const plan = planRollup(TMP, CAP);
+    applyRollup(TMP, plan);
+
+    expect(fs.statSync(p).size).toBeLessThanOrEqual(CAP);
+
+    const archiveDir = path.join(TMP, "projects/_archive");
+    const archives = fs.readdirSync(archiveDir).filter((f) => f.startsWith("huge-"));
+    expect(archives.length).toBeGreaterThan(0);
+    expect(fs.readFileSync(path.join(archiveDir, archives[0]), "utf8")).toContain("project: huge");
+
+    const trash = fs.readdirSync(path.join(TMP, ".trash"));
+    expect(trash.some((f) => f.includes("huge"))).toBe(true);
+  });
+});

--- a/tests/vaultWriter.test.ts
+++ b/tests/vaultWriter.test.ts
@@ -134,4 +134,43 @@ describe("vaultWriter", () => {
     const archive = fs.readFileSync(path.join(archiveDir, files[0]), "utf8");
     expect(archive).toMatch(/^---[\s\S]*\nproject: big2\n[\s\S]*---/m);
   });
+
+  it("two same-date project_facts stay under ceiling and overflow goes to _archive with project: tag", () => {
+    const CAP = 10 * 1024;
+    process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES = String(CAP);
+    const fm = { type: "project", status: "active", project: "sameday", created: "2026-06-05" };
+    const projectsDir = path.join(TMP, "projects");
+    fs.mkdirSync(projectsDir, { recursive: true });
+
+    let seed = "# sameday\n\n## Recent activity\n";
+    for (let i = 1; i <= 24; i++) {
+      seed += `\n### 2026-05-${String(i).padStart(2, "0")}\n\n${"a".repeat(380)}\n`;
+    }
+    fs.writeFileSync(
+      path.join(projectsDir, "sameday.md"),
+      `---\ntype: project\nstatus: active\nproject: sameday\n---\n\n${seed}`,
+    );
+
+    const bigFact = "z".repeat(500);
+    const r1 = writeNote("projects/sameday.md", { frontmatter: fm, body: bigFact + " first same-date fact on 2026-06-05", mode: "append" });
+    expect(r1.ok).toBe(true);
+
+    const r2 = writeNote("projects/sameday.md", { frontmatter: fm, body: bigFact + " second same-date fact on 2026-06-05 distinct content", mode: "append" });
+    expect(r2.ok).toBe(true);
+
+    const liveSize = fs.statSync(path.join(projectsDir, "sameday.md")).size;
+    expect(liveSize).toBeLessThanOrEqual(CAP);
+
+    const liveText = fs.readFileSync(path.join(projectsDir, "sameday.md"), "utf8");
+    expect(liveText).toContain("second same-date fact on 2026-06-05 distinct content");
+
+    const archiveDir = path.join(projectsDir, "_archive");
+    expect(fs.existsSync(archiveDir)).toBe(true);
+    const archiveFiles = fs.readdirSync(archiveDir).filter((f) => f.startsWith("sameday-"));
+    expect(archiveFiles.length).toBeGreaterThan(0);
+    const archiveContent = fs.readFileSync(path.join(archiveDir, archiveFiles[0]), "utf8");
+    expect(archiveContent).toMatch(/project: sameday/);
+
+    delete process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES;
+  });
 });

--- a/tests/vaultWriter.test.ts
+++ b/tests/vaultWriter.test.ts
@@ -89,4 +89,49 @@ describe("vaultWriter", () => {
     expect(writeNote(".git/HEAD.md", { frontmatter: { type: "project", status: "active" }, body: "", mode: "create" }).ok).toBe(false);
     expect(writeNote("subdir/.trash/x.md", { frontmatter: { type: "project", status: "active" }, body: "", mode: "create" }).ok).toBe(false);
   });
+
+  it("project append stays under the 32KB hard ceiling even from a legacy-H2-only note", () => {
+    const fm = { type: "project", status: "active", project: "big" };
+    let seed = "# Big\n\n## What it is\n\nx\n\n## Recent activity\n";
+    for (let i = 0; i < 130; i++) {
+      const day = String((i % 27) + 1).padStart(2, "0");
+      seed += `\n## 2026-05-${day} 09:0${i % 10}\n\n${"q".repeat(450)}\n`;
+    }
+    fs.mkdirSync(path.join(TMP, "projects"), { recursive: true });
+    fs.writeFileSync(
+      path.join(TMP, "projects/big.md"),
+      `---\ntype: project\nstatus: active\nproject: big\n---\n\n${seed}`,
+    );
+    expect(fs.statSync(path.join(TMP, "projects/big.md")).size).toBeGreaterThan(32 * 1024);
+
+    const r = writeNote("projects/big.md", { frontmatter: fm, body: "a brand new distilled fact about the build", mode: "append" });
+    expect(r.ok).toBe(true);
+
+    const after = fs.statSync(path.join(TMP, "projects/big.md")).size;
+    expect(after).toBeLessThanOrEqual(32 * 1024);
+    const text = fs.readFileSync(path.join(TMP, "projects/big.md"), "utf8");
+    expect(text).toContain("a brand new distilled fact about the build");
+  });
+
+  it("evicted project content lands in projects/_archive tagged with the project slug", () => {
+    const fm = { type: "project", status: "active", project: "big2" };
+    let seed = "# Big2\n\n## Recent activity\n";
+    for (let i = 0; i < 130; i++) {
+      const day = String((i % 27) + 1).padStart(2, "0");
+      seed += `\n## 2026-05-${day} 09:0${i % 10}\n\n${"w".repeat(450)}\n`;
+    }
+    fs.mkdirSync(path.join(TMP, "projects"), { recursive: true });
+    fs.writeFileSync(
+      path.join(TMP, "projects/big2.md"),
+      `---\ntype: project\nstatus: active\nproject: big2\n---\n\n${seed}`,
+    );
+
+    writeNote("projects/big2.md", { frontmatter: fm, body: "newest fact to force an archive write here", mode: "append" });
+
+    const archiveDir = path.join(TMP, "projects/_archive");
+    const files = fs.readdirSync(archiveDir).filter((f) => f.startsWith("big2-"));
+    expect(files.length).toBeGreaterThan(0);
+    const archive = fs.readFileSync(path.join(archiveDir, files[0]), "utf8");
+    expect(archive).toMatch(/^---[\s\S]*\nproject: big2\n[\s\S]*---/m);
+  });
 });

--- a/tests/vaultWriterReplace.test.ts
+++ b/tests/vaultWriterReplace.test.ts
@@ -41,13 +41,14 @@ it("replace no-ops when normalized body unchanged (mtime stable)", () => {
   expect(m2).toBe(m1);
 });
 
-it("create/append modes still behave as before (regression guard)", () => {
+it("create/append modes use dated subsections and same-date content merges", () => {
   writeNote("projects/x.md", { frontmatter: { type: "project", status: "active", project: "x", created: "2026-05-19" }, body: "first", mode: "create" });
   writeNote("projects/x.md", { frontmatter: { type: "project", status: "active", project: "x", created: "2026-05-19" }, body: "second", mode: "append" });
   const c = fs.readFileSync(path.join(TMP, "projects/x.md"), "utf8");
   expect(c).toContain("first");
   expect(c).toContain("second");
-  expect(c).toMatch(/## \d{4}-\d\d-\d\d \d\d:\d\d/);
+  expect(c).toMatch(/### \d{4}-\d\d-\d\d/);
+  expect(c).not.toMatch(/## \d{4}-\d\d-\d\d \d\d:\d\d/);
 });
 
 it("replace does not throw when created is absent on both sides", () => {


### PR DESCRIPTION
SuperBrain v1 Wave A. Collapses the dual project-write path into one writer with a hard 32KB ceiling that now fires on the dominant same-date path (the exact vector that grew superbrain.md to 213KB). Overflow is archived to projects/_archive (project-tagged, stays indexed and recallable). Includes a one-time rollup script (dry-run by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)