### PR TITLE
fix: reliable 0.8.x first-run upgrade (model pre-fetch + hardened download)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ behavior may change without notice.
 
 ## [Unreleased]
 
+## 0.8.1: a reliable first-run upgrade
+
+Fixes the rough first session after upgrading to the 0.8 line. The embedding model is now fetched during the one-time native-dependency bootstrap (in the background) instead of lazily inside a short-lived hook, so semantic recall is ready by your next session rather than racing a download mid-conversation. The download itself is hardened: it follows HuggingFace's relative redirects (a relative redirect on the tokenizer previously crashed the fetch), verifies each file's size before committing it (a truncated download can no longer leave a half-written model that silently pins recall to keyword-only), cleans up stale partial downloads, and serializes concurrent fetches. The one-time setup notice now says that recall and the session brief are warming up, so a fresh install no longer silently falls back to reading the vault by hand.
+
 ## 0.8.0: semantic recall returns, a ~400MB lighter install, and always-on working memory
 
 **Semantic recall is back, on every path.** The 0.7.x hooks had fallen back to keyword-only (BM25) recall to dodge a native crash in the embedding library. That stack is gone: the ~428MB onnxruntime/transformers dependency is replaced by a vendored pure-JavaScript static embedding (a Model2Vec "potion" model), so the install is roughly 400MB smaller, has no native build step, and starts faster. Keyword and meaning-based recall are fused again everywhere, including the short-lived session-start and per-prompt hooks. The vector index moves to a compact int8 form and re-embeds itself once on upgrade.

--- a/bin/sb-bootstrap.ts
+++ b/bin/sb-bootstrap.ts
@@ -62,6 +62,15 @@ async function main() {
       return;
     }
     markBootstrapDone(root);
+    // Step 4: pre-fetch the embedding model now, while we already have a
+    // background process, so semantic recall is ready next session instead of
+    // racing a fragile lazy download inside a short-lived hook.
+    try {
+      const { ensureModelAssets } = await import("../src/staticEmbed/modelCache.js");
+      await ensureModelAssets();
+    } catch (e: any) {
+      writeFailure(`bootstrap step 4 (model prefetch) failed (non-fatal; recall stays keyword-only until it succeeds): ${e?.message || e}`);
+    }
     // After successful bootstrap, check for legacy vault state and auto-run
     // the safe (idempotent) frontmatter backfill in a detached subprocess.
     try {

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -13,7 +13,7 @@ async function main() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
-  const server = new McpServer({ name: "superbrain", version: "0.8.0" });
+  const server = new McpServer({ name: "superbrain", version: "0.8.1" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).",

--- a/bin/sb-session-start.ts
+++ b/bin/sb-session-start.ts
@@ -23,7 +23,7 @@ async function main() {
     const root = pluginRoot();
     if (!depsPresent(root)) {
       runBootstrap(root);
-      parts.push("SuperBrain is rebuilding native dependencies for this install (one-time per plugin version). Capture resumes automatically next session.");
+      parts.push("SuperBrain is finishing one-time setup for this version (building native dependencies and fetching the embedding model). Recall, the session brief, and capture are warming up and will be ready next session; for now, work from the current conversation rather than assuming SuperBrain recall is available.");
     } else {
       // One-time backfill: assign project to all NULL notes before any query.
       // Ships atomically with the fail-closed isCrossProject filter.

--- a/dist/bin/sb-bootstrap.js
+++ b/dist/bin/sb-bootstrap.js
@@ -63,6 +63,16 @@ async function main() {
             return;
         }
         markBootstrapDone(root);
+        // Step 4: pre-fetch the embedding model now, while we already have a
+        // background process, so semantic recall is ready next session instead of
+        // racing a fragile lazy download inside a short-lived hook.
+        try {
+            const { ensureModelAssets } = await import("../src/staticEmbed/modelCache.js");
+            await ensureModelAssets();
+        }
+        catch (e) {
+            writeFailure(`bootstrap step 4 (model prefetch) failed (non-fatal; recall stays keyword-only until it succeeds): ${e?.message || e}`);
+        }
         // After successful bootstrap, check for legacy vault state and auto-run
         // the safe (idempotent) frontmatter backfill in a detached subprocess.
         try {

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -12,7 +12,7 @@ async function main() {
     const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
-    const server = new McpServer({ name: "superbrain", version: "0.8.0" });
+    const server = new McpServer({ name: "superbrain", version: "0.8.1" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).", { query: z.string(), k: z.number().optional() }, async ({ query, k }) => (await handleSearch({ query, k })));
     const transport = new StdioServerTransport();
     server.connect(transport).catch(() => process.exit(1));

--- a/dist/bin/sb-session-start.js
+++ b/dist/bin/sb-session-start.js
@@ -33,7 +33,7 @@ async function main() {
         const root = pluginRoot();
         if (!depsPresent(root)) {
             runBootstrap(root);
-            parts.push("SuperBrain is rebuilding native dependencies for this install (one-time per plugin version). Capture resumes automatically next session.");
+            parts.push("SuperBrain is finishing one-time setup for this version (building native dependencies and fetching the embedding model). Recall, the session brief, and capture are warming up and will be ready next session; for now, work from the current conversation rather than assuming SuperBrain recall is available.");
         }
         else {
             // One-time backfill: assign project to all NULL notes before any query.

--- a/dist/src/staticEmbed/modelCache.js
+++ b/dist/src/staticEmbed/modelCache.js
@@ -6,8 +6,10 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import https from "node:https";
+import { acquireLock, releaseLock } from "../lockfile.js";
 const HF_BASE = "https://huggingface.co/minishlab/potion-base-8M/resolve/main";
 const ASSETS = ["model.safetensors", "tokenizer.json"];
+const MIN_BYTES = { "model.safetensors": 20_000_000, "tokenizer.json": 100_000 };
 export function modelDir() {
     if (process.env.SUPERBRAIN_MODEL_DIR)
         return process.env.SUPERBRAIN_MODEL_DIR;
@@ -16,50 +18,109 @@ export function modelDir() {
 export function modelAssetPath(asset) {
     return path.join(modelDir(), asset);
 }
-function downloadFile(url, dest) {
+function downloadFile(url, dest, minSize) {
     return new Promise((resolve, reject) => {
         const tmp = dest + ".part";
         const cleanup = () => { try {
             fs.rmSync(tmp, { force: true });
         }
         catch { /* ignore */ } };
+        const fail = (e) => { cleanup(); reject(e instanceof Error ? e : new Error(String(e))); };
         const follow = (u, depth) => {
             if (depth > 5) {
-                reject(new Error(`too many redirects fetching ${url}`));
+                fail(new Error(`too many redirects fetching ${url}`));
                 return;
             }
-            const req = https.get(u, { headers: { "User-Agent": "superbrain/1 (node)" } }, (res) => {
-                if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307 || res.statusCode === 308) {
-                    res.resume();
-                    follow(res.headers.location, depth + 1);
-                    return;
-                }
-                if (res.statusCode !== 200) {
-                    res.resume();
-                    reject(new Error(`HTTP ${res.statusCode} fetching ${u}`));
-                    return;
-                }
-                const out = fs.createWriteStream(tmp);
-                res.on("error", (e) => { out.destroy(); cleanup(); reject(e); });
-                out.on("error", (e) => { cleanup(); reject(e); });
-                out.on("finish", () => { out.close(); fs.renameSync(tmp, dest); resolve(); });
-                res.pipe(out);
-            });
+            let req;
+            try {
+                req = https.get(u, { headers: { "User-Agent": "superbrain/1 (node)" } }, (res) => {
+                    const code = res.statusCode ?? 0;
+                    if (code === 301 || code === 302 || code === 307 || code === 308) {
+                        res.resume();
+                        const loc = res.headers.location;
+                        if (!loc) {
+                            fail(new Error(`redirect without location fetching ${u}`));
+                            return;
+                        }
+                        // HuggingFace may return a RELATIVE redirect; resolve it against the current url.
+                        let next;
+                        try {
+                            next = new URL(loc, u).toString();
+                        }
+                        catch (e) {
+                            fail(e);
+                            return;
+                        }
+                        follow(next, depth + 1);
+                        return;
+                    }
+                    if (code !== 200) {
+                        res.resume();
+                        fail(new Error(`HTTP ${code} fetching ${u}`));
+                        return;
+                    }
+                    const expected = Number(res.headers["content-length"]) || 0;
+                    const out = fs.createWriteStream(tmp);
+                    res.on("error", (e) => { out.destroy(); fail(e); });
+                    out.on("error", (e) => fail(e));
+                    out.on("finish", () => {
+                        out.close(() => {
+                            let size = 0;
+                            try {
+                                size = fs.statSync(tmp).size;
+                            }
+                            catch { /* part missing */ }
+                            if (size < minSize || (expected > 0 && size !== expected)) {
+                                fail(new Error(`incomplete download for ${path.basename(dest)}: got ${size} bytes, expected ${expected || ">= " + minSize}`));
+                                return;
+                            }
+                            try {
+                                fs.renameSync(tmp, dest);
+                                resolve();
+                            }
+                            catch (e) {
+                                fail(e);
+                            }
+                        });
+                    });
+                    res.pipe(out);
+                });
+            }
+            catch (e) {
+                fail(e);
+                return;
+            }
             req.setTimeout(60000, () => { req.destroy(new Error(`timeout fetching ${u}`)); });
-            req.on("error", (e) => { cleanup(); reject(e); });
+            req.on("error", (e) => fail(e));
         };
         follow(url, 0);
     });
 }
+// Single-process lock + size verification so a truncated download can never
+// leave a half-written model that silently pins recall to keyword-only.
 export async function ensureModelAssets() {
     const dir = modelDir();
     fs.mkdirSync(dir, { recursive: true });
-    for (const asset of ASSETS) {
-        const dest = path.join(dir, asset);
-        if (!fs.existsSync(dest)) {
+    if (ASSETS.every((a) => fs.existsSync(path.join(dir, a))))
+        return;
+    if (!acquireLock("model-download", { maxAgeMs: 15 * 60 * 1000 })) {
+        throw new Error("model download already in progress in another process");
+    }
+    try {
+        for (const asset of ASSETS) {
+            const dest = path.join(dir, asset);
+            if (fs.existsSync(dest))
+                continue;
+            try {
+                fs.rmSync(dest + ".part", { force: true });
+            }
+            catch { /* ignore stale part */ }
             process.stderr.write(`[superbrain] downloading ${asset} from HuggingFace...\n`);
-            await downloadFile(`${HF_BASE}/${asset}`, dest);
+            await downloadFile(`${HF_BASE}/${asset}`, dest, MIN_BYTES[asset] ?? 0);
             process.stderr.write(`[superbrain] cached ${asset}\n`);
         }
+    }
+    finally {
+        releaseLock("model-download");
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",

--- a/src/staticEmbed/modelCache.ts
+++ b/src/staticEmbed/modelCache.ts
@@ -6,9 +6,11 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import https from "node:https";
+import { acquireLock, releaseLock } from "../lockfile.js";
 
 const HF_BASE = "https://huggingface.co/minishlab/potion-base-8M/resolve/main";
 const ASSETS = ["model.safetensors", "tokenizer.json"] as const;
+const MIN_BYTES: Record<string, number> = { "model.safetensors": 20_000_000, "tokenizer.json": 100_000 };
 
 export function modelDir(): string {
   if (process.env.SUPERBRAIN_MODEL_DIR) return process.env.SUPERBRAIN_MODEL_DIR;
@@ -19,45 +21,72 @@ export function modelAssetPath(asset: (typeof ASSETS)[number]): string {
   return path.join(modelDir(), asset);
 }
 
-function downloadFile(url: string, dest: string): Promise<void> {
+function downloadFile(url: string, dest: string, minSize: number): Promise<void> {
   return new Promise((resolve, reject) => {
     const tmp = dest + ".part";
     const cleanup = () => { try { fs.rmSync(tmp, { force: true }); } catch { /* ignore */ } };
+    const fail = (e: unknown) => { cleanup(); reject(e instanceof Error ? e : new Error(String(e))); };
     const follow = (u: string, depth: number) => {
-      if (depth > 5) { reject(new Error(`too many redirects fetching ${url}`)); return; }
-      const req = https.get(u, { headers: { "User-Agent": "superbrain/1 (node)" } }, (res) => {
-        if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307 || res.statusCode === 308) {
-          res.resume();
-          follow(res.headers.location!, depth + 1);
-          return;
-        }
-        if (res.statusCode !== 200) {
-          res.resume();
-          reject(new Error(`HTTP ${res.statusCode} fetching ${u}`));
-          return;
-        }
-        const out = fs.createWriteStream(tmp);
-        res.on("error", (e) => { out.destroy(); cleanup(); reject(e); });
-        out.on("error", (e) => { cleanup(); reject(e); });
-        out.on("finish", () => { out.close(); fs.renameSync(tmp, dest); resolve(); });
-        res.pipe(out);
-      });
+      if (depth > 5) { fail(new Error(`too many redirects fetching ${url}`)); return; }
+      let req;
+      try {
+        req = https.get(u, { headers: { "User-Agent": "superbrain/1 (node)" } }, (res) => {
+          const code = res.statusCode ?? 0;
+          if (code === 301 || code === 302 || code === 307 || code === 308) {
+            res.resume();
+            const loc = res.headers.location;
+            if (!loc) { fail(new Error(`redirect without location fetching ${u}`)); return; }
+            // HuggingFace may return a RELATIVE redirect; resolve it against the current url.
+            let next: string;
+            try { next = new URL(loc, u).toString(); } catch (e) { fail(e); return; }
+            follow(next, depth + 1);
+            return;
+          }
+          if (code !== 200) { res.resume(); fail(new Error(`HTTP ${code} fetching ${u}`)); return; }
+          const expected = Number(res.headers["content-length"]) || 0;
+          const out = fs.createWriteStream(tmp);
+          res.on("error", (e) => { out.destroy(); fail(e); });
+          out.on("error", (e) => fail(e));
+          out.on("finish", () => {
+            out.close(() => {
+              let size = 0;
+              try { size = fs.statSync(tmp).size; } catch { /* part missing */ }
+              if (size < minSize || (expected > 0 && size !== expected)) {
+                fail(new Error(`incomplete download for ${path.basename(dest)}: got ${size} bytes, expected ${expected || ">= " + minSize}`));
+                return;
+              }
+              try { fs.renameSync(tmp, dest); resolve(); } catch (e) { fail(e); }
+            });
+          });
+          res.pipe(out);
+        });
+      } catch (e) { fail(e); return; }
       req.setTimeout(60000, () => { req.destroy(new Error(`timeout fetching ${u}`)); });
-      req.on("error", (e) => { cleanup(); reject(e); });
+      req.on("error", (e) => fail(e));
     };
     follow(url, 0);
   });
 }
 
+// Single-process lock + size verification so a truncated download can never
+// leave a half-written model that silently pins recall to keyword-only.
 export async function ensureModelAssets(): Promise<void> {
   const dir = modelDir();
   fs.mkdirSync(dir, { recursive: true });
-  for (const asset of ASSETS) {
-    const dest = path.join(dir, asset);
-    if (!fs.existsSync(dest)) {
+  if (ASSETS.every((a) => fs.existsSync(path.join(dir, a)))) return;
+  if (!acquireLock("model-download", { maxAgeMs: 15 * 60 * 1000 })) {
+    throw new Error("model download already in progress in another process");
+  }
+  try {
+    for (const asset of ASSETS) {
+      const dest = path.join(dir, asset);
+      if (fs.existsSync(dest)) continue;
+      try { fs.rmSync(dest + ".part", { force: true }); } catch { /* ignore stale part */ }
       process.stderr.write(`[superbrain] downloading ${asset} from HuggingFace...\n`);
-      await downloadFile(`${HF_BASE}/${asset}`, dest);
+      await downloadFile(`${HF_BASE}/${asset}`, dest, MIN_BYTES[asset] ?? 0);
       process.stderr.write(`[superbrain] cached ${asset}\n`);
     }
+  } finally {
+    releaseLock("model-download");
   }
 }

--- a/tests/freshCloneE2E.test.ts
+++ b/tests/freshCloneE2E.test.ts
@@ -33,5 +33,5 @@ it("every hook entrypoint loads + exits 0 with NO node_modules; SessionStart boo
   const ss = execFileSync(process.execPath, [path.join(CLONE, "dist/bin/sb-session-start.js")], {
     input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
     env, encoding: "utf8" });
-  expect(ss).toMatch(/rebuilding native dependencies/i);
+  expect(ss).toMatch(/native dependencies/i);
 });

--- a/tests/modelCache.test.ts
+++ b/tests/modelCache.test.ts
@@ -1,0 +1,24 @@
+import { it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ensureModelAssets } from "../src/staticEmbed/modelCache.js";
+
+it("ensureModelAssets is a no-op when both assets already exist (no download, no re-validation)", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-model-"));
+  // Deliberately tiny files: if ensureModelAssets re-validated existing assets
+  // against MIN_BYTES it would delete or reject these; it must not.
+  fs.writeFileSync(path.join(dir, "model.safetensors"), "x");
+  fs.writeFileSync(path.join(dir, "tokenizer.json"), "y");
+  const prev = process.env.SUPERBRAIN_MODEL_DIR;
+  process.env.SUPERBRAIN_MODEL_DIR = dir;
+  try {
+    await expect(ensureModelAssets()).resolves.toBeUndefined();
+    expect(fs.existsSync(path.join(dir, "model.safetensors"))).toBe(true);
+    expect(fs.existsSync(path.join(dir, "tokenizer.json"))).toBe(true);
+  } finally {
+    if (prev === undefined) delete process.env.SUPERBRAIN_MODEL_DIR;
+    else process.env.SUPERBRAIN_MODEL_DIR = prev;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/sessionStartBootstrap.test.ts
+++ b/tests/sessionStartBootstrap.test.ts
@@ -24,6 +24,7 @@ it("no deps: emits the rebuilding-native-deps notice, exits 0, does NOT crash", 
       SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_BOOTSTRAP_FAKE: "1" },
     encoding: "utf8",
   });
-  expect(out).toMatch(/rebuilding native dependencies/i);
+  expect(out).toMatch(/native dependencies/i);
+  expect(out).toMatch(/recall/i);
   expect(out).toMatch(/additionalContext/);
 });


### PR DESCRIPTION
Fixes the broken first session after a 0.8.x upgrade. Pre-fetches the embedding model during the native-dependency bootstrap instead of a lazy hot-path download; follows HuggingFace relative redirects (the tokenizer redirect was crashing the fetch), verifies each file's size before committing it, cleans stale .part files, and serializes concurrent downloads. The one-time setup notice now says recall and the session brief are warming up, so a fresh install no longer silently falls back to grepping the vault. 790 tests; release:check green.