### PR TITLE
chore: complete synthetic-name scrub (scripts + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ refactor before macOS/Windows can be required-green).
   emitted link by (1) exact relative-path, (2) exact basename
   (preferring `projects/` → `decisions/` → ...), or (3) token-subset
   against post-date-strip filenames for 2+ token links. Resolution is
-  **case-insensitive** (so `[[Weddy]]` matches `projects/weddy.md`)
+  **case-insensitive** (so `[[Alpha-proj]]` matches `projects/alpha-proj.md`)
   and strips leading `./`, `../`, and pipe-aliases (`[[target|alias]]`)
   before matching. Unresolved links are dropped rather than rendered.
   `runDistill`, `runRollup`, and `injectRun`'s distill branch all

--- a/scripts/retro-prune-preferences.ts
+++ b/scripts/retro-prune-preferences.ts
@@ -132,7 +132,7 @@ export function parsePreferences(content: string): Entry[] {
  *                   There is no length cap — real preferences in this vault are long.
  *   DEMOTE-PROJECT  matches /^for <single-word-slug>:/i where the slug is a proper
  *                   noun (single CamelCase or lowercase word, not a multi-word phrase).
- *                   e.g. "For Weddy: …" → project slug "weddy"
+ *                   e.g. "For Alpha-proj: …" → project slug "alpha-proj"
  *                   but  "For CLI tools: …" → NOT a project slug → keep
  *   DEMOTE-LESSON   clear past-tense observations ("I learned…", "We got burned…",
  *                   "We discovered…") that carry no actionable directive.


### PR DESCRIPTION
Follow-up to #57, which scoped to tests/ and src/. Replaces the last real project name (a script comment and a CHANGELOG line) with a synthetic slug. No behavior change; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)