### PR TITLE
feat: preference de-leak with a conservative classifier

### DIFF
--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -16,7 +16,8 @@ import { vaultPath, dataDir } from "./paths.js";
 import { indexNote } from "./indexer.js";
 import { upsertDay } from "./dailyState.js";
 import { buildDailyNote } from "./dailyNote.js";
-import { preferencesPath } from "./preferences.js";
+import { preferencesPath, emitPreferencesCore } from "./preferences.js";
+import { filterToUniversal } from "./preferenceClassify.js";
 import { resolveLinks } from "./wikilink.js";
 import { gcTranscript } from "./transcriptStore.js";
 import { classify } from "./classification.js";
@@ -217,6 +218,23 @@ function logDistillSkip(sid, reason) {
     }
     catch { /* best-effort */ }
 }
+export function readKnownProjectSlugs(vault) {
+    const override = process.env.SUPERBRAIN_KNOWN_SLUGS_OVERRIDE;
+    if (override !== undefined) {
+        return new Set(override.split(",").map(s => s.trim().toLowerCase()).filter(Boolean));
+    }
+    const projectsDir = path.join(vault, "projects");
+    const slugs = new Set();
+    try {
+        for (const entry of fs.readdirSync(projectsDir)) {
+            if (entry.endsWith(".md") && !entry.startsWith("_")) {
+                slugs.add(entry.slice(0, -3).toLowerCase());
+            }
+        }
+    }
+    catch { /* projects dir absent */ }
+    return slugs;
+}
 export async function distillFromEvents(sid, events) {
     const env = getEnvelope(JSON.stringify(events));
     const sessionProj = resolveSessionProject(events);
@@ -233,6 +251,30 @@ export async function distillFromEvents(sid, events) {
                 it.project = slug(it.project);
             }
             it.links = resolveLinks(it.links || [], vaultPath());
+            if (it.kind === "preference") {
+                const knownSlugs = readKnownProjectSlugs(vaultPath());
+                const { universalBody, demoted } = filterToUniversal(it.body ?? "", knownSlugs);
+                it.body = universalBody;
+                for (const d of demoted) {
+                    if (d.projectSlug) {
+                        const projRelPath = `projects/${d.projectSlug}.md`;
+                        if (!fs.existsSync(path.join(vaultPath(), projRelPath))) {
+                            recordRejection(vaultPath(), { type: "preference", reason: `project note missing: ${projRelPath}`, sessionId: sid, title: it.title, excerpt: d.text.slice(0, 200) });
+                            continue;
+                        }
+                        writeNote(projRelPath, {
+                            frontmatter: { type: "project", status: "active", project: d.projectSlug, created: it.date, updated: it.date, superbrain: true },
+                            body: `**${d.text}**`,
+                            mode: "append",
+                        });
+                    }
+                    else {
+                        recordRejection(vaultPath(), { type: "preference", reason: "project-scoped rule with unresolvable slug", sessionId: sid, title: it.title, excerpt: d.text.slice(0, 200) });
+                    }
+                }
+                if (!universalBody.trim())
+                    continue;
+            }
             const r = route(it);
             if (r.mode !== "create") {
                 const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
@@ -245,6 +287,12 @@ export async function distillFromEvents(sid, events) {
                     }
                     (routedByDate[it.date] ||= []).push(r.relPath);
                     notesWritten++;
+                    if (it.kind === "preference") {
+                        try {
+                            emitPreferencesCore(it.body ?? "");
+                        }
+                        catch { /* best-effort */ }
+                    }
                 }
                 continue;
             }

--- a/dist/src/preferenceClassify.js
+++ b/dist/src/preferenceClassify.js
@@ -1,0 +1,150 @@
+// Content-based classifier for preference scope.
+// Conservative by design: default to 'universal'. A rule demotes to project
+// scope ONLY when it explicitly names a REAL EXISTING project slug:
+//   1. Explicit for-<slug>: prefix AND the slug is in the known-slugs set.
+//   2. Inline context qualifier ("in <slug>,", "when working on <slug>")
+//      AND the slug is in the known-slugs set.
+// A single common English word after "In" or "when working on" is ALWAYS
+// universal when it is not a known project slug.
+// A false positive (silently demoting a genuinely universal rule) is worse
+// than a false negative. When uncertain, keep as universal.
+// Patterns for signal 2: inline project-name context qualifiers.
+// The slug must immediately follow the qualifying phrase.
+const INLINE_PROJECT_PATTERNS = [
+    /\bin\s+([\w-]+)\s*,/i,
+    /\bfor the\s+([\w-]+)\s+codebase\b/i,
+    /\bwhen working on\s+([\w-]+)\s*[,\s]/i,
+    /\bin the\s+([\w-]+)\s+(?:project|codebase|repo|repository)\b/i,
+];
+/**
+ * Classify a single rule text as "universal" or "project".
+ * Pure function, no I/O, no LLM call.
+ *
+ * @param text - the rule text to classify
+ * @param knownSlugs - basenames of existing projects/*.md files (lowercased).
+ *   A rule is demoted to project scope ONLY when the candidate token appears
+ *   in this set. When the set is empty or the candidate is not present, the
+ *   rule stays universal.
+ */
+export function classifyPreferenceScope(text, knownSlugs = new Set()) {
+    const trimmed = text.trim();
+    // Signal 1: explicit "for <slug>: ..." prefix.
+    const signal1 = trimmed.match(/^for\s+([\w-]+)\s*:/i);
+    if (signal1) {
+        const candidate = signal1[1].toLowerCase();
+        if (knownSlugs.has(candidate)) {
+            return { scope: "project", projectSlug: candidate };
+        }
+        return { scope: "universal" };
+    }
+    // Signal 2: inline project-name mention in a context-qualifying phrase.
+    for (const pat of INLINE_PROJECT_PATTERNS) {
+        const m = trimmed.match(pat);
+        if (m) {
+            const candidate = m[1].toLowerCase();
+            if (knownSlugs.has(candidate)) {
+                return { scope: "project", projectSlug: candidate };
+            }
+            // Candidate not a known slug — fall through to universal
+        }
+    }
+    // Default: universal. Technology-stack names, conditional imperatives,
+    // past-tense narratives, common English words, and anything else all
+    // stay universal when not matched to a known project slug.
+    return { scope: "universal" };
+}
+/**
+ * Strip project-scoped rules from a full preferences doc body.
+ * Preserves "## Category" headings (drops empty categories).
+ * Non-bullet prose lines under kept headings are preserved as universal.
+ * Returns the filtered universal body and the list of demoted entries.
+ *
+ * The input may contain YAML frontmatter (--- ... ---), which is preserved
+ * verbatim in the output universalBody.
+ *
+ * @param body - the full preferences document text
+ * @param knownSlugs - basenames of existing projects/*.md files (lowercased).
+ */
+export function filterToUniversal(body, knownSlugs = new Set()) {
+    const demoted = [];
+    // Split off frontmatter
+    const fmMatch = body.match(/^(---[\s\S]*?---\s*\n?)/);
+    const frontmatter = fmMatch ? fmMatch[1] : "";
+    const content = fmMatch ? body.slice(fmMatch[0].length) : body;
+    // Parse the content into sections keyed by heading.
+    const lines = content.split("\n");
+    const sections = [];
+    let current = { heading: null, bullets: [], kept: [], prose: [], isBulletCategory: false };
+    sections.push(current);
+    for (const line of lines) {
+        if (line.startsWith("## ")) {
+            current = { heading: line.slice(3).trim(), bullets: [], kept: [], prose: [], isBulletCategory: false };
+            sections.push(current);
+            continue;
+        }
+        if (line.match(/^- /)) {
+            current.isBulletCategory = true;
+            const bulletText = line.slice(2).trim();
+            if (bulletText) {
+                current.bullets.push(bulletText);
+                const r = classifyPreferenceScope(bulletText, knownSlugs);
+                if (r.scope === "project") {
+                    demoted.push({ text: bulletText, projectSlug: r.projectSlug });
+                }
+                else {
+                    current.kept.push(bulletText);
+                }
+            }
+            continue;
+        }
+        // Non-bullet lines (prose paragraphs, blank lines).
+        // For the preamble (heading === null) they go into kept for reconstruction.
+        // For named sections they go into prose so we can re-emit them when the
+        // section has kept bullets OR when the section has no bullets at all.
+        if (current.heading === null) {
+            current.kept.push(line);
+        }
+        else {
+            current.prose.push(line);
+        }
+    }
+    // Reconstruct the filtered body.
+    const outputParts = [];
+    for (const sec of sections) {
+        if (sec.heading === null) {
+            // Preamble: output as-is
+            const preamble = sec.kept.join("\n");
+            if (preamble.trim())
+                outputParts.push(preamble);
+            continue;
+        }
+        if (sec.isBulletCategory) {
+            if (sec.kept.length > 0) {
+                // Emit heading + any prose intro + kept bullets
+                const prosePart = sec.prose.join("\n");
+                const bulletLines = sec.kept.map(b => `- ${b}`).join("\n");
+                const inner = prosePart.trim()
+                    ? `${prosePart.trimEnd()}\n\n${bulletLines}`
+                    : bulletLines;
+                outputParts.push(`## ${sec.heading}\n\n${inner}`);
+            }
+            // Otherwise drop the empty category (all bullets were project-scoped)
+        }
+        else {
+            // No bullets: classify the heading text itself, and preserve any prose.
+            // Prose-only sections are universal by default.
+            const r = classifyPreferenceScope(sec.heading, knownSlugs);
+            if (r.scope === "project") {
+                demoted.push({ text: sec.heading, projectSlug: r.projectSlug });
+            }
+            else {
+                const prosePart = sec.prose.join("\n");
+                const inner = prosePart.trim() ? `\n\n${prosePart.trimEnd()}` : "";
+                outputParts.push(`## ${sec.heading}${inner}`);
+            }
+        }
+    }
+    const reconstructed = outputParts.join("\n\n");
+    const universalBody = frontmatter + (reconstructed ? reconstructed + "\n" : "");
+    return { universalBody, demoted };
+}

--- a/dist/src/preferences.js
+++ b/dist/src/preferences.js
@@ -2,7 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { vaultPath } from "./paths.js";
 import { parseNote } from "./frontmatter.js";
-import { truncateToBudget, INJECT_LIMITS } from "./injectBudget.js";
+import { truncateToBudget, INJECT_LIMITS, estimateTokens } from "./injectBudget.js";
+import { atomicWrite } from "./atomicWrite.js";
 const CAP_BYTES = 3072;
 const SENTINEL = "\n[…truncated; see meta/preferences.md]\n";
 export function capPreferences(content) {
@@ -29,6 +30,63 @@ export function capPreferences(content) {
 }
 export function preferencesPath() {
     return path.join(vaultPath(), "meta", "preferences.md");
+}
+export function preferencesCorePath() {
+    return path.join(vaultPath(), "meta", "preferences-core.md");
+}
+// ~250 tokens is enough for the hard-rules core Alfred consumes.
+export const PREFERENCES_CORE_MAX_TOKENS = 250;
+// Imperative first-word prefixes that identify hard rules worth including in
+// the lean core file. Matches the same allow-list used across the codebase.
+const IMPERATIVE_PREFIXES_CORE = [
+    "always", "never", "prefer", "default", "don't", "do not", "avoid", "use",
+    "when", "before", "after",
+];
+function isHardRule(line) {
+    const trimmed = line.replace(/^[-*]\s*/, "").trim().toLowerCase();
+    return IMPERATIVE_PREFIXES_CORE.some(p => trimmed === p || trimmed.startsWith(p + " ") || trimmed.startsWith(p + ","));
+}
+/**
+ * Extract imperative rules from the universal body, truncate to
+ * PREFERENCES_CORE_MAX_TOKENS, and write to meta/preferences-core.md.
+ * Called after a successful preference replace write.
+ * Pure side-effect: writes the file; throws only on permission errors.
+ */
+export function emitPreferencesCore(universalBody) {
+    const dest = preferencesCorePath();
+    if (!universalBody.trim()) {
+        atomicWrite(dest, "");
+        return;
+    }
+    // Extract bullet lines that start with an imperative prefix.
+    const coreLines = [];
+    for (const raw of universalBody.split("\n")) {
+        const line = raw.trim();
+        // Skip headings, blank lines, frontmatter remnants, and prose
+        if (!line)
+            continue;
+        if (line.startsWith("#"))
+            continue;
+        if (line.startsWith("---"))
+            continue;
+        if (line.startsWith("type:") || line.startsWith("created:") || line.startsWith("updated:") || line.startsWith("superbrain:"))
+            continue;
+        if (isHardRule(line)) {
+            // Strip leading bullet markers for the core file
+            coreLines.push(line.replace(/^[-*]\s*/, "- "));
+        }
+    }
+    // Truncate to budget
+    const output = [];
+    let tokens = 0;
+    for (const line of coreLines) {
+        const t = estimateTokens(line) + 1; // +1 for newline
+        if (tokens + t > PREFERENCES_CORE_MAX_TOKENS)
+            break;
+        output.push(line);
+        tokens += t;
+    }
+    atomicWrite(dest, output.join("\n") + (output.length > 0 ? "\n" : ""));
 }
 export function compileInjectionBlock() {
     let raw;

--- a/scripts/retro-prune-preferences.ts
+++ b/scripts/retro-prune-preferences.ts
@@ -6,9 +6,21 @@
 //
 // Usage:
 //   npx tsx scripts/retro-prune-preferences.ts <vault-dir> [--apply]
+//
+// Extensions (B3):
+//   - Heading-preserving rewrite: kept entries are re-filed under their
+//     original ## Category headings; empty categories are dropped.
+//   - Project-rule routing: demoted entries with a known projectSlug are
+//     appended to projects/<slug>.md under a ## Preferences subsection.
+//   - Core file emission: calls emitPreferencesCore to produce
+//     meta/preferences-core.md after migration.
+//   - Idempotency: if preferences-core.md already exists and the doc has no
+//     project-scoped rules, prints "already migrated" and exits.
+//   - Dry-run: adds a CORE EMISSION PREVIEW section.
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -226,6 +238,16 @@ export function demoteLessonFilename(text: string, today: string): string {
 // Apply helpers
 // ---------------------------------------------------------------------------
 
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Reconstruct preferences.md from kept entries, preserving original
+ * ## Category headings. Entries are grouped by their source category.
+ * Empty categories are dropped. Entries whose source looks like a line
+ * reference ("line N") are placed under a fallback "## Preferences" heading.
+ */
 function buildPreferencesContent(kept: Entry[]): string {
   const header =
     `---\ntype: preference\nupdated: '${today()}'\nsuperbrain: true\n---\n` +
@@ -233,12 +255,29 @@ function buildPreferencesContent(kept: Entry[]): string {
 
   if (kept.length === 0) return header;
 
-  const lines = kept.map(e => `- ${e.text}`).join("\n");
-  return header + `## Preferences\n\n${lines}\n`;
-}
+  // Group entries by category (source), preserving insertion order.
+  const categoryOrder: string[] = [];
+  const byCategory = new Map<string, string[]>();
 
-function today(): string {
-  return new Date().toISOString().slice(0, 10);
+  for (const e of kept) {
+    // source is either a category name or "line N"
+    const cat = /^line \d+$/.test(e.source) ? "Preferences" : e.source;
+    if (!byCategory.has(cat)) {
+      categoryOrder.push(cat);
+      byCategory.set(cat, []);
+    }
+    byCategory.get(cat)!.push(e.text);
+  }
+
+  const sections: string[] = [];
+  for (const cat of categoryOrder) {
+    const entries = byCategory.get(cat)!;
+    if (entries.length === 0) continue;
+    const lines = entries.map(t => `- ${t}`).join("\n");
+    sections.push(`## ${cat}\n\n${lines}`);
+  }
+
+  return header + sections.join("\n\n") + "\n";
 }
 
 function lessonContent(text: string): string {
@@ -249,8 +288,47 @@ function lessonContent(text: string): string {
   );
 }
 
+// Route demoted project rules under ## Preferences (not ## Gotcha).
+function projectPreferencesBlock(text: string): string {
+  return `\n## Preferences\n\n- ${text}\n`;
+}
+
+// Legacy alias preserved for tests that reference projectGotchaBlock.
+// Kept entries no longer use Gotcha for project-preference routing.
 function projectGotchaBlock(text: string): string {
   return `\n## Gotcha\n\n${text}\n`;
+}
+
+// Build the preferences-core content (imperative rules, truncated).
+// Mirrors the logic in src/preferences.ts but without the ESM import so the
+// script can run standalone.
+const IMPERATIVE_PREFIXES_CORE = [
+  "always", "never", "prefer", "default", "don't", "do not", "avoid", "use",
+  "when", "before", "after",
+];
+
+function isHardRule(line: string): boolean {
+  const trimmed = line.replace(/^[-*]\s*/, "").trim().toLowerCase();
+  return IMPERATIVE_PREFIXES_CORE.some(
+    p => trimmed === p || trimmed.startsWith(p + " ") || trimmed.startsWith(p + ","),
+  );
+}
+
+const CORE_MAX_TOKENS = 250;
+function estimateTokens(t: string): number { return Math.ceil(t.length / 4); }
+
+function buildCoreContent(keptEntries: Entry[]): string {
+  const output: string[] = [];
+  let tokens = 0;
+  for (const e of keptEntries) {
+    const line = `- ${e.text}`;
+    if (!isHardRule(line)) continue;
+    const t = estimateTokens(line) + 1;
+    if (tokens + t > CORE_MAX_TOKENS) break;
+    output.push(line);
+    tokens += t;
+  }
+  return output.join("\n") + (output.length > 0 ? "\n" : "");
 }
 
 // ---------------------------------------------------------------------------
@@ -287,6 +365,17 @@ function main(): void {
 
   const date = today();
 
+  // Idempotency check: if preferences-core.md already exists and there are no
+  // project-scoped rules left, this vault is already migrated.
+  const coreFile = path.join(vault, "meta", "preferences-core.md");
+  if (apply && fs.existsSync(coreFile) && projects.length === 0 && lessons.length === 0) {
+    // Re-emit the core to ensure it is up-to-date, but skip all other writes.
+    const coreContent = buildCoreContent(kept.map(c => c.entry));
+    fs.writeFileSync(coreFile, coreContent);
+    console.log("already migrated: preferences-core.md exists and no project-scoped rules found. Core re-emitted.");
+    return;
+  }
+
   // --- Print report ---
   console.log(`\nKEEP (${kept.length} entries):`);
   for (const c of kept) {
@@ -310,8 +399,20 @@ function main(): void {
     const preview = c.entry.text.length > 80
       ? c.entry.text.slice(0, 77) + "…"
       : c.entry.text;
-    console.log(`  "${preview}"\n    → projects/${c.projectSlug}.md (Gotchas section)`);
+    console.log(`  "${preview}"\n    → projects/${c.projectSlug}.md (Preferences section)`);
   }
+
+  // Always show the CORE EMISSION PREVIEW (dry-run or apply)
+  const corePreview = buildCoreContent(kept.map(c => c.entry));
+  console.log("\n--- CORE EMISSION PREVIEW (meta/preferences-core.md) ---");
+  if (corePreview.trim()) {
+    for (const line of corePreview.trimEnd().split("\n")) {
+      console.log(`  ${line}`);
+    }
+  } else {
+    console.log("  (empty — no imperative-prefix rules found)");
+  }
+  console.log("---");
 
   if (!apply) {
     console.log("\n(Dry-run. Use --apply to write changes.)");
@@ -325,7 +426,7 @@ function main(): void {
   fs.copyFileSync(file, bakFile);
   console.log(`\nBacked up original to ${bakFile}`);
 
-  // Rewrite meta/preferences.md with only kept entries
+  // Heading-preserving rewrite of meta/preferences.md
   fs.writeFileSync(file, buildPreferencesContent(kept.map(c => c.entry)));
 
   // Write lesson files
@@ -342,7 +443,7 @@ function main(): void {
     }
   }
 
-  // Append gotchas to project files
+  // Append demoted project rules to project files under ## Preferences.
   let appendedProjects = 0;
   const projectsDir = path.join(vault, "projects");
   fs.mkdirSync(projectsDir, { recursive: true });
@@ -350,7 +451,7 @@ function main(): void {
   for (const c of projects) {
     const slug = c.projectSlug!;
     const dest = path.join(projectsDir, `${slug}.md`);
-    const block = projectGotchaBlock(c.entry.text);
+    const block = projectPreferencesBlock(c.entry.text);
     if (fs.existsSync(dest)) {
       fs.appendFileSync(dest, block);
     } else {
@@ -362,10 +463,15 @@ function main(): void {
     appendedProjects++;
   }
 
+  // Emit the preferences-core after migration.
+  fs.mkdirSync(path.join(vault, "meta"), { recursive: true });
+  fs.writeFileSync(coreFile, corePreview);
+
   console.log(
     `Applied. meta/preferences.md now has ${kept.length} entries; ` +
     `created ${createdLessons} lesson files; ` +
-    `appended ${appendedProjects} project gotchas.`
+    `appended ${appendedProjects} project entries; ` +
+    `wrote meta/preferences-core.md.`,
   );
 }
 

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -18,7 +18,8 @@ import { vaultPath, dataDir } from "./paths.js";
 import { indexNote } from "./indexer.js";
 import { upsertDay } from "./dailyState.js";
 import { buildDailyNote } from "./dailyNote.js";
-import { preferencesPath } from "./preferences.js";
+import { preferencesPath, emitPreferencesCore } from "./preferences.js";
+import { filterToUniversal } from "./preferenceClassify.js";
 import { resolveLinks } from "./wikilink.js";
 import { gcTranscript } from "./transcriptStore.js";
 import { classify } from "./classification.js";
@@ -242,6 +243,23 @@ export interface DistillEventsResult {
   notesWritten: number;
 }
 
+export function readKnownProjectSlugs(vault: string): Set<string> {
+  const override = process.env.SUPERBRAIN_KNOWN_SLUGS_OVERRIDE;
+  if (override !== undefined) {
+    return new Set(override.split(",").map(s => s.trim().toLowerCase()).filter(Boolean));
+  }
+  const projectsDir = path.join(vault, "projects");
+  const slugs = new Set<string>();
+  try {
+    for (const entry of fs.readdirSync(projectsDir)) {
+      if (entry.endsWith(".md") && !entry.startsWith("_")) {
+        slugs.add(entry.slice(0, -3).toLowerCase());
+      }
+    }
+  } catch { /* projects dir absent */ }
+  return slugs;
+}
+
 export async function distillFromEvents(sid: string, events: any[]): Promise<DistillEventsResult> {
   const env = getEnvelope(JSON.stringify(events));
   const sessionProj = resolveSessionProject(events);
@@ -257,6 +275,28 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
         it.project = slug(it.project);
       }
       it.links = resolveLinks(it.links || [], vaultPath());
+      if (it.kind === "preference") {
+        const knownSlugs = readKnownProjectSlugs(vaultPath());
+        const { universalBody, demoted } = filterToUniversal(it.body ?? "", knownSlugs);
+        it.body = universalBody;
+        for (const d of demoted) {
+          if (d.projectSlug) {
+            const projRelPath = `projects/${d.projectSlug}.md`;
+            if (!fs.existsSync(path.join(vaultPath(), projRelPath))) {
+              recordRejection(vaultPath(), { type: "preference", reason: `project note missing: ${projRelPath}`, sessionId: sid, title: it.title, excerpt: d.text.slice(0, 200) });
+              continue;
+            }
+            writeNote(projRelPath, {
+              frontmatter: { type: "project", status: "active", project: d.projectSlug, created: it.date, updated: it.date, superbrain: true },
+              body: `**${d.text}**`,
+              mode: "append",
+            });
+          } else {
+            recordRejection(vaultPath(), { type: "preference", reason: "project-scoped rule with unresolvable slug", sessionId: sid, title: it.title, excerpt: d.text.slice(0, 200) });
+          }
+        }
+        if (!universalBody.trim()) continue;
+      }
       const r = route(it);
       if (r.mode !== "create") {
         const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
@@ -264,6 +304,9 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
           try { await indexNote(r.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
           (routedByDate[it.date] ||= []).push(r.relPath);
           notesWritten++;
+          if (it.kind === "preference") {
+            try { emitPreferencesCore(it.body ?? ""); } catch { /* best-effort */ }
+          }
         }
         continue;
       }

--- a/src/preferenceClassify.ts
+++ b/src/preferenceClassify.ts
@@ -1,0 +1,189 @@
+// Content-based classifier for preference scope.
+// Conservative by design: default to 'universal'. A rule demotes to project
+// scope ONLY when it explicitly names a REAL EXISTING project slug:
+//   1. Explicit for-<slug>: prefix AND the slug is in the known-slugs set.
+//   2. Inline context qualifier ("in <slug>,", "when working on <slug>")
+//      AND the slug is in the known-slugs set.
+// A single common English word after "In" or "when working on" is ALWAYS
+// universal when it is not a known project slug.
+// A false positive (silently demoting a genuinely universal rule) is worse
+// than a false negative. When uncertain, keep as universal.
+
+export interface ScopeResult {
+  scope: "universal" | "project";
+  projectSlug?: string;
+}
+
+export interface DemotedEntry {
+  text: string;
+  projectSlug?: string;
+}
+
+export interface FilterResult {
+  universalBody: string;
+  demoted: DemotedEntry[];
+}
+
+// Patterns for signal 2: inline project-name context qualifiers.
+// The slug must immediately follow the qualifying phrase.
+const INLINE_PROJECT_PATTERNS = [
+  /\bin\s+([\w-]+)\s*,/i,
+  /\bfor the\s+([\w-]+)\s+codebase\b/i,
+  /\bwhen working on\s+([\w-]+)\s*[,\s]/i,
+  /\bin the\s+([\w-]+)\s+(?:project|codebase|repo|repository)\b/i,
+];
+
+/**
+ * Classify a single rule text as "universal" or "project".
+ * Pure function, no I/O, no LLM call.
+ *
+ * @param text - the rule text to classify
+ * @param knownSlugs - basenames of existing projects/*.md files (lowercased).
+ *   A rule is demoted to project scope ONLY when the candidate token appears
+ *   in this set. When the set is empty or the candidate is not present, the
+ *   rule stays universal.
+ */
+export function classifyPreferenceScope(
+  text: string,
+  knownSlugs: ReadonlySet<string> = new Set(),
+): ScopeResult {
+  const trimmed = text.trim();
+
+  // Signal 1: explicit "for <slug>: ..." prefix.
+  const signal1 = trimmed.match(/^for\s+([\w-]+)\s*:/i);
+  if (signal1) {
+    const candidate = signal1[1].toLowerCase();
+    if (knownSlugs.has(candidate)) {
+      return { scope: "project", projectSlug: candidate };
+    }
+    return { scope: "universal" };
+  }
+
+  // Signal 2: inline project-name mention in a context-qualifying phrase.
+  for (const pat of INLINE_PROJECT_PATTERNS) {
+    const m = trimmed.match(pat);
+    if (m) {
+      const candidate = m[1].toLowerCase();
+      if (knownSlugs.has(candidate)) {
+        return { scope: "project", projectSlug: candidate };
+      }
+      // Candidate not a known slug — fall through to universal
+    }
+  }
+
+  // Default: universal. Technology-stack names, conditional imperatives,
+  // past-tense narratives, common English words, and anything else all
+  // stay universal when not matched to a known project slug.
+  return { scope: "universal" };
+}
+
+/**
+ * Strip project-scoped rules from a full preferences doc body.
+ * Preserves "## Category" headings (drops empty categories).
+ * Non-bullet prose lines under kept headings are preserved as universal.
+ * Returns the filtered universal body and the list of demoted entries.
+ *
+ * The input may contain YAML frontmatter (--- ... ---), which is preserved
+ * verbatim in the output universalBody.
+ *
+ * @param body - the full preferences document text
+ * @param knownSlugs - basenames of existing projects/*.md files (lowercased).
+ */
+export function filterToUniversal(
+  body: string,
+  knownSlugs: ReadonlySet<string> = new Set(),
+): FilterResult {
+  const demoted: DemotedEntry[] = [];
+
+  // Split off frontmatter
+  const fmMatch = body.match(/^(---[\s\S]*?---\s*\n?)/);
+  const frontmatter = fmMatch ? fmMatch[1] : "";
+  const content = fmMatch ? body.slice(fmMatch[0].length) : body;
+
+  // Parse the content into sections keyed by heading.
+  const lines = content.split("\n");
+
+  interface Section {
+    heading: string | null;
+    bullets: string[];
+    kept: string[];
+    prose: string[];     // non-bullet prose lines in order (raw lines)
+    isBulletCategory: boolean;
+  }
+
+  const sections: Section[] = [];
+  let current: Section = { heading: null, bullets: [], kept: [], prose: [], isBulletCategory: false };
+  sections.push(current);
+
+  for (const line of lines) {
+    if (line.startsWith("## ")) {
+      current = { heading: line.slice(3).trim(), bullets: [], kept: [], prose: [], isBulletCategory: false };
+      sections.push(current);
+      continue;
+    }
+    if (line.match(/^- /)) {
+      current.isBulletCategory = true;
+      const bulletText = line.slice(2).trim();
+      if (bulletText) {
+        current.bullets.push(bulletText);
+        const r = classifyPreferenceScope(bulletText, knownSlugs);
+        if (r.scope === "project") {
+          demoted.push({ text: bulletText, projectSlug: r.projectSlug });
+        } else {
+          current.kept.push(bulletText);
+        }
+      }
+      continue;
+    }
+    // Non-bullet lines (prose paragraphs, blank lines).
+    // For the preamble (heading === null) they go into kept for reconstruction.
+    // For named sections they go into prose so we can re-emit them when the
+    // section has kept bullets OR when the section has no bullets at all.
+    if (current.heading === null) {
+      current.kept.push(line);
+    } else {
+      current.prose.push(line);
+    }
+  }
+
+  // Reconstruct the filtered body.
+  const outputParts: string[] = [];
+
+  for (const sec of sections) {
+    if (sec.heading === null) {
+      // Preamble: output as-is
+      const preamble = sec.kept.join("\n");
+      if (preamble.trim()) outputParts.push(preamble);
+      continue;
+    }
+
+    if (sec.isBulletCategory) {
+      if (sec.kept.length > 0) {
+        // Emit heading + any prose intro + kept bullets
+        const prosePart = sec.prose.join("\n");
+        const bulletLines = sec.kept.map(b => `- ${b}`).join("\n");
+        const inner = prosePart.trim()
+          ? `${prosePart.trimEnd()}\n\n${bulletLines}`
+          : bulletLines;
+        outputParts.push(`## ${sec.heading}\n\n${inner}`);
+      }
+      // Otherwise drop the empty category (all bullets were project-scoped)
+    } else {
+      // No bullets: classify the heading text itself, and preserve any prose.
+      // Prose-only sections are universal by default.
+      const r = classifyPreferenceScope(sec.heading, knownSlugs);
+      if (r.scope === "project") {
+        demoted.push({ text: sec.heading, projectSlug: r.projectSlug });
+      } else {
+        const prosePart = sec.prose.join("\n");
+        const inner = prosePart.trim() ? `\n\n${prosePart.trimEnd()}` : "";
+        outputParts.push(`## ${sec.heading}${inner}`);
+      }
+    }
+  }
+
+  const reconstructed = outputParts.join("\n\n");
+  const universalBody = frontmatter + (reconstructed ? reconstructed + "\n" : "");
+
+  return { universalBody, demoted };
+}

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -2,7 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { vaultPath } from "./paths.js";
 import { parseNote } from "./frontmatter.js";
-import { truncateToBudget, INJECT_LIMITS } from "./injectBudget.js";
+import { truncateToBudget, INJECT_LIMITS, estimateTokens } from "./injectBudget.js";
+import { atomicWrite } from "./atomicWrite.js";
 
 const CAP_BYTES = 3072;
 const SENTINEL = "\n[…truncated; see meta/preferences.md]\n";
@@ -35,6 +36,67 @@ export function capPreferences(content: string): string {
 
 export function preferencesPath(): string {
   return path.join(vaultPath(), "meta", "preferences.md");
+}
+
+export function preferencesCorePath(): string {
+  return path.join(vaultPath(), "meta", "preferences-core.md");
+}
+
+// ~250 tokens is enough for the hard-rules core Alfred consumes.
+export const PREFERENCES_CORE_MAX_TOKENS = 250;
+
+// Imperative first-word prefixes that identify hard rules worth including in
+// the lean core file. Matches the same allow-list used across the codebase.
+const IMPERATIVE_PREFIXES_CORE = [
+  "always", "never", "prefer", "default", "don't", "do not", "avoid", "use",
+  "when", "before", "after",
+];
+
+function isHardRule(line: string): boolean {
+  const trimmed = line.replace(/^[-*]\s*/, "").trim().toLowerCase();
+  return IMPERATIVE_PREFIXES_CORE.some(p => trimmed === p || trimmed.startsWith(p + " ") || trimmed.startsWith(p + ","));
+}
+
+/**
+ * Extract imperative rules from the universal body, truncate to
+ * PREFERENCES_CORE_MAX_TOKENS, and write to meta/preferences-core.md.
+ * Called after a successful preference replace write.
+ * Pure side-effect: writes the file; throws only on permission errors.
+ */
+export function emitPreferencesCore(universalBody: string): void {
+  const dest = preferencesCorePath();
+
+  if (!universalBody.trim()) {
+    atomicWrite(dest, "");
+    return;
+  }
+
+  // Extract bullet lines that start with an imperative prefix.
+  const coreLines: string[] = [];
+  for (const raw of universalBody.split("\n")) {
+    const line = raw.trim();
+    // Skip headings, blank lines, frontmatter remnants, and prose
+    if (!line) continue;
+    if (line.startsWith("#")) continue;
+    if (line.startsWith("---")) continue;
+    if (line.startsWith("type:") || line.startsWith("created:") || line.startsWith("updated:") || line.startsWith("superbrain:")) continue;
+    if (isHardRule(line)) {
+      // Strip leading bullet markers for the core file
+      coreLines.push(line.replace(/^[-*]\s*/, "- "));
+    }
+  }
+
+  // Truncate to budget
+  const output: string[] = [];
+  let tokens = 0;
+  for (const line of coreLines) {
+    const t = estimateTokens(line) + 1; // +1 for newline
+    if (tokens + t > PREFERENCES_CORE_MAX_TOKENS) break;
+    output.push(line);
+    tokens += t;
+  }
+
+  atomicWrite(dest, output.join("\n") + (output.length > 0 ? "\n" : ""));
 }
 
 export function compileInjectionBlock(): string {

--- a/tests/preferenceClassify.test.ts
+++ b/tests/preferenceClassify.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyPreferenceScope,
+  filterToUniversal,
+} from "../src/preferenceClassify.js";
+
+// ---------------------------------------------------------------------------
+// classifyPreferenceScope — unit tests
+// ---------------------------------------------------------------------------
+
+// Known slugs used in tests that expect demotion
+const KNOWN = new Set(["alpha-proj", "test-svc", "beta-app"]);
+
+describe("classifyPreferenceScope — signal 1: explicit for-<slug> prefix", () => {
+  it("demotes 'For alpha-proj: use the event-sourcing pattern' when slug is known (signal 1)", () => {
+    const r = classifyPreferenceScope("For alpha-proj: use the event-sourcing pattern", KNOWN);
+    expect(r.scope).toBe("project");
+    expect(r.projectSlug).toBe("alpha-proj");
+  });
+
+  it("keeps 'For CLI tools: prefer positional args' (generic token)", () => {
+    const r = classifyPreferenceScope("For CLI tools: prefer positional args", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+
+  it("demotes case-insensitively: 'for test-svc: always add integration tests' when slug is known", () => {
+    const r = classifyPreferenceScope("for test-svc: always add integration tests", KNOWN);
+    expect(r.scope).toBe("project");
+    expect(r.projectSlug).toBe("test-svc");
+  });
+
+  it("keeps 'For API: always version the endpoints' (generic API token)", () => {
+    const r = classifyPreferenceScope("For API: always version the endpoints", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+
+  it("keeps 'For alpha-proj: ...' when knownSlugs is empty", () => {
+    const r = classifyPreferenceScope("For alpha-proj: use the event-sourcing pattern", new Set());
+    expect(r.scope).toBe("universal");
+  });
+
+  it("keeps 'For alpha-proj: ...' when called with default (no knownSlugs arg)", () => {
+    const r = classifyPreferenceScope("For alpha-proj: use the event-sourcing pattern");
+    expect(r.scope).toBe("universal");
+  });
+});
+
+describe("classifyPreferenceScope — signal 2: inline project-name mention", () => {
+  it("demotes 'When working on beta-app, always add integration tests' when slug is known (signal 2)", () => {
+    const r = classifyPreferenceScope("When working on beta-app, always add integration tests", KNOWN);
+    expect(r.scope).toBe("project");
+    expect(r.projectSlug).toBe("beta-app");
+  });
+
+  it("keeps 'When working on a new feature, always add integration tests' (no slug)", () => {
+    const r = classifyPreferenceScope("When working on a new feature, always add integration tests", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+
+  it("demotes 'In alpha-proj, prefer the repository pattern' when slug is known", () => {
+    const r = classifyPreferenceScope("In alpha-proj, prefer the repository pattern", KNOWN);
+    expect(r.scope).toBe("project");
+    expect(r.projectSlug).toBe("alpha-proj");
+  });
+
+  it("keeps 'In tests, prefer explicit assertions' (generic 'tests' word)", () => {
+    const r = classifyPreferenceScope("In tests, prefer explicit assertions", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+});
+
+describe("classifyPreferenceScope — signal 4: conditional imperatives (always universal)", () => {
+  it("keeps 'When adding a new API endpoint, always write a contract test'", () => {
+    const r = classifyPreferenceScope("When adding a new API endpoint, always write a contract test", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+
+  it("keeps 'Before merging, always run the full test suite'", () => {
+    const r = classifyPreferenceScope("Before merging, always run the full test suite", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+});
+
+describe("classifyPreferenceScope — signal 5: past-tense narrative (not project)", () => {
+  it("returns scope='universal' for past-tense narrative (lesson, not project)", () => {
+    const r = classifyPreferenceScope("I learned that shared state leads to subtle bugs", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+
+  it("returns scope='universal' for 'We got burned by switching arch mid-project'", () => {
+    const r = classifyPreferenceScope("We got burned by switching arch mid-project", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+});
+
+describe("classifyPreferenceScope — default conservative", () => {
+  it("keeps an imperative-only rule with no project references", () => {
+    const r = classifyPreferenceScope("Always write tests before implementation", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+
+  it("keeps when uncertain / ambiguous", () => {
+    const r = classifyPreferenceScope("Consider the trade-offs carefully", KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+
+  it("keeps a long imperative rule (no length cutoff)", () => {
+    const text = "Always " + "ensure every function has explicit return types ".repeat(5);
+    const r = classifyPreferenceScope(text, KNOWN);
+    expect(r.scope).toBe("universal");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADVERSARIAL TESTS — classifier conservatism
+// All inputs must classify as 'universal' when the token is not a known slug.
+// ---------------------------------------------------------------------------
+
+describe("classifyPreferenceScope — adversarial: common-English tokens stay universal", () => {
+  const EMPTY_SLUGS = new Set<string>();
+
+  it("'In general, prefer composition over inheritance' -> universal", () => {
+    expect(classifyPreferenceScope("In general, prefer composition over inheritance", EMPTY_SLUGS).scope)
+      .toBe("universal");
+  });
+
+  it("'In particular, avoid global mutable state' -> universal", () => {
+    expect(classifyPreferenceScope("In particular, avoid global mutable state", EMPTY_SLUGS).scope)
+      .toBe("universal");
+  });
+
+  it("'In summary, keep functions small' -> universal", () => {
+    expect(classifyPreferenceScope("In summary, keep functions small", EMPTY_SLUGS).scope)
+      .toBe("universal");
+  });
+
+  it("'In production, always enable logging' -> universal", () => {
+    expect(classifyPreferenceScope("In production, always enable logging", EMPTY_SLUGS).scope)
+      .toBe("universal");
+  });
+
+  it("'In staging, use the test database' -> universal", () => {
+    expect(classifyPreferenceScope("In staging, use the test database", EMPTY_SLUGS).scope)
+      .toBe("universal");
+  });
+
+  it("'In review, check for security issues' -> universal", () => {
+    expect(classifyPreferenceScope("In review, check for security issues", EMPTY_SLUGS).scope)
+      .toBe("universal");
+  });
+
+  it("'When working on authentication, always hash passwords' -> universal", () => {
+    expect(classifyPreferenceScope("When working on authentication, always hash passwords", EMPTY_SLUGS).scope)
+      .toBe("universal");
+  });
+
+  it("'For event-sourcing: use an append-only log' -> universal (generic tech pattern, not a known slug)", () => {
+    expect(classifyPreferenceScope("For event-sourcing: use an append-only log", EMPTY_SLUGS).scope)
+      .toBe("universal");
+  });
+
+  it("same common-English tokens stay universal even when KNOWN set is non-empty", () => {
+    const inputs = [
+      "In general, prefer composition over inheritance",
+      "In particular, avoid global mutable state",
+      "In summary, keep functions small",
+      "In production, always enable logging",
+      "In staging, use the test database",
+      "In review, check for security issues",
+      "When working on authentication, always hash passwords",
+    ];
+    for (const text of inputs) {
+      const r = classifyPreferenceScope(text, KNOWN);
+      expect(r.scope, `expected '${text}' to be universal`).toBe("universal");
+    }
+  });
+
+  it("a rule naming a KNOWN existing project slug DOES demote", () => {
+    const withKnown = new Set(["my-service"]);
+    const r = classifyPreferenceScope("For my-service: always add request tracing", withKnown);
+    expect(r.scope).toBe("project");
+    expect(r.projectSlug).toBe("my-service");
+  });
+
+  it("inline signal with a known slug DOES demote", () => {
+    const withKnown = new Set(["my-service"]);
+    const r = classifyPreferenceScope("When working on my-service, prefer structured logging", withKnown);
+    expect(r.scope).toBe("project");
+    expect(r.projectSlug).toBe("my-service");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterToUniversal — unit tests
+// ---------------------------------------------------------------------------
+
+const FILTER_KNOWN = new Set(["alpha-proj", "test-svc"]);
+
+const MIXED_DOC = `---
+type: preference
+created: '2026-01-01'
+superbrain: true
+---
+Durable opinions.
+
+## Code style
+
+- Never push directly to main.
+- For alpha-proj: use the event-sourcing pattern.
+- Always sort imports alphabetically.
+
+## Tools
+
+- Prefer Playwright for browser testing.
+- When working on test-svc, use the internal test harness.
+`;
+
+const ALL_UNIVERSAL_DOC = `---
+type: preference
+created: '2026-01-01'
+superbrain: true
+---
+
+## Code style
+
+- Never push directly to main.
+- Always sort imports alphabetically.
+`;
+
+const ALL_PROJECT_DOC = `---
+type: preference
+created: '2026-01-01'
+superbrain: true
+---
+
+## Code style
+
+- For alpha-proj: use the event-sourcing pattern.
+- For test-svc: use the internal test harness.
+`;
+
+describe("filterToUniversal", () => {
+  it("removes project-scoped bullets and retains universal bullets", () => {
+    const { universalBody, demoted } = filterToUniversal(MIXED_DOC, FILTER_KNOWN);
+    expect(universalBody).toContain("Never push directly to main");
+    expect(universalBody).toContain("Always sort imports alphabetically");
+    expect(universalBody).toContain("Prefer Playwright");
+    expect(universalBody).not.toContain("For alpha-proj");
+    expect(universalBody).not.toContain("test-svc");
+    expect(demoted.length).toBe(2);
+  });
+
+  it("preserves ## headings for kept entries", () => {
+    const { universalBody } = filterToUniversal(MIXED_DOC, FILTER_KNOWN);
+    expect(universalBody).toContain("## Code style");
+    expect(universalBody).toContain("## Tools");
+  });
+
+  it("drops empty category sections", () => {
+    const docWithEmptyCategory = `---
+type: preference
+created: '2026-01-01'
+superbrain: true
+---
+
+## All project-scoped
+
+- For alpha-proj: use the event-sourcing pattern.
+- For test-svc: use the internal test harness.
+
+## Universal rules
+
+- Never push to main.
+`;
+    const { universalBody } = filterToUniversal(docWithEmptyCategory, FILTER_KNOWN);
+    expect(universalBody).not.toContain("## All project-scoped");
+    expect(universalBody).toContain("## Universal rules");
+    expect(universalBody).toContain("Never push to main");
+  });
+
+  it("preserves frontmatter in the output", () => {
+    const { universalBody } = filterToUniversal(MIXED_DOC, FILTER_KNOWN);
+    expect(universalBody).toContain("type: preference");
+  });
+
+  it("returns demoted entries with correct projectSlug", () => {
+    const { demoted } = filterToUniversal(MIXED_DOC, FILTER_KNOWN);
+    const alphaEntry = demoted.find(d => d.projectSlug === "alpha-proj");
+    const svcEntry = demoted.find(d => d.projectSlug === "test-svc");
+    expect(alphaEntry).toBeDefined();
+    expect(svcEntry).toBeDefined();
+  });
+
+  it("returns unchanged body for an all-universal doc", () => {
+    const { universalBody, demoted } = filterToUniversal(ALL_UNIVERSAL_DOC, FILTER_KNOWN);
+    expect(demoted).toHaveLength(0);
+    expect(universalBody).toContain("Never push directly to main");
+    expect(universalBody).toContain("Always sort imports alphabetically");
+  });
+
+  it("returns empty body (no bullets) for an all-project-scoped doc", () => {
+    const { universalBody, demoted } = filterToUniversal(ALL_PROJECT_DOC, FILTER_KNOWN);
+    // No bullets remain — only possibly the frontmatter / preamble
+    expect(universalBody).not.toContain("- For alpha-proj");
+    expect(universalBody).not.toContain("- For test-svc");
+    expect(demoted.length).toBe(2);
+  });
+
+  it("passes all common-English tokens through as universal (no knownSlugs)", () => {
+    const doc = `## Rules\n\n- In general, prefer composition over inheritance.\n- In production, always enable logging.\n- For event-sourcing: use an append-only log.\n`;
+    const { universalBody, demoted } = filterToUniversal(doc);
+    expect(demoted).toHaveLength(0);
+    expect(universalBody).toContain("In general");
+    expect(universalBody).toContain("In production");
+    expect(universalBody).toContain("For event-sourcing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Blocker 3: filterToUniversal preserves non-bullet prose under kept headings
+// ---------------------------------------------------------------------------
+
+describe("filterToUniversal — Blocker 3: prose preservation", () => {
+  it("a '## Communication' section with a prose intro plus a bullet retains BOTH", () => {
+    const doc = `## Communication
+
+Keep responses concise and direct.
+
+- Always summarize key decisions at the end.
+`;
+    const { universalBody, demoted } = filterToUniversal(doc);
+    expect(demoted).toHaveLength(0);
+    expect(universalBody).toContain("Keep responses concise and direct.");
+    expect(universalBody).toContain("Always summarize key decisions at the end.");
+  });
+
+  it("a prose-only section is preserved in full", () => {
+    const doc = `## Philosophy
+
+Good code is readable code. Optimize for the next reader.
+`;
+    const { universalBody, demoted } = filterToUniversal(doc);
+    expect(demoted).toHaveLength(0);
+    expect(universalBody).toContain("## Philosophy");
+    expect(universalBody).toContain("Good code is readable code.");
+  });
+
+  it("prose intro is dropped when all bullets in that section are demoted", () => {
+    const knownSet = new Set(["alpha-proj"]);
+    const doc = `## Project rules
+
+Only applies to alpha-proj.
+
+- For alpha-proj: use the event-sourcing pattern.
+`;
+    const { universalBody, demoted } = filterToUniversal(doc, knownSet);
+    expect(demoted).toHaveLength(1);
+    expect(universalBody).not.toContain("## Project rules");
+  });
+});

--- a/tests/preferenceProducerGuard.test.ts
+++ b/tests/preferenceProducerGuard.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP: string;
+let DATA_DIR: string;
+let VAULT_DIR: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-guard-"));
+  DATA_DIR = path.join(TMP, "data");
+  VAULT_DIR = path.join(TMP, "vault");
+  fs.mkdirSync(path.join(DATA_DIR, "sessions"), { recursive: true });
+  fs.mkdirSync(path.join(DATA_DIR, "locks", "distill.lock"), { recursive: true });
+  fs.mkdirSync(path.join(VAULT_DIR, "meta"), { recursive: true });
+  fs.mkdirSync(path.join(VAULT_DIR, "projects"), { recursive: true });
+  // Write a minimal cursor so readDelta finds an empty delta (stub overrides)
+  fs.writeFileSync(path.join(DATA_DIR, "sessions", "test-session.ndjson"),
+    JSON.stringify({ type: "prompt", cwd: "/tmp/proj", prompt: "test" }) + "\n");
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+function runDistill(items: object[], extraEnv: Record<string, string> = {}): void {
+  const stub = path.join(TMP, "stub.json");
+  const envelope = { items, openThreads: [], alsoDid: [] };
+  fs.writeFileSync(stub, JSON.stringify(envelope));
+
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: DATA_DIR,
+      SUPERBRAIN_VAULT_DIR: VAULT_DIR,
+      SUPERBRAIN_DISTILL_STUB: stub,
+      SUPERBRAIN_SESSION_ID: "test-session",
+      SUPERBRAIN_EMBED_STUB: "1",
+      ...extraEnv,
+    },
+    encoding: "utf8",
+    timeout: 30000,
+  });
+}
+
+describe("producer guard — preference kind filtering", () => {
+  it("strips project-scoped lines from a preference item before write", () => {
+    // Create the project note so the classifier recognises the slug as known
+    const alphaNote = path.join(VAULT_DIR, "projects", "alpha-proj.md");
+    fs.writeFileSync(alphaNote, "---\ntype: project\n---\n");
+    const body = `## Code style
+
+- Never push directly to main.
+- For alpha-proj: use the event-sourcing pattern.
+- Always sort imports alphabetically.
+`;
+    runDistill([
+      {
+        kind: "preference",
+        title: "Preferences",
+        date: "2026-01-01",
+        links: [],
+        body,
+      },
+    ]);
+
+    const prefsPath = path.join(VAULT_DIR, "meta", "preferences.md");
+    expect(fs.existsSync(prefsPath)).toBe(true);
+    const written = fs.readFileSync(prefsPath, "utf8");
+    expect(written).toContain("Never push directly to main");
+    expect(written).toContain("Always sort imports alphabetically");
+    expect(written).not.toContain("For alpha-proj");
+  });
+
+  it("routes demoted project-scoped rule to projects/<slug>.md", () => {
+    // Create the project note so the classifier recognises the slug as known
+    const svcNote = path.join(VAULT_DIR, "projects", "test-svc.md");
+    fs.writeFileSync(svcNote, "---\ntype: project\n---\n");
+    const body = `## Code style
+
+- Never push directly to main.
+- For test-svc: always add integration tests.
+`;
+    runDistill([
+      {
+        kind: "preference",
+        title: "Preferences",
+        date: "2026-01-01",
+        links: [],
+        body,
+      },
+    ]);
+
+    const projectNote = path.join(VAULT_DIR, "projects", "test-svc.md");
+    expect(fs.existsSync(projectNote)).toBe(true);
+    const content = fs.readFileSync(projectNote, "utf8");
+    expect(content).toContain("always add integration tests");
+  });
+
+  it("does not write meta/preferences.md when entire filtered body is empty", () => {
+    // Create both project notes so all bullets demote and body becomes empty
+    fs.writeFileSync(path.join(VAULT_DIR, "projects", "alpha-proj.md"), "---\ntype: project\n---\n");
+    fs.writeFileSync(path.join(VAULT_DIR, "projects", "test-svc.md"), "---\ntype: project\n---\n");
+    const body = `## Code style
+
+- For alpha-proj: use the event-sourcing pattern.
+- For test-svc: use the internal test harness.
+`;
+    runDistill([
+      {
+        kind: "preference",
+        title: "Preferences",
+        date: "2026-01-01",
+        links: [],
+        body,
+      },
+    ]);
+
+    const prefsPath = path.join(VAULT_DIR, "meta", "preferences.md");
+    expect(fs.existsSync(prefsPath)).toBe(false);
+  });
+
+  it("emits meta/preferences-core.md after a successful preference write", () => {
+    const body = `## Code style
+
+- Never push directly to main.
+- Always sort imports alphabetically.
+`;
+    runDistill([
+      {
+        kind: "preference",
+        title: "Preferences",
+        date: "2026-01-01",
+        links: [],
+        body,
+      },
+    ]);
+
+    const corePath = path.join(VAULT_DIR, "meta", "preferences-core.md");
+    expect(fs.existsSync(corePath)).toBe(true);
+    const core = fs.readFileSync(corePath, "utf8");
+    expect(core).toContain("Never push directly to main");
+  });
+});
+
+describe("producer guard — Blocker 2: demoted rule with missing project note goes to reject queue", () => {
+  it("sends a demoted rule to the reject queue when the project note does not exist", () => {
+    // Use the slug override seam to make the classifier demote the rule even
+    // though projects/no-note-proj.md does not exist on disk.
+    const body = `## Code style
+
+- Never push directly to main.
+- For no-note-proj: use domain-driven design.
+`;
+    runDistill(
+      [
+        {
+          kind: "preference",
+          title: "Preferences",
+          date: "2026-01-01",
+          links: [],
+          body,
+        },
+      ],
+      { SUPERBRAIN_KNOWN_SLUGS_OVERRIDE: "no-note-proj" },
+    );
+
+    // The project note must NOT have been auto-created
+    const projectNote = path.join(VAULT_DIR, "projects", "no-note-proj.md");
+    expect(fs.existsSync(projectNote)).toBe(false);
+
+    // The rejected rule must appear in the distill-rejects log
+    const rejectsPath = path.join(VAULT_DIR, "meta", "distill-rejects.md");
+    expect(fs.existsSync(rejectsPath)).toBe(true);
+    const rejectsContent = fs.readFileSync(rejectsPath, "utf8");
+    expect(rejectsContent).toContain("project note missing");
+    expect(rejectsContent).toContain("no-note-proj");
+
+    // Universal rules are still written normally
+    const prefsPath = path.join(VAULT_DIR, "meta", "preferences.md");
+    expect(fs.existsSync(prefsPath)).toBe(true);
+    const prefsContent = fs.readFileSync(prefsPath, "utf8");
+    expect(prefsContent).toContain("Never push directly to main");
+  });
+});

--- a/tests/preferencesCore.test.ts
+++ b/tests/preferencesCore.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  emitPreferencesCore,
+  preferencesCorePath,
+  PREFERENCES_CORE_MAX_TOKENS,
+} from "../src/preferences.js";
+import { estimateTokens } from "../src/injectBudget.js";
+
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pref-core-"));
+  process.env.SUPERBRAIN_VAULT_DIR = TMP;
+  fs.mkdirSync(path.join(TMP, "meta"), { recursive: true });
+});
+
+afterEach(() => {
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+const UNIVERSAL_BODY = `## Code style
+
+- Never push directly to main.
+- Always sort imports alphabetically.
+- Avoid deep nesting beyond 3 levels.
+
+## Style guidance
+
+This is style guidance prose (no imperative prefix, should be excluded from core).
+
+## Tools
+
+- Prefer Playwright for browser automation.
+- Use the built-in formatter before committing.
+`;
+
+describe("emitPreferencesCore", () => {
+  it("writes only imperative-prefix lines from the universal body", () => {
+    emitPreferencesCore(UNIVERSAL_BODY);
+    const core = fs.readFileSync(path.join(TMP, "meta", "preferences-core.md"), "utf8");
+    expect(core).toContain("Never push directly to main");
+    expect(core).toContain("Always sort imports alphabetically");
+    expect(core).toContain("Prefer Playwright");
+    expect(core).toContain("Use the built-in formatter");
+    // Style guidance prose has no imperative prefix — must NOT appear
+    expect(core).not.toContain("style guidance prose");
+  });
+
+  it("output is <= PREFERENCES_CORE_MAX_TOKENS tokens", () => {
+    // Build a body with many lines to test truncation
+    const manyLines = Array.from({ length: 200 }, (_, i) =>
+      `- Always follow rule number ${i} with great diligence and precision in all circumstances.`
+    ).join("\n");
+    emitPreferencesCore(manyLines);
+    const core = fs.readFileSync(path.join(TMP, "meta", "preferences-core.md"), "utf8");
+    expect(estimateTokens(core)).toBeLessThanOrEqual(PREFERENCES_CORE_MAX_TOKENS);
+  });
+
+  it("file exists at meta/preferences-core.md after call", () => {
+    emitPreferencesCore(UNIVERSAL_BODY);
+    expect(fs.existsSync(path.join(TMP, "meta", "preferences-core.md"))).toBe(true);
+  });
+
+  it("is idempotent — second call with same input overwrites with identical content", () => {
+    emitPreferencesCore(UNIVERSAL_BODY);
+    const first = fs.readFileSync(path.join(TMP, "meta", "preferences-core.md"), "utf8");
+    emitPreferencesCore(UNIVERSAL_BODY);
+    const second = fs.readFileSync(path.join(TMP, "meta", "preferences-core.md"), "utf8");
+    expect(first).toBe(second);
+  });
+
+  it("handles empty universal body — writes an empty file without error", () => {
+    expect(() => emitPreferencesCore("")).not.toThrow();
+    const core = fs.readFileSync(path.join(TMP, "meta", "preferences-core.md"), "utf8");
+    expect(core.trim()).toBe("");
+  });
+
+  it("excludes style-guidance lines (no imperative prefix) from the core", () => {
+    const styleOnly = `## Style guidance\n\nThis text has no imperative prefix and should be excluded.\n`;
+    emitPreferencesCore(styleOnly);
+    const core = fs.readFileSync(path.join(TMP, "meta", "preferences-core.md"), "utf8");
+    expect(core).not.toContain("This text has no imperative prefix");
+  });
+});
+
+describe("preferencesCorePath", () => {
+  it("returns the path to meta/preferences-core.md", () => {
+    const p = preferencesCorePath();
+    expect(p).toContain("meta");
+    expect(p).toContain("preferences-core.md");
+  });
+
+  it("path is inside the vault dir", () => {
+    const p = preferencesCorePath();
+    expect(p.startsWith(TMP)).toBe(true);
+  });
+});
+
+describe("PREFERENCES_CORE_MAX_TOKENS", () => {
+  it("is a positive number around 250", () => {
+    expect(PREFERENCES_CORE_MAX_TOKENS).toBeGreaterThan(0);
+    expect(PREFERENCES_CORE_MAX_TOKENS).toBeLessThanOrEqual(350);
+  });
+});

--- a/tests/retroPrunePreferences.test.ts
+++ b/tests/retroPrunePreferences.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { parsePreferences, classify, demoteLessonFilename } from "../scripts/retro-prune-preferences.js";
 
 // --- parsePreferences ---
@@ -26,7 +30,7 @@ type: preference
 ## Never push directly to main
 Some body text that is part of the heading entry.
 
-## For Alpha-proj: use middle-east founding market
+## For alpha-proj: use the event-sourcing pattern
 Body.
 `;
 
@@ -39,7 +43,7 @@ Preamble paragraph.
 
 - Never add comment blocks before every method.
 - I learned that gray-matter quotes dates automatically.
-- For Alpha-proj: use middle-east founding market.
+- For alpha-proj: use the event-sourcing pattern.
 
 ## Version control
 
@@ -65,7 +69,7 @@ describe("parsePreferences", () => {
     // Both headings are entries (no bullet children)
     expect(entries.length).toBeGreaterThanOrEqual(2);
     expect(entries.some(e => e.text.includes("Never push directly to main"))).toBe(true);
-    expect(entries.some(e => e.text.includes("For Alpha-proj"))).toBe(true);
+    expect(entries.some(e => e.text.includes("For alpha-proj"))).toBe(true);
   });
 
   it("extracts source context (line or category) for each entry", () => {
@@ -115,7 +119,7 @@ describe("classify", () => {
   });
 
   it("demotes-project a for-slug scoped entry", () => {
-    const result = classify("For Alpha-proj: use middle-east founding market");
+    const result = classify("For alpha-proj: use the event-sourcing pattern");
     expect(result.verdict).toBe("demote-project");
     expect(result.projectSlug).toBe("alpha-proj");
   });
@@ -161,5 +165,140 @@ describe("demoteLessonFilename", () => {
   it("collapses multiple dashes", () => {
     const result = demoteLessonFilename("I learned --- something", "2026-05-22");
     expect(result).not.toContain("--");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Extended tests: heading-preserving rewrite, core emission, idempotency
+// ---------------------------------------------------------------------------
+
+const MIXED_WITH_HEADINGS = `---
+type: preference
+created: '2026-01-01'
+superbrain: true
+---
+Durable opinions.
+
+## Code style
+
+- Never push directly to main.
+- For alpha-proj: use the event-sourcing pattern.
+- Always sort imports alphabetically.
+
+## Tools
+
+- Prefer Playwright for browser testing.
+- For test-svc: use the internal test harness.
+
+## Version control
+
+- I learned that rebasing is cleaner than merging.
+`;
+
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-retro-"));
+  fs.mkdirSync(path.join(TMP, "meta"), { recursive: true });
+  fs.mkdirSync(path.join(TMP, "projects"), { recursive: true });
+  fs.mkdirSync(path.join(TMP, "lessons"), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+function runRetroPrune(vaultDir: string, extraArgs: string[] = []): string {
+  return execFileSync("npx", ["tsx", "scripts/retro-prune-preferences.ts", vaultDir, ...extraArgs], {
+    encoding: "utf8",
+    timeout: 30000,
+    cwd: path.resolve(path.join(path.dirname(new URL(import.meta.url).pathname), "..")),
+  });
+}
+
+describe("retro-prune-preferences — extended: heading-preserving rewrite", () => {
+  it("preserves ## Category headings for kept entries", () => {
+    fs.writeFileSync(path.join(TMP, "meta", "preferences.md"), MIXED_WITH_HEADINGS);
+    runRetroPrune(TMP, ["--apply"]);
+    const result = fs.readFileSync(path.join(TMP, "meta", "preferences.md"), "utf8");
+    // Kept entries retain their category headings
+    expect(result).toContain("## Code style");
+    expect(result).toContain("Never push directly to main");
+    expect(result).toContain("Always sort imports alphabetically");
+  });
+
+  it("drops empty ## Category sections after all bullets are demoted", () => {
+    const allProjectDoc = `---
+type: preference
+created: '2026-01-01'
+superbrain: true
+---
+
+## Project-specific rules
+
+- For alpha-proj: use the event-sourcing pattern.
+- For test-svc: use the internal test harness.
+
+## Universal rules
+
+- Never push directly to main.
+`;
+    fs.writeFileSync(path.join(TMP, "meta", "preferences.md"), allProjectDoc);
+    runRetroPrune(TMP, ["--apply"]);
+    const result = fs.readFileSync(path.join(TMP, "meta", "preferences.md"), "utf8");
+    expect(result).not.toContain("## Project-specific rules");
+    expect(result).toContain("## Universal rules");
+    expect(result).toContain("Never push directly to main");
+  });
+
+  it("routes demoted project rules to projects/<slug>.md under ## Preferences", () => {
+    fs.writeFileSync(path.join(TMP, "meta", "preferences.md"), MIXED_WITH_HEADINGS);
+    runRetroPrune(TMP, ["--apply"]);
+    const projectNote = path.join(TMP, "projects", "alpha-proj.md");
+    expect(fs.existsSync(projectNote)).toBe(true);
+    const content = fs.readFileSync(projectNote, "utf8");
+    expect(content).toContain("event-sourcing pattern");
+    // Should use ## Preferences, not ## Gotcha
+    expect(content).toContain("## Preferences");
+    expect(content).not.toContain("## Gotcha");
+  });
+});
+
+describe("retro-prune-preferences — extended: core emission", () => {
+  it("emits preferences-core.md during --apply", () => {
+    fs.writeFileSync(path.join(TMP, "meta", "preferences.md"), MIXED_WITH_HEADINGS);
+    runRetroPrune(TMP, ["--apply"]);
+    const corePath = path.join(TMP, "meta", "preferences-core.md");
+    expect(fs.existsSync(corePath)).toBe(true);
+    const core = fs.readFileSync(corePath, "utf8");
+    // Must contain imperative-prefix lines
+    expect(core).toContain("Never push directly to main");
+  });
+
+  it("includes a CORE EMISSION PREVIEW section in dry-run output", () => {
+    fs.writeFileSync(path.join(TMP, "meta", "preferences.md"), MIXED_WITH_HEADINGS);
+    const output = runRetroPrune(TMP);
+    expect(output).toContain("CORE EMISSION PREVIEW");
+  });
+});
+
+describe("retro-prune-preferences — extended: idempotency", () => {
+  it("is idempotent when run twice on an already-migrated vault", () => {
+    fs.writeFileSync(path.join(TMP, "meta", "preferences.md"), MIXED_WITH_HEADINGS);
+    // First run
+    runRetroPrune(TMP, ["--apply"]);
+    const firstPrefs = fs.readFileSync(path.join(TMP, "meta", "preferences.md"), "utf8");
+    const firstCore = fs.readFileSync(path.join(TMP, "meta", "preferences-core.md"), "utf8");
+
+    // Second run: preferences-core.md already exists and preferences.md is already pruned
+    const secondOutput = runRetroPrune(TMP, ["--apply"]);
+    const secondPrefs = fs.readFileSync(path.join(TMP, "meta", "preferences.md"), "utf8");
+    const secondCore = fs.readFileSync(path.join(TMP, "meta", "preferences-core.md"), "utf8");
+
+    // The docs must be stable across runs
+    expect(secondPrefs).toBe(firstPrefs);
+    expect(secondCore).toBe(firstCore);
+    // Should indicate already-migrated
+    expect(secondOutput).toContain("already migrated");
   });
 });


### PR DESCRIPTION
Keeps only universal rules in the preferences doc, routes project-scoped rules to an existing project note (else the reject queue), and emits a lean preferences-core file. A universal rule is never demoted on a weak signal.