### PR TITLE
perf(C0-PR5): G7/G8/G9/G10 recall hot-path fixes

### DIFF
--- a/dist/src/indexer.js
+++ b/dist/src/indexer.js
@@ -9,6 +9,7 @@ import { parseNote } from "./frontmatter.js";
 import { deriveEdges, deleteEdgesFrom, upsertEdges } from "./edges.js";
 import { slug as routerSlug } from "./router.js";
 const EXCLUDED = new Set([".trash", ".obsidian", ".git", "node_modules"]);
+const CROSS_CUTTING_FOLDERS = new Set(["daily", "decisions", "lessons", "knowledge", "meta"]);
 function walk(dir, root, acc) {
     for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
         if (e.isDirectory()) {
@@ -40,7 +41,15 @@ async function indexInto(ix, relPath) {
     const created = typeof fm.created === "string" ? fm.created
         : fm.created instanceof Date ? fm.created.toISOString()
             : undefined;
-    ix.upsertNote(relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs, fm.project, created);
+    // G10: default cross-cutting folders to project='global' when frontmatter lacks project,
+    // so the G10 global filter does not require path heuristics.
+    let noteProject = fm.project;
+    if (!noteProject || (typeof noteProject === "string" && !noteProject.trim())) {
+        const topFolder = relPath.split("/")[0];
+        if (CROSS_CUTTING_FOLDERS.has(topFolder))
+            noteProject = "global";
+    }
+    ix.upsertNote(relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs, noteProject, created);
     upsertEdges(ix.db, deriveEdges(relPath, fm));
 }
 export async function indexNote(relPath) {

--- a/dist/src/searchIndex.js
+++ b/dist/src/searchIndex.js
@@ -45,6 +45,8 @@ function ensureVecTable(db) {
     CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY, rel_path TEXT, heading_path TEXT, anchor TEXT, text TEXT);
     CREATE INDEX IF NOT EXISTS chunks_rel ON chunks(rel_path);
+    CREATE INDEX IF NOT EXISTS notes_project ON notes(project);
+    CREATE INDEX IF NOT EXISTS notes_created ON notes(created DESC);
     CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(text, content='');
   `);
     const storedDim = db.prepare("SELECT value FROM embed_meta WHERE key='dim'").get()?.value;
@@ -80,6 +82,11 @@ export function openIndex() {
     if (!cols.includes("created"))
         db.exec("ALTER TABLE notes ADD COLUMN created TEXT");
     ensureEdgesTable(db);
+    // G9: ensure indexes exist (idempotent, covers DBs opened before this PR)
+    db.exec(`
+    CREATE INDEX IF NOT EXISTS notes_project ON notes(project);
+    CREATE INDEX IF NOT EXISTS notes_created ON notes(created DESC);
+  `);
     const delByPath = db.transaction((relPath) => {
         const rows = db.prepare("SELECT id, heading_path, text FROM chunks WHERE rel_path=?").all(relPath);
         for (const r of rows) {
@@ -89,22 +96,39 @@ export function openIndex() {
         db.prepare("DELETE FROM chunks WHERE rel_path=?").run(relPath);
         db.prepare("DELETE FROM notes WHERE rel_path=?").run(relPath);
     });
+    // G7: hoist all prepared statements once here
     const insChunk = db.prepare("INSERT INTO chunks(rel_path,heading_path,anchor,text) VALUES (?,?,?,?)");
     const insFts = db.prepare("INSERT INTO chunks_fts(rowid,text) VALUES (?,?)");
     const insVec = db.prepare("INSERT INTO vec_chunks(chunk_id,embedding) VALUES (?,vec_int8(?))");
     const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created) VALUES (?,?,?,?,?)");
+    const selectChunkById = db.prepare("SELECT rel_path,heading_path,anchor,text FROM chunks WHERE id=?");
+    const selectChunkRelPath = db.prepare("SELECT rel_path FROM chunks WHERE id=?");
+    const selectNoteProject = db.prepare("SELECT project FROM notes WHERE rel_path=?");
+    const selectFtsRows = db.prepare("SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY bm25(chunks_fts) LIMIT ?");
+    const selectVecRows = db.prepare("SELECT chunk_id, distance FROM vec_chunks WHERE embedding MATCH vec_int8(?) ORDER BY distance LIMIT ?");
+    const selectGlobalFallback = db.prepare(`
+    SELECT c.id FROM chunks c
+    JOIN notes n ON n.rel_path = c.rel_path
+    WHERE n.project = 'global'
+    ORDER BY n.created DESC, c.id DESC
+    LIMIT ?
+  `);
+    const selectAllPaths = db.prepare("SELECT rel_path FROM notes ORDER BY rel_path");
+    const selectNoteMeta = db.prepare("SELECT mtime,hash FROM notes WHERE rel_path=?");
     const upsert = db.transaction((relPath, mtime, hash, chunks, embs, project, created) => {
         delByPath(relPath);
         const capped = chunks.slice(0, CHUNK_CAP);
         capped.forEach((c, i) => {
             const id = Number(insChunk.run(relPath, c.headingPath, c.anchor, c.text).lastInsertRowid);
             insFts.run(id, (c.headingPath ? c.headingPath + " " : "") + c.text);
+            // G8: pass Buffer directly to vec_int8(?) instead of JSON string
             insVec.run(BigInt(id), serializeInt8ForSql(quantizeToInt8(embs[i])));
         });
         insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null));
     });
+    // G7: hydrate uses hoisted selectChunkById
     const hydrate = (ids) => ids.map((id) => {
-        const r = db.prepare("SELECT rel_path,heading_path,anchor,text FROM chunks WHERE id=?").get(id);
+        const r = selectChunkById.get(id);
         return r ? { relPath: r.rel_path, headingPath: r.heading_path, anchor: r.anchor, text: r.text } : null;
     }).filter(Boolean);
     return {
@@ -114,55 +138,54 @@ export function openIndex() {
         bm25: (q, k) => {
             const terms = q.replace(/[^\w\s]/g, " ").trim().split(/\s+/).filter(Boolean);
             const ftsQuery = terms.length ? terms.join(" OR ") : '""';
-            const rows = db.prepare("SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY bm25(chunks_fts) LIMIT ?").all(ftsQuery, k);
+            // G7: reuse hoisted selectFtsRows
+            const rows = selectFtsRows.all(ftsQuery, k);
             return hydrate(rows.map((r) => r.rowid));
         },
         vectorKNN: (v, k) => {
-            const rows = db.prepare("SELECT chunk_id, distance FROM vec_chunks WHERE embedding MATCH vec_int8(?) ORDER BY distance LIMIT ?").all(serializeInt8ForSql(quantizeToInt8(v)), k);
+            // G7: reuse hoisted selectVecRows; G8: pass Buffer
+            const rows = selectVecRows.all(serializeInt8ForSql(quantizeToInt8(v)), k);
             const hits = hydrate(rows.map((r) => Number(r.chunk_id)));
             hits.forEach((h, i) => { h.distance = rows[i]?.distance; });
             return hits;
         },
         bm25Global: (q, k) => {
-            // Fetch a wider BM25 set and filter down to global/daily/pref notes.
             const terms = q.replace(/[^\w\s]/g, " ").trim().split(/\s+/).filter(Boolean);
             const ftsQuery = terms.length ? terms.join(" OR ") : '""';
-            const rows = db.prepare("SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY bm25(chunks_fts) LIMIT ?").all(ftsQuery, k * 4);
+            // G7: reuse hoisted selectFtsRows (wider set), selectChunkRelPath, selectNoteProject
+            const rows = selectFtsRows.all(ftsQuery, k * 4);
             const filtered = [];
             for (const row of rows) {
                 if (filtered.length >= k)
                     break;
-                const chunk = db.prepare("SELECT rel_path FROM chunks WHERE id=?").get(row.rowid);
+                // G7: reuse hoisted statements; G10: only project='global'
+                const chunk = selectChunkRelPath.get(row.rowid);
                 if (!chunk)
                     continue;
-                const note = db.prepare("SELECT project FROM notes WHERE rel_path=?").get(chunk.rel_path);
+                const note = selectNoteProject.get(chunk.rel_path);
                 if (!note)
                     continue;
-                if (note.project === "global" ||
-                    chunk.rel_path.startsWith("daily/") ||
-                    chunk.rel_path === "meta/preferences.md") {
+                if (note.project === "global") {
                     filtered.push(row.rowid);
                 }
             }
             return hydrate(filtered);
         },
         vectorKNNGlobal: (v, k) => {
-            // Fetch a wider candidate set from vectorKNN, then filter to global/daily/pref.
-            const allRows = db.prepare("SELECT chunk_id, distance FROM vec_chunks WHERE embedding MATCH vec_int8(?) ORDER BY distance LIMIT ?").all(serializeInt8ForSql(quantizeToInt8(v)), k * 4);
-            // Filter by joining with notes for global/daily/pref restriction
+            // G7: reuse hoisted selectVecRows; G8: pass Buffer; G10: only project='global'
+            const allRows = selectVecRows.all(serializeInt8ForSql(quantizeToInt8(v)), k * 4);
             const filtered = [];
             for (const row of allRows) {
                 if (filtered.length >= k)
                     break;
-                const chunk = db.prepare("SELECT rel_path FROM chunks WHERE id=?").get(Number(row.chunk_id));
+                // G7: reuse hoisted statements
+                const chunk = selectChunkRelPath.get(Number(row.chunk_id));
                 if (!chunk)
                     continue;
-                const note = db.prepare("SELECT project FROM notes WHERE rel_path=?").get(chunk.rel_path);
+                const note = selectNoteProject.get(chunk.rel_path);
                 if (!note)
                     continue;
-                if (note.project === "global" ||
-                    chunk.rel_path.startsWith("daily/") ||
-                    chunk.rel_path === "meta/preferences.md") {
+                if (note.project === "global") {
                     filtered.push(row);
                 }
             }
@@ -171,18 +194,8 @@ export function openIndex() {
             return hits;
         },
         globalFallbackNotes: (k) => {
-            // Return chunks from global/daily/pref notes ordered by created date desc.
-            const rows = db.prepare(`
-        SELECT c.id FROM chunks c
-        JOIN notes n ON n.rel_path = c.rel_path
-        WHERE (
-          n.project = 'global'
-          OR n.rel_path LIKE 'daily/%'
-          OR n.rel_path = 'meta/preferences.md'
-        )
-        ORDER BY n.created DESC, c.id DESC
-        LIMIT ?
-      `).all(k);
+            // G7: reuse hoisted selectGlobalFallback; G10: only project='global'
+            const rows = selectGlobalFallback.all(k);
             return hydrate(rows.map((r) => r.id));
         },
         getProjectsForPaths: (relPaths) => {
@@ -200,10 +213,13 @@ export function openIndex() {
             return new Map(rows.map((r) => [r.rel_path, r.created]));
         },
         getNoteMeta: (rp) => {
-            const r = db.prepare("SELECT mtime,hash FROM notes WHERE rel_path=?").get(rp);
+            // G7: reuse hoisted selectNoteMeta
+            const r = selectNoteMeta.get(rp);
             return r ? { mtime: r.mtime, hash: r.hash } : null;
         },
-        allIndexedPaths: () => db.prepare("SELECT rel_path FROM notes ORDER BY rel_path").all().map((r) => r.rel_path),
+        allIndexedPaths: () => 
+        // G7: reuse hoisted selectAllPaths
+        selectAllPaths.all().map((r) => r.rel_path),
         close: () => db.close(),
     };
 }

--- a/dist/src/staticEmbed/int8Quant.js
+++ b/dist/src/staticEmbed/int8Quant.js
@@ -11,7 +11,7 @@ export function quantizeToInt8(v) {
     return out;
 }
 export function serializeInt8ForSql(q) {
-    return "[" + Array.from(q).join(",") + "]";
+    return Buffer.from(q.buffer, q.byteOffset, q.byteLength);
 }
 export function int8ArrayFromBuffer(buf) {
     return new Int8Array(buf.buffer, buf.byteOffset, buf.byteLength);

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -11,6 +11,8 @@ import { slug as routerSlug } from "./router.js";
 
 const EXCLUDED = new Set([".trash", ".obsidian", ".git", "node_modules"]);
 
+const CROSS_CUTTING_FOLDERS = new Set(["daily", "decisions", "lessons", "knowledge", "meta"]);
+
 function walk(dir: string, root: string, acc: string[]) {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     if (e.isDirectory()) {
@@ -38,7 +40,14 @@ async function indexInto(ix: ReturnType<typeof openIndex>, relPath: string) {
   const created = typeof fm.created === "string" ? fm.created
     : fm.created instanceof Date ? (fm.created as Date).toISOString()
     : undefined;
-  ix.upsertNote(relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs, fm.project as string | undefined, created);
+  // G10: default cross-cutting folders to project='global' when frontmatter lacks project,
+  // so the G10 global filter does not require path heuristics.
+  let noteProject: string | undefined = fm.project as string | undefined;
+  if (!noteProject || (typeof noteProject === "string" && !noteProject.trim())) {
+    const topFolder = relPath.split("/")[0];
+    if (CROSS_CUTTING_FOLDERS.has(topFolder)) noteProject = "global";
+  }
+  ix.upsertNote(relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs, noteProject, created);
   upsertEdges(ix.db, deriveEdges(relPath, fm));
 }
 

--- a/src/searchIndex.ts
+++ b/src/searchIndex.ts
@@ -42,11 +42,11 @@ export interface Index {
   deleteNote(relPath: string): void;
   bm25(query: string, k: number): Hit[];
   vectorKNN(v: Float32Array, k: number): Hit[];
-  /** BM25 restricted to global/daily/preference notes only. */
+  /** BM25 restricted to global notes only (project='global'). */
   bm25Global(query: string, k: number): Hit[];
-  /** vectorKNN restricted to global/daily/preference notes only. */
+  /** vectorKNN restricted to global notes only (project='global'). */
   vectorKNNGlobal(v: Float32Array, k: number): Hit[];
-  /** Fallback: return up to k global/daily/pref notes ordered by created date desc. */
+  /** Fallback: return up to k global notes ordered by created date desc. */
   globalFallbackNotes(k: number): Hit[];
   getNoteMeta(relPath: string): { mtime: number; hash: string } | null;
   getProjectsForPaths(relPaths: string[]): Map<string, string>;
@@ -73,6 +73,8 @@ function ensureVecTable(db: Database.Database): void {
     CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY, rel_path TEXT, heading_path TEXT, anchor TEXT, text TEXT);
     CREATE INDEX IF NOT EXISTS chunks_rel ON chunks(rel_path);
+    CREATE INDEX IF NOT EXISTS notes_project ON notes(project);
+    CREATE INDEX IF NOT EXISTS notes_created ON notes(created DESC);
     CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(text, content='');
   `);
 
@@ -112,6 +114,12 @@ export function openIndex(): Index {
   if (!cols.includes("created")) db.exec("ALTER TABLE notes ADD COLUMN created TEXT");
   ensureEdgesTable(db);
 
+  // G9: ensure indexes exist (idempotent, covers DBs opened before this PR)
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS notes_project ON notes(project);
+    CREATE INDEX IF NOT EXISTS notes_created ON notes(created DESC);
+  `);
+
   const delByPath = db.transaction((relPath: string) => {
     const rows = db.prepare("SELECT id, heading_path, text FROM chunks WHERE rel_path=?").all(relPath) as { id: number; heading_path: string; text: string }[];
     for (const r of rows) {
@@ -122,10 +130,31 @@ export function openIndex(): Index {
     db.prepare("DELETE FROM notes WHERE rel_path=?").run(relPath);
   });
 
+  // G7: hoist all prepared statements once here
   const insChunk = db.prepare("INSERT INTO chunks(rel_path,heading_path,anchor,text) VALUES (?,?,?,?)");
   const insFts = db.prepare("INSERT INTO chunks_fts(rowid,text) VALUES (?,?)");
   const insVec = db.prepare("INSERT INTO vec_chunks(chunk_id,embedding) VALUES (?,vec_int8(?))");
   const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created) VALUES (?,?,?,?,?)");
+
+  const selectChunkById = db.prepare("SELECT rel_path,heading_path,anchor,text FROM chunks WHERE id=?");
+  const selectChunkRelPath = db.prepare("SELECT rel_path FROM chunks WHERE id=?");
+  const selectNoteProject = db.prepare("SELECT project FROM notes WHERE rel_path=?");
+
+  const selectFtsRows = db.prepare(
+    "SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY bm25(chunks_fts) LIMIT ?"
+  );
+  const selectVecRows = db.prepare(
+    "SELECT chunk_id, distance FROM vec_chunks WHERE embedding MATCH vec_int8(?) ORDER BY distance LIMIT ?"
+  );
+  const selectGlobalFallback = db.prepare(`
+    SELECT c.id FROM chunks c
+    JOIN notes n ON n.rel_path = c.rel_path
+    WHERE n.project = 'global'
+    ORDER BY n.created DESC, c.id DESC
+    LIMIT ?
+  `);
+  const selectAllPaths = db.prepare("SELECT rel_path FROM notes ORDER BY rel_path");
+  const selectNoteMeta = db.prepare("SELECT mtime,hash FROM notes WHERE rel_path=?");
 
   const upsert = db.transaction((relPath: string, mtime: number, hash: string,
       chunks: { headingPath: string; anchor: string; text: string }[], embs: Float32Array[],
@@ -135,13 +164,15 @@ export function openIndex(): Index {
     capped.forEach((c, i) => {
       const id = Number(insChunk.run(relPath, c.headingPath, c.anchor, c.text).lastInsertRowid);
       insFts.run(id, (c.headingPath ? c.headingPath + " " : "") + c.text);
+      // G8: pass Buffer directly to vec_int8(?) instead of JSON string
       insVec.run(BigInt(id), serializeInt8ForSql(quantizeToInt8(embs[i])));
     });
     insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null));
   });
 
+  // G7: hydrate uses hoisted selectChunkById
   const hydrate = (ids: number[]): Hit[] => ids.map((id) => {
-    const r = db.prepare("SELECT rel_path,heading_path,anchor,text FROM chunks WHERE id=?").get(id) as any;
+    const r = selectChunkById.get(id) as any;
     return r ? { relPath: r.rel_path, headingPath: r.heading_path, anchor: r.anchor, text: r.text } : null;
   }).filter(Boolean) as Hit[];
 
@@ -152,61 +183,48 @@ export function openIndex(): Index {
     bm25: (q, k) => {
       const terms = q.replace(/[^\w\s]/g, " ").trim().split(/\s+/).filter(Boolean);
       const ftsQuery = terms.length ? terms.join(" OR ") : '""';
-      const rows = db.prepare(
-        "SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY bm25(chunks_fts) LIMIT ?"
-      ).all(ftsQuery, k) as { rowid: number }[];
+      // G7: reuse hoisted selectFtsRows
+      const rows = selectFtsRows.all(ftsQuery, k) as { rowid: number }[];
       return hydrate(rows.map((r) => r.rowid));
     },
     vectorKNN: (v, k) => {
-      const rows = db.prepare(
-        "SELECT chunk_id, distance FROM vec_chunks WHERE embedding MATCH vec_int8(?) ORDER BY distance LIMIT ?"
-      ).all(serializeInt8ForSql(quantizeToInt8(v)), k) as { chunk_id: number; distance: number }[];
+      // G7: reuse hoisted selectVecRows; G8: pass Buffer
+      const rows = selectVecRows.all(serializeInt8ForSql(quantizeToInt8(v)), k) as { chunk_id: number; distance: number }[];
       const hits = hydrate(rows.map((r) => Number(r.chunk_id)));
       hits.forEach((h, i) => { h.distance = rows[i]?.distance; });
       return hits;
     },
     bm25Global: (q, k) => {
-      // Fetch a wider BM25 set and filter down to global/daily/pref notes.
       const terms = q.replace(/[^\w\s]/g, " ").trim().split(/\s+/).filter(Boolean);
       const ftsQuery = terms.length ? terms.join(" OR ") : '""';
-      const rows = db.prepare(
-        "SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY bm25(chunks_fts) LIMIT ?"
-      ).all(ftsQuery, k * 4) as { rowid: number }[];
+      // G7: reuse hoisted selectFtsRows (wider set), selectChunkRelPath, selectNoteProject
+      const rows = selectFtsRows.all(ftsQuery, k * 4) as { rowid: number }[];
       const filtered: number[] = [];
       for (const row of rows) {
         if (filtered.length >= k) break;
-        const chunk = db.prepare("SELECT rel_path FROM chunks WHERE id=?").get(row.rowid) as { rel_path: string } | undefined;
+        // G7: reuse hoisted statements; G10: only project='global'
+        const chunk = selectChunkRelPath.get(row.rowid) as { rel_path: string } | undefined;
         if (!chunk) continue;
-        const note = db.prepare("SELECT project FROM notes WHERE rel_path=?").get(chunk.rel_path) as { project: string | null } | undefined;
+        const note = selectNoteProject.get(chunk.rel_path) as { project: string | null } | undefined;
         if (!note) continue;
-        if (
-          note.project === "global" ||
-          chunk.rel_path.startsWith("daily/") ||
-          chunk.rel_path === "meta/preferences.md"
-        ) {
+        if (note.project === "global") {
           filtered.push(row.rowid);
         }
       }
       return hydrate(filtered);
     },
     vectorKNNGlobal: (v, k) => {
-      // Fetch a wider candidate set from vectorKNN, then filter to global/daily/pref.
-      const allRows = db.prepare(
-        "SELECT chunk_id, distance FROM vec_chunks WHERE embedding MATCH vec_int8(?) ORDER BY distance LIMIT ?"
-      ).all(serializeInt8ForSql(quantizeToInt8(v)), k * 4) as { chunk_id: number; distance: number }[];
-      // Filter by joining with notes for global/daily/pref restriction
+      // G7: reuse hoisted selectVecRows; G8: pass Buffer; G10: only project='global'
+      const allRows = selectVecRows.all(serializeInt8ForSql(quantizeToInt8(v)), k * 4) as { chunk_id: number; distance: number }[];
       const filtered: { chunk_id: number; distance: number }[] = [];
       for (const row of allRows) {
         if (filtered.length >= k) break;
-        const chunk = db.prepare("SELECT rel_path FROM chunks WHERE id=?").get(Number(row.chunk_id)) as { rel_path: string } | undefined;
+        // G7: reuse hoisted statements
+        const chunk = selectChunkRelPath.get(Number(row.chunk_id)) as { rel_path: string } | undefined;
         if (!chunk) continue;
-        const note = db.prepare("SELECT project FROM notes WHERE rel_path=?").get(chunk.rel_path) as { project: string | null } | undefined;
+        const note = selectNoteProject.get(chunk.rel_path) as { project: string | null } | undefined;
         if (!note) continue;
-        if (
-          note.project === "global" ||
-          chunk.rel_path.startsWith("daily/") ||
-          chunk.rel_path === "meta/preferences.md"
-        ) {
+        if (note.project === "global") {
           filtered.push(row);
         }
       }
@@ -215,18 +233,8 @@ export function openIndex(): Index {
       return hits;
     },
     globalFallbackNotes: (k) => {
-      // Return chunks from global/daily/pref notes ordered by created date desc.
-      const rows = db.prepare(`
-        SELECT c.id FROM chunks c
-        JOIN notes n ON n.rel_path = c.rel_path
-        WHERE (
-          n.project = 'global'
-          OR n.rel_path LIKE 'daily/%'
-          OR n.rel_path = 'meta/preferences.md'
-        )
-        ORDER BY n.created DESC, c.id DESC
-        LIMIT ?
-      `).all(k) as { id: number }[];
+      // G7: reuse hoisted selectGlobalFallback; G10: only project='global'
+      const rows = selectGlobalFallback.all(k) as { id: number }[];
       return hydrate(rows.map((r) => r.id));
     },
     getProjectsForPaths: (relPaths: string[]): Map<string, string> => {
@@ -246,11 +254,13 @@ export function openIndex(): Index {
       return new Map(rows.map((r) => [r.rel_path, r.created]));
     },
     getNoteMeta: (rp) => {
-      const r = db.prepare("SELECT mtime,hash FROM notes WHERE rel_path=?").get(rp) as any;
+      // G7: reuse hoisted selectNoteMeta
+      const r = selectNoteMeta.get(rp) as any;
       return r ? { mtime: r.mtime, hash: r.hash } : null;
     },
     allIndexedPaths: () =>
-      (db.prepare("SELECT rel_path FROM notes ORDER BY rel_path").all() as any[]).map((r) => r.rel_path),
+      // G7: reuse hoisted selectAllPaths
+      (selectAllPaths.all() as any[]).map((r) => r.rel_path),
     close: () => db.close(),
   };
 }

--- a/src/staticEmbed/int8Quant.ts
+++ b/src/staticEmbed/int8Quant.ts
@@ -12,8 +12,8 @@ export function quantizeToInt8(v: Float32Array): Int8Array {
   return out;
 }
 
-export function serializeInt8ForSql(q: Int8Array): string {
-  return "[" + Array.from(q).join(",") + "]";
+export function serializeInt8ForSql(q: Int8Array): Buffer {
+  return Buffer.from(q.buffer, q.byteOffset, q.byteLength);
 }
 
 export function int8ArrayFromBuffer(buf: Buffer): Int8Array {

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -132,6 +132,38 @@ describe("indexer", () => {
     expect(rows.every((r) => r.to_path !== "projects/alpha.md")).toBe(true);
   });
 
+  it("indexNote stamps project='global' for cross-cutting folders when frontmatter lacks project", async () => {
+    const crossCutting = ["daily", "decisions", "lessons", "knowledge", "meta"];
+    for (const folder of crossCutting) {
+      fs.mkdirSync(path.join(TMP_VAULT, folder), { recursive: true });
+      fs.writeFileSync(
+        path.join(TMP_VAULT, `${folder}/test-note.md`),
+        `---\ntype: note\n---\n## Section\ncontent for ${folder}`
+      );
+      await indexNote(`${folder}/test-note.md`);
+    }
+    const ix = openIndex();
+    for (const folder of crossCutting) {
+      const meta = ix.db.prepare("SELECT project FROM notes WHERE rel_path=?")
+        .get(`${folder}/test-note.md`) as { project: string | null } | undefined;
+      expect(meta?.project).toBe("global");
+    }
+    ix.close();
+  });
+
+  it("indexNote preserves explicit project from frontmatter (no override)", async () => {
+    fs.writeFileSync(
+      path.join(TMP_VAULT, "decisions/explicit.md"),
+      "---\ntype: decision\nproject: alpha-proj\n---\n## D\nsome content"
+    );
+    await indexNote("decisions/explicit.md");
+    const ix = openIndex();
+    const meta = ix.db.prepare("SELECT project FROM notes WHERE rel_path=?")
+      .get("decisions/explicit.md") as { project: string | null } | undefined;
+    expect(meta?.project).toBe("alpha-proj");
+    ix.close();
+  });
+
   it("forcedReindexIfNeeded runs once for a version then is a no-op on second call", async () => {
     const f = path.join(TMP_VAULT, "decisions/f.md");
     fs.writeFileSync(f, "---\ntype: decision\nproject: bar\n---\n## F\ncontent for sentinel test");

--- a/tests/searchIndex.test.ts
+++ b/tests/searchIndex.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import Database from "better-sqlite3";
 import { openIndex, rrf } from "../src/searchIndex";
+import { serializeInt8ForSql, quantizeToInt8 } from "../src/staticEmbed/int8Quant.js";
 
 let TMP: string;
 
@@ -96,6 +98,128 @@ describe("searchIndex", () => {
     ix.deleteNote("p/h.md");
     expect(ix.bm25("Gotchas", 5).length).toBe(0);     // heading term purged on delete too
     expect(ix.bm25("beta", 5).length).toBe(0);
+    ix.close();
+  });
+});
+
+describe("G7: prepared statements hoisted (no per-call prepare)", () => {
+  it("does not call db.prepare after openIndex() when global methods are invoked", () => {
+    const ix = openIndex();
+    // Seed some global data
+    ix.upsertNote("daily/2026-01-01.md", 1, "h1",
+      [{ headingPath: "", anchor: "", text: "daily note content" }], [vec(0.1)],
+      "global", "2026-01-01");
+    ix.upsertNote("meta/preferences.md", 1, "h2",
+      [{ headingPath: "", anchor: "", text: "preference content" }], [vec(0.2)],
+      "global", "2026-01-01");
+
+    // Spy on db.prepare AFTER openIndex returned
+    const prepareSpy = vi.spyOn(ix.db, "prepare");
+
+    // Call each global method 3 times
+    for (let i = 0; i < 3; i++) {
+      ix.bm25Global("daily note", 2);
+      ix.vectorKNNGlobal(vec(0.1), 2);
+      ix.globalFallbackNotes(2);
+    }
+    // Also call hydrate-using methods
+    for (let i = 0; i < 3; i++) {
+      ix.bm25("daily", 2);
+      ix.vectorKNN(vec(0.1), 2);
+    }
+
+    expect(prepareSpy).not.toHaveBeenCalled();
+    prepareSpy.mockRestore();
+    ix.close();
+  });
+});
+
+describe("G8: serializeInt8ForSql returns Buffer", () => {
+  it("returns a Buffer whose byteLength equals the Int8Array length", () => {
+    const v = new Float32Array(256).fill(0.5);
+    const q = quantizeToInt8(v);
+    const result = serializeInt8ForSql(q);
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect((result as Buffer).byteLength).toBe(256);
+  });
+
+  it("round-trip: upsert with buffer int8 and vectorKNN returns correct hit", () => {
+    const ix = openIndex();
+    ix.upsertNote("test/buf.md", 1, "h",
+      [{ headingPath: "", anchor: "", text: "buffer round trip" }],
+      [vec(0.7)], "global", "2026-01-01");
+    const hits = ix.vectorKNN(vec(0.7), 1);
+    expect(hits.length).toBe(1);
+    expect(hits[0].relPath).toBe("test/buf.md");
+    ix.close();
+  });
+});
+
+describe("G9: indexes on notes(project) and notes(created)", () => {
+  it("EXPLAIN QUERY PLAN shows index scan for globalFallbackNotes query", () => {
+    const ix = openIndex();
+    ix.upsertNote("daily/2026-01-01.md", 1, "h",
+      [{ headingPath: "", anchor: "", text: "indexed note" }], [vec(0.3)],
+      "global", "2026-01-01");
+
+    // Check that the notes_project index exists
+    const indexes = ix.db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='notes'"
+    ).all() as { name: string }[];
+    const indexNames = indexes.map((r) => r.name);
+    expect(indexNames).toContain("notes_project");
+    expect(indexNames).toContain("notes_created");
+
+    // EXPLAIN QUERY PLAN should not show SCAN TABLE for the global filter
+    const plan = ix.db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT c.id FROM chunks c
+      JOIN notes n ON n.rel_path = c.rel_path
+      WHERE n.project = 'global'
+      ORDER BY n.created DESC, c.id DESC
+      LIMIT 10
+    `).all() as { detail: string }[];
+    const planStr = plan.map((r) => r.detail).join(" ");
+    // Should use the notes_project or notes_created index, not a full table scan on notes
+    expect(planStr).not.toMatch(/SCAN TABLE notes(?! USING)/);
+    ix.close();
+  });
+});
+
+describe("G10: unified global filter uses only project='global'", () => {
+  it("returns a project='global' note at a non-daily path", () => {
+    const ix = openIndex();
+    ix.upsertNote("meta/custom.md", 1, "h",
+      [{ headingPath: "", anchor: "", text: "cross cutting global knowledge" }],
+      [vec(0.4)], "global", "2026-01-01");
+
+    const bm = ix.bm25Global("cross cutting", 5);
+    expect(bm.some((h) => h.relPath === "meta/custom.md")).toBe(true);
+
+    const knn = ix.vectorKNNGlobal(vec(0.4), 5);
+    expect(knn.some((h) => h.relPath === "meta/custom.md")).toBe(true);
+
+    const fb = ix.globalFallbackNotes(5);
+    expect(fb.some((h) => h.relPath === "meta/custom.md")).toBe(true);
+    ix.close();
+  });
+
+  it("does NOT return a daily/ note with project=null after G10 fix", () => {
+    const ix = openIndex();
+    // Insert a note at daily/ path but with project=null (old behavior)
+    ix.db.prepare(
+      "INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created) VALUES (?,?,?,?,?)"
+    ).run("daily/2026-01-02.md", 1, "h2", null, "2026-01-02");
+    ix.db.prepare("INSERT INTO chunks(rel_path,heading_path,anchor,text) VALUES (?,?,?,?)")
+      .run("daily/2026-01-02.md", "", "", "null project daily note");
+    const chunkId = ix.db.prepare("SELECT last_insert_rowid() as id").get() as { id: number };
+    ix.db.prepare("INSERT INTO chunks_fts(rowid,text) VALUES (?,?)").run(chunkId.id, "null project daily note");
+
+    const bm = ix.bm25Global("null project daily", 5);
+    expect(bm.some((h) => h.relPath === "daily/2026-01-02.md")).toBe(false);
+
+    const fb = ix.globalFallbackNotes(5);
+    expect(fb.some((h) => h.relPath === "daily/2026-01-02.md")).toBe(false);
     ix.close();
   });
 });

--- a/tests/staticEmbed.test.ts
+++ b/tests/staticEmbed.test.ts
@@ -113,10 +113,18 @@ describe("int8 quantization", () => {
     expect(q[2]).toBe(127);
   });
 
-  it("serializeInt8ForSql returns a JSON array string", () => {
+  it("serializeInt8ForSql returns a Buffer (not a JSON string)", () => {
     const q = new Int8Array([10, -20, 30, -40]);
-    const s = serializeInt8ForSql(q);
-    expect(s).toBe("[10,-20,30,-40]");
+    const result = serializeInt8ForSql(q);
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect((result as Buffer).byteLength).toBe(4);
+  });
+
+  it("serializeInt8ForSql buffer contains correct int8 bytes", () => {
+    const q = new Int8Array([10, -20, 30, -40]);
+    const buf = serializeInt8ForSql(q) as unknown as Buffer;
+    const recovered = new Int8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    expect(Array.from(recovered)).toEqual([10, -20, 30, -40]);
   });
 
   it("int8ArrayFromBuffer round-trips raw bytes", () => {


### PR DESCRIPTION
## Summary

- G7: Hoist all db.prepare() calls into openIndex() so zero statements are prepared per method invocation; eliminates N+1 prepare pattern across hydrate, bm25Global, vectorKNNGlobal, globalFallbackNotes, and all other hot-path methods
- G8: serializeInt8ForSql returns a Buffer over raw int8 bytes instead of a JSON array string; vec_int8(?) accepts a buffer directly, removing per-call JSON serialisation and re-parse on every upsert and KNN query
- G9: Add CREATE INDEX IF NOT EXISTS notes_project and notes_created at openIndex() time (idempotent); globalFallbackNotes now uses an index scan
- G10: Remove daily/ and meta/preferences.md path heuristics from global filter methods; the sole filter is note.project = 'global'. indexInto in indexer.ts stamps project='global' for cross-cutting folders (daily/, decisions/, lessons/, knowledge/, meta/) when frontmatter lacks a project value, preventing global-filter starvation without C1

## Test plan

- G7: spy on db.prepare after openIndex(), call each global method 3x, assert zero further prepares
- G8: unit-assert serializeInt8ForSql returns a Buffer with correct byteLength; round-trip upsert/vectorKNN correctness
- G9: assert notes_project and notes_created indexes exist; EXPLAIN QUERY PLAN does not show SCAN TABLE notes for the global fallback query
- G10: a project=global note at a non-daily path is returned; a daily/ note with project=null is excluded
- Indexer: indexNote stamps project=global for each cross-cutting folder; explicit project in frontmatter is preserved
- Full suite green (799/799), tsc --noEmit clean

Generated with [Claude Code](https://claude.com/claude-code)