### PR TITLE
chore(tests): use synthetic project names in fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 *.log
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-node_modules
+node_modules/
+/node_modules
 *.log
 .DS_Store
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/alex/Projects/Vibe/SuperBrain/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/alex/Projects/Vibe/SuperBrain/node_modules

--- a/src/wikilink.ts
+++ b/src/wikilink.ts
@@ -7,7 +7,7 @@ const DATE_PREFIX = /^\d{4}-\d{2}-\d{2}-/;
 
 interface Index {
   // Index keys are lowercased so lookup is case-insensitive — Obsidian
-  // treats `[[Weddy]]` and `[[weddy]]` as the same target.
+  // treats `[[Alpha-proj]]` and `[[alpha-proj]]` as the same target.
   byRelPath: Map<string, string>;
   byBasename: Map<string, string[]>;
   byTokens: Array<{ rel: string; tokens: Set<string>; }>;

--- a/tests/backfillFrontmatter.test.ts
+++ b/tests/backfillFrontmatter.test.ts
@@ -60,18 +60,18 @@ describe("inferType", () => {
 // ---------------------------------------------------------------------------
 
 describe("inferProject", () => {
-  const knownProjects = ["superbrain", "weddy", "theweproject", "lean-ctx"];
+  const knownProjects = ["superbrain", "alpha-proj", "beta-svc", "gamma-lib"];
 
   it("projects/ folder → basename as project slug", () => {
     expect(inferProject("projects/superbrain.md", "", knownProjects)).toBe("superbrain");
   });
 
   it("projects/_archive/ → basename prefix before -YYYY-Q*", () => {
-    expect(inferProject("projects/_archive/weddy-2025-Q4.md", "", knownProjects)).toBe("weddy");
+    expect(inferProject("projects/_archive/alpha-proj-2025-Q4.md", "", knownProjects)).toBe("alpha-proj");
   });
 
   it("projects/_archive/ → basename prefix before -YYYY (no quarter)", () => {
-    expect(inferProject("projects/_archive/lean-ctx-2025-Q1.md", "", knownProjects)).toBe("lean-ctx");
+    expect(inferProject("projects/_archive/gamma-lib-2025-Q1.md", "", knownProjects)).toBe("gamma-lib");
   });
 
   it("daily/ → no project (null)", () => {
@@ -87,7 +87,7 @@ describe("inferProject", () => {
   });
 
   it("decisions/ → global (not derived from body)", () => {
-    const bodyWithSlug = "We decided to use TypeScript for theweproject frontend.";
+    const bodyWithSlug = "We decided to use TypeScript for beta-svc frontend.";
     expect(inferProject("decisions/2026-05-20-foo.md", bodyWithSlug, knownProjects)).toBe("global");
   });
 
@@ -97,12 +97,12 @@ describe("inferProject", () => {
   });
 
   it("capture/ body mentioning a slug → global (no body scan)", () => {
-    const bodyWithSlug = "Working on lean-ctx today, got some ideas.";
+    const bodyWithSlug = "Working on gamma-lib today, got some ideas.";
     expect(inferProject("capture/idea.md", bodyWithSlug, knownProjects)).toBe("global");
   });
 
   it("capture/ body containing inject marker mentioning a project → global, not that project", () => {
-    const bodyWithMarker = "<!-- superbrain:inject project=superbrain -->\nsome content about lean-ctx";
+    const bodyWithMarker = "<!-- superbrain:inject project=superbrain -->\nsome content about gamma-lib";
     expect(inferProject("capture/idea.md", bodyWithMarker, knownProjects)).toBe("global");
   });
 
@@ -281,11 +281,11 @@ describe("planBackfill", () => {
   });
 
   it("handles _archive subfolder correctly", () => {
-    writeNote("projects/_archive/weddy-2025-Q4.md", `---\nstatus: archived\n---\n\nbody\n`);
+    writeNote("projects/_archive/alpha-proj-2025-Q4.md", `---\nstatus: archived\n---\n\nbody\n`);
     const proposals = planBackfill(tmpDir);
-    const p = proposals.find(p => p.file.includes("weddy-2025-Q4.md"));
+    const p = proposals.find(p => p.file.includes("alpha-proj-2025-Q4.md"));
     expect(p).toBeDefined();
     expect(p!.changes.some(c => c.field === "type" && c.value === "project")).toBe(true);
-    expect(p!.changes.some(c => c.field === "project" && c.value === "weddy")).toBe(true);
+    expect(p!.changes.some(c => c.field === "project" && c.value === "alpha-proj")).toBe(true);
   });
 });

--- a/tests/discoverer.test.ts
+++ b/tests/discoverer.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 
 describe("discoverer — gates", () => {
   it("projectSlug uses the basename, hyphenated and lowercased", () => {
-    expect(projectSlug("/Users/alex/Projects/Vibe/SuperBrain")).toBe("superbrain");
+    expect(projectSlug("/home/user/code/SuperBrain")).toBe("superbrain");
     expect(projectSlug("/tmp/My Cool Repo")).toBe("my-cool-repo");
   });
 

--- a/tests/distillSkip.test.ts
+++ b/tests/distillSkip.test.ts
@@ -21,7 +21,7 @@ describe("shouldSkipDistill — pure helper", () => {
     const events = [
       { type: "prompt", prompt: "What is X?" },
       { type: "tool", tool: "Read", file: "/p/x.md" },
-      { type: "tool", tool: "mcp__lean-ctx__ctx_read", file: "/p/y.md" },
+      { type: "tool", tool: "mcp__gamma-lib__ctx_read", file: "/p/y.md" },
     ];
     const r = shouldSkipDistill(events);
     expect(r.skip).toBe(true);

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -40,10 +40,10 @@ describe("frontmatter", () => {
     expect(() => serializeNote({ type: "preference", created: "2026-05-22" }, "body")).not.toThrow();
   });
 
-  it("parseNote normalizes wikilink project ([['projects/weddy']]) to string", () => {
-    const raw = "---\ntype: project\nstatus: active\nproject:\n  - - projects/weddy\n---\n\nbody";
+  it("parseNote normalizes wikilink project ([['projects/alpha-proj']]) to string", () => {
+    const raw = "---\ntype: project\nstatus: active\nproject:\n  - - projects/alpha-proj\n---\n\nbody";
     const { data } = parseNote(raw);
-    expect(data.project).toBe("projects/weddy");
+    expect(data.project).toBe("projects/alpha-proj");
   });
 
   it("serializeNote on note missing type does not throw and returns markdown", () => {

--- a/tests/preferenceCandidates.test.ts
+++ b/tests/preferenceCandidates.test.ts
@@ -12,7 +12,7 @@ describe("isPromotable", () => {
     expect(isPromotable({ rule: "always sort imports" }, 2)).toBe(false);
   });
   it("rejects a project-scoped rule", () => {
-    expect(isPromotable({ rule: "for Weddy: use middle-east founding market" }, 5)).toBe(false);
+    expect(isPromotable({ rule: "for Alpha-proj: use middle-east founding market" }, 5)).toBe(false);
   });
   it("rejects non-imperative", () => {
     expect(isPromotable({ rule: "I learned about gray-matter" }, 5)).toBe(false);
@@ -64,9 +64,9 @@ describe("appendCandidate + autoPromoteCandidates", () => {
   });
 
   it("does not promote project-scoped candidates even after 5 observations", () => {
-    for (let i = 0; i < 5; i++) appendCandidate(vaultDir, { rule: "for Weddy: use middle-east founding market" });
+    for (let i = 0; i < 5; i++) appendCandidate(vaultDir, { rule: "for Alpha-proj: use middle-east founding market" });
     const promoted = autoPromoteCandidates(vaultDir);
-    expect(promoted).not.toContain("for Weddy: use middle-east founding market");
+    expect(promoted).not.toContain("for Alpha-proj: use middle-east founding market");
   });
 
   it("counts variants of same rule (case + trailing punctuation)", () => {

--- a/tests/recall.test.ts
+++ b/tests/recall.test.ts
@@ -71,9 +71,9 @@ describe("project-scoped recall", () => {
     );
     ix.upsertNote(
       "decisions/we1.md", 2, "h-we",
-      [{ headingPath: "", anchor: "root", text: "hybrid fusion topic weddy" }],
+      [{ headingPath: "", anchor: "root", text: "hybrid fusion topic alpha-proj" }],
       [STUB_VEC],
-      "weddy",
+      "alpha-proj",
     );
     ix.upsertNote(
       "decisions/glob.md", 2, "h-gl",

--- a/tests/retroPrunePreferences.test.ts
+++ b/tests/retroPrunePreferences.test.ts
@@ -26,7 +26,7 @@ type: preference
 ## Never push directly to main
 Some body text that is part of the heading entry.
 
-## For Weddy: use middle-east founding market
+## For Alpha-proj: use middle-east founding market
 Body.
 `;
 
@@ -39,7 +39,7 @@ Preamble paragraph.
 
 - Never add comment blocks before every method.
 - I learned that gray-matter quotes dates automatically.
-- For Weddy: use middle-east founding market.
+- For Alpha-proj: use middle-east founding market.
 
 ## Version control
 
@@ -65,7 +65,7 @@ describe("parsePreferences", () => {
     // Both headings are entries (no bullet children)
     expect(entries.length).toBeGreaterThanOrEqual(2);
     expect(entries.some(e => e.text.includes("Never push directly to main"))).toBe(true);
-    expect(entries.some(e => e.text.includes("For Weddy"))).toBe(true);
+    expect(entries.some(e => e.text.includes("For Alpha-proj"))).toBe(true);
   });
 
   it("extracts source context (line or category) for each entry", () => {
@@ -115,15 +115,15 @@ describe("classify", () => {
   });
 
   it("demotes-project a for-slug scoped entry", () => {
-    const result = classify("For Weddy: use middle-east founding market");
+    const result = classify("For Alpha-proj: use middle-east founding market");
     expect(result.verdict).toBe("demote-project");
-    expect(result.projectSlug).toBe("weddy");
+    expect(result.projectSlug).toBe("alpha-proj");
   });
 
   it("demotes-project case-insensitively", () => {
-    const result = classify("for weddy: prefer TypeScript");
+    const result = classify("for alpha-proj: prefer TypeScript");
     expect(result.verdict).toBe("demote-project");
-    expect(result.projectSlug).toBe("weddy");
+    expect(result.projectSlug).toBe("alpha-proj");
   });
 
   it("keeps a long imperative rule (no length cap for imperatives)", () => {

--- a/tests/searchIndex.test.ts
+++ b/tests/searchIndex.test.ts
@@ -69,7 +69,7 @@ describe("searchIndex", () => {
       ix.upsertNote("projects/z.md", 1, "h1",
         [{ headingPath: "", anchor: "", text: "wikilink project test" }],
         [vec(0.5)],
-        ["projects/weddy"] as any,
+        ["projects/alpha-proj"] as any,
         "2026-05-28")
     ).not.toThrow();
     expect(ix.getNoteMeta("projects/z.md")).not.toBeNull();

--- a/tests/wikilink.test.ts
+++ b/tests/wikilink.test.ts
@@ -79,16 +79,16 @@ describe("resolveLinks", () => {
     expect(resolveLinks(["anything"], path.join(vault, "does-not-exist"))).toEqual([]);
   });
 
-  it("resolves links case-insensitively (Weddy -> projects/weddy)", () => {
-    touch("projects/weddy.md");
-    expect(resolveLinks(["Weddy"], vault)).toEqual(["projects/weddy"]);
-    expect(resolveLinks(["WEDDY"], vault)).toEqual(["projects/weddy"]);
+  it("resolves links case-insensitively (Alpha-proj -> projects/alpha-proj)", () => {
+    touch("projects/alpha-proj.md");
+    expect(resolveLinks(["Alpha-proj"], vault)).toEqual(["projects/alpha-proj"]);
+    expect(resolveLinks(["ALPHA-PROJ"], vault)).toEqual(["projects/alpha-proj"]);
     expect(resolveLinks(["[[Engram]]"], vault)).toEqual([]);
   });
 
-  it("resolves case-insensitive full relative paths (Projects/Weddy -> projects/weddy)", () => {
-    touch("projects/weddy.md");
-    expect(resolveLinks(["Projects/Weddy"], vault)).toEqual(["projects/weddy"]);
+  it("resolves case-insensitive full relative paths (Projects/Alpha-proj -> projects/alpha-proj)", () => {
+    touch("projects/alpha-proj.md");
+    expect(resolveLinks(["Projects/Alpha-proj"], vault)).toEqual(["projects/alpha-proj"]);
   });
 
   it("strips leading ../ and ./ from links before resolving", () => {
@@ -99,8 +99,8 @@ describe("resolveLinks", () => {
   });
 
   it("strips pipe alias before resolving (Obsidian [[target|alias]] form)", () => {
-    touch("projects/weddy.md");
-    expect(resolveLinks(["weddy|the weddy project"], vault)).toEqual(["projects/weddy"]);
-    expect(resolveLinks(["[[weddy|Weddy]]"], vault)).toEqual(["projects/weddy"]);
+    touch("projects/alpha-proj.md");
+    expect(resolveLinks(["alpha-proj|the alpha-proj project"], vault)).toEqual(["projects/alpha-proj"]);
+    expect(resolveLinks(["[[alpha-proj|Alpha-proj]]"], vault)).toEqual(["projects/alpha-proj"]);
   });
 });


### PR DESCRIPTION
Replace real project names in test fixtures and one source comment with synthetic slugs. No behavior change; tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)