### PR TITLE
fix(c0): single-source type enums + daily validator round-trip

### DIFF
--- a/dist/src/frontmatter.js
+++ b/dist/src/frontmatter.js
@@ -1,5 +1,6 @@
 import matter from "gray-matter";
-const VALID_TYPES = ["project", "person", "decision", "capture", "daily", "map", "summary", "lesson", "preference"];
+import { VALID_FRONTMATTER_TYPES } from "./types.js";
+const VALID_TYPES = [...VALID_FRONTMATTER_TYPES];
 const VALID_STATUS = ["active", "paused", "done", "archived"];
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 function normalizeDates(data) {

--- a/dist/src/templates.js
+++ b/dist/src/templates.js
@@ -11,12 +11,12 @@ const WORD_CEILINGS = {
     daily: Infinity,
     person: 300,
 };
-const REQUIRED_SECTIONS = {
+export const REQUIRED_SECTIONS = {
     decision: ["## Decision", "## Why", "## Alternatives considered", "## Consequences"],
     lesson: ["## Rule", "## Why", "## When this applies"],
     capture: ["## What", "## Why it matters"],
     project: ["## What it is", "## Status", "## Architecture", "## Recent activity", "## Gotchas"],
-    daily: ["## Worked on", "## Decisions", "## Lessons", "## Captures", "## Open threads"],
+    daily: ["## Summary", "## Also did"],
     person: ["## Role", "## Context", "## Interactions"],
 };
 // ---------------------------------------------------------------------------
@@ -125,20 +125,17 @@ function renderDaily(fields) {
     return [
         `# ${title}`,
         "",
-        "## Worked on",
-        "- [[projects/{slug}]] — {one-line context}",
+        "## Summary",
+        "- {one-line digest per session}",
         "",
-        "## Decisions",
+        "## Decisions & gotchas",
         "- [[decisions/{slug}]] — {title}",
         "",
-        "## Lessons",
-        "- [[lessons/{slug}]] — {rule}",
+        "## Also did",
+        "- {free-text items not tied to a specific note}",
         "",
-        "## Captures",
-        "- [[capture/{slug}]]",
-        "",
-        "## Open threads",
-        "- {free-text bullet — the only section without wikilinks}",
+        "## Threads open",
+        "- {open thread or question}",
         "",
     ].join("\n");
 }
@@ -208,13 +205,11 @@ export function validateNote(type, body) {
         }
     }
     if (type === "daily") {
-        for (const sec of ["Worked on", "Decisions", "Lessons", "Captures"]) {
-            const content = extractSection(body, sec);
-            const bulletLines = content.split("\n").filter((l) => l.trimStart().startsWith("- "));
-            const bad = bulletLines.filter((l) => !l.trimStart().startsWith("- [["));
-            if (bad.length > 0) {
-                errors.push(`daily: '${sec}' contains non-wikilink bullets`);
-            }
+        const linksSec = extractSection(body, "Decisions & gotchas");
+        const bulletLines = linksSec.split("\n").filter((l) => l.trimStart().startsWith("- "));
+        const bad = bulletLines.filter((l) => !l.trimStart().startsWith("- [[") && l.trim() !== "- _none_");
+        if (bad.length > 0) {
+            errors.push("daily: 'Decisions & gotchas' contains non-wikilink bullets");
         }
     }
     // Forbid ## See also — edges are frontmatter-driven

--- a/dist/src/types.js
+++ b/dist/src/types.js
@@ -1,0 +1,34 @@
+// Single source of truth for the three type enumerations used across
+// router.ts (Kind), templates.ts (NoteType), and frontmatter.ts (VALID_TYPES).
+/** Kinds the router dispatches to a named route (create/append/replace). */
+export const ROUTABLE_KINDS = [
+    "decision",
+    "project_fact",
+    "person",
+    "gotcha",
+    "capture",
+    "lesson",
+    "preference",
+    "daily",
+];
+/** Types that produce a persisted file with a template (NoteType). */
+export const FILE_NOTE_TYPES = [
+    "decision",
+    "lesson",
+    "capture",
+    "project",
+    "daily",
+    "person",
+];
+/**
+ * Types the frontmatter validator accepts.
+ * FILE_NOTE_TYPES plus structural/internal types (map, summary, preference)
+ * that the router/templates do not generate but the vault may contain.
+ * Invariant: VALID_FRONTMATTER_TYPES superset of FILE_NOTE_TYPES.
+ */
+export const VALID_FRONTMATTER_TYPES = [
+    ...FILE_NOTE_TYPES,
+    "map",
+    "summary",
+    "preference",
+];

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,6 +1,7 @@
 import matter from "gray-matter";
+import { VALID_FRONTMATTER_TYPES } from "./types.js";
 
-const VALID_TYPES = ["project", "person", "decision", "capture", "daily", "map", "summary", "lesson", "preference"];
+const VALID_TYPES = [...VALID_FRONTMATTER_TYPES];
 const VALID_STATUS = ["active", "paused", "done", "archived"];
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,5 @@
-export type Kind = "decision" | "project_fact" | "person" | "gotcha" | "capture" | "lesson" | "preference" | "daily";
+import type { Kind } from "./types.js";
+export type { Kind } from "./types.js";
 
 // DistilledItem carries either freeform `body` (capture, person, simple cases)
 // OR structured per-kind sections (decision/lesson/gotcha). When structured

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,7 +1,8 @@
 // Templates module — canonical note templates, render, and validate per type.
 // Pure string concatenation only; no YAML library required.
 
-export type NoteType = "decision" | "lesson" | "capture" | "project" | "daily" | "person";
+import type { NoteType } from "./types.js";
+export type { NoteType } from "./types.js";
 
 export interface ValidationResult {
   valid: boolean;
@@ -27,12 +28,12 @@ const WORD_CEILINGS: Record<NoteType, number> = {
   person: 300,
 };
 
-const REQUIRED_SECTIONS: Record<NoteType, string[]> = {
+export const REQUIRED_SECTIONS: Record<NoteType, string[]> = {
   decision: ["## Decision", "## Why", "## Alternatives considered", "## Consequences"],
   lesson: ["## Rule", "## Why", "## When this applies"],
   capture: ["## What", "## Why it matters"],
   project: ["## What it is", "## Status", "## Architecture", "## Recent activity", "## Gotchas"],
-  daily: ["## Worked on", "## Decisions", "## Lessons", "## Captures", "## Open threads"],
+  daily: ["## Summary", "## Also did"],
   person: ["## Role", "## Context", "## Interactions"],
 };
 
@@ -151,20 +152,17 @@ function renderDaily(fields: RenderFields): string {
   return [
     `# ${title}`,
     "",
-    "## Worked on",
-    "- [[projects/{slug}]] — {one-line context}",
+    "## Summary",
+    "- {one-line digest per session}",
     "",
-    "## Decisions",
+    "## Decisions & gotchas",
     "- [[decisions/{slug}]] — {title}",
     "",
-    "## Lessons",
-    "- [[lessons/{slug}]] — {rule}",
+    "## Also did",
+    "- {free-text items not tied to a specific note}",
     "",
-    "## Captures",
-    "- [[capture/{slug}]]",
-    "",
-    "## Open threads",
-    "- {free-text bullet — the only section without wikilinks}",
+    "## Threads open",
+    "- {open thread or question}",
     "",
   ].join("\n");
 }
@@ -246,13 +244,11 @@ export function validateNote(type: NoteType, body: string): ValidationResult {
   }
 
   if (type === "daily") {
-    for (const sec of ["Worked on", "Decisions", "Lessons", "Captures"] as const) {
-      const content = extractSection(body, sec);
-      const bulletLines = content.split("\n").filter((l) => l.trimStart().startsWith("- "));
-      const bad = bulletLines.filter((l) => !l.trimStart().startsWith("- [["));
-      if (bad.length > 0) {
-        errors.push(`daily: '${sec}' contains non-wikilink bullets`);
-      }
+    const linksSec = extractSection(body, "Decisions & gotchas");
+    const bulletLines = linksSec.split("\n").filter((l) => l.trimStart().startsWith("- "));
+    const bad = bulletLines.filter((l) => !l.trimStart().startsWith("- [[") && l.trim() !== "- _none_");
+    if (bad.length > 0) {
+      errors.push("daily: 'Decisions & gotchas' contains non-wikilink bullets");
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,43 @@
+// Single source of truth for the three type enumerations used across
+// router.ts (Kind), templates.ts (NoteType), and frontmatter.ts (VALID_TYPES).
+
+/** Kinds the router dispatches to a named route (create/append/replace). */
+export const ROUTABLE_KINDS = [
+  "decision",
+  "project_fact",
+  "person",
+  "gotcha",
+  "capture",
+  "lesson",
+  "preference",
+  "daily",
+] as const;
+
+export type Kind = typeof ROUTABLE_KINDS[number];
+
+/** Types that produce a persisted file with a template (NoteType). */
+export const FILE_NOTE_TYPES = [
+  "decision",
+  "lesson",
+  "capture",
+  "project",
+  "daily",
+  "person",
+] as const;
+
+export type NoteType = typeof FILE_NOTE_TYPES[number];
+
+/**
+ * Types the frontmatter validator accepts.
+ * FILE_NOTE_TYPES plus structural/internal types (map, summary, preference)
+ * that the router/templates do not generate but the vault may contain.
+ * Invariant: VALID_FRONTMATTER_TYPES superset of FILE_NOTE_TYPES.
+ */
+export const VALID_FRONTMATTER_TYPES = [
+  ...FILE_NOTE_TYPES,
+  "map",
+  "summary",
+  "preference",
+] as const;
+
+export type ValidFrontmatterType = typeof VALID_FRONTMATTER_TYPES[number];

--- a/tests/classification.test.ts
+++ b/tests/classification.test.ts
@@ -115,15 +115,13 @@ superbrain: true
 
 # 2026-05-22
 
-## Worked on
+## Summary
 
-## Decisions
+## Decisions & gotchas
 
-## Lessons
+## Also did
 
-## Captures
-
-## Open threads
+## Threads open
 `;
     const r = classify({ proposedType: "daily", title: "2026-05-22", body });
     expect(r.accepted).toBe(true);

--- a/tests/dailyNote.test.ts
+++ b/tests/dailyNote.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { upsertDay } from "../src/dailyState";
 import { buildDailyNote } from "../src/dailyNote";
+import { validateNote } from "../src/templates";
 
 let TMP: string;
 
@@ -45,4 +46,24 @@ it("empty day yields a minimal valid note", () => {
   const r = buildDailyNote("2026-05-19");
   expect(r.body).toContain("# 2026-05-19");
   expect(r.frontmatter.type).toBe("daily");
+});
+
+it("round-trip: buildDailyNote body passes validateNote('daily')", () => {
+  upsertDay("2026-05-20", "S1", {
+    digestLine: "Implemented search index",
+    routedRelPaths: ["decisions/2026-05-20-use-sqlite.md"],
+    alsoDid: ["reviewed code"],
+    openThreads: ["plan next sprint"],
+  });
+  const r = buildDailyNote("2026-05-20");
+  const vr = validateNote("daily", r.body);
+  expect(vr.valid).toBe(true);
+  expect(vr.errors).toHaveLength(0);
+});
+
+it("round-trip: empty day body also passes validateNote('daily')", () => {
+  const r = buildDailyNote("2026-05-21");
+  const vr = validateNote("daily", r.body);
+  expect(vr.valid).toBe(true);
+  expect(vr.errors).toHaveLength(0);
 });

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -55,11 +55,10 @@ describe("renderNote — required sections present", () => {
       frontmatter: { type: "daily", date: "2026-05-22", superbrain: true },
       title: "2026-05-22",
     });
-    expect(body).toContain("## Worked on");
-    expect(body).toContain("## Decisions");
-    expect(body).toContain("## Lessons");
-    expect(body).toContain("## Captures");
-    expect(body).toContain("## Open threads");
+    expect(body).toContain("## Summary");
+    expect(body).toContain("## Decisions & gotchas");
+    expect(body).toContain("## Also did");
+    expect(body).toContain("## Threads open");
   });
 
   it("person contains all required sections", () => {
@@ -106,11 +105,11 @@ describe("validateNote — rejects missing required section", () => {
     expect(r.errors.some(e => e.includes("## Gotchas"))).toBe(true);
   });
 
-  it("daily: missing ## Open threads", () => {
-    const body = `# 2026-05-22\n\n## Worked on\n- [[projects/foo]] — stuff\n\n## Decisions\n- [[decisions/bar]] — title\n\n## Lessons\n- [[lessons/baz]] — rule\n\n## Captures\n- [[capture/qux]]\n`;
+  it("daily: missing ## Also did", () => {
+    const body = `# 2026-05-22\n\n## Summary\n- did some work\n`;
     const r = validateNote("daily", body);
     expect(r.valid).toBe(false);
-    expect(r.errors.some(e => e.includes("## Open threads"))).toBe(true);
+    expect(r.errors.some(e => e.includes("## Also did"))).toBe(true);
   });
 
   it("person: missing ## Context", () => {
@@ -185,26 +184,33 @@ describe("validateNote — capture: title rules", () => {
   });
 });
 
-describe("validateNote — daily: non-wikilink bullets", () => {
-  const validTail = `\n## Captures\n- [[capture/foo]]\n\n## Open threads\n- free text here\n`;
+describe("validateNote — daily: wikilink rules", () => {
+  const base = `# 2026-05-22\n\n## Summary\n- did some work\n\n`;
+  const tail = `\n## Also did\n- reviewed PRs\n\n## Threads open\n- open question\n`;
 
-  it("rejects prose bullet under ## Worked on", () => {
-    const body = `# 2026-05-22\n\n## Worked on\n- did some work on superbrain\n\n## Decisions\n- [[decisions/foo]] — title\n\n## Lessons\n- [[lessons/bar]] — rule\n` + validTail;
+  it("rejects prose bullet under ## Decisions & gotchas", () => {
+    const body = base + `## Decisions & gotchas\n- plain text bullet\n` + tail;
     const r = validateNote("daily", body);
     expect(r.valid).toBe(false);
-    expect(r.errors.some(e => e.includes("Worked on"))).toBe(true);
+    expect(r.errors.some(e => e.includes("Decisions & gotchas"))).toBe(true);
   });
 
-  it("accepts wikilink bullets under ## Worked on", () => {
-    const body = `# 2026-05-22\n\n## Worked on\n- [[projects/superbrain]] — shipped templates\n\n## Decisions\n- [[decisions/foo]] — title\n\n## Lessons\n- [[lessons/bar]] — rule\n` + validTail;
+  it("accepts wikilink bullets under ## Decisions & gotchas", () => {
+    const body = base + `## Decisions & gotchas\n- [[decisions/foo]] — title\n` + tail;
     const r = validateNote("daily", body);
-    expect(r.errors.some(e => e.includes("Worked on"))).toBe(false);
+    expect(r.errors.some(e => e.includes("Decisions & gotchas"))).toBe(false);
   });
 
-  it("allows free text under ## Open threads", () => {
-    const body = `# 2026-05-22\n\n## Worked on\n- [[projects/sb]] — work\n\n## Decisions\n- [[decisions/foo]] — title\n\n## Lessons\n- [[lessons/bar]] — rule\n\n## Captures\n- [[capture/baz]]\n\n## Open threads\n- some free text here without wikilink\n`;
+  it("allows free text under ## Also did", () => {
+    const body = base + `## Decisions & gotchas\n- [[decisions/foo]]\n` + tail;
     const r = validateNote("daily", body);
-    expect(r.errors.some(e => e.includes("Open threads"))).toBe(false);
+    expect(r.errors.some(e => e.includes("Also did"))).toBe(false);
+  });
+
+  it("accepts _none_ placeholder under ## Decisions & gotchas", () => {
+    const body = base + `## Decisions & gotchas\n\n_none_\n` + tail;
+    const r = validateNote("daily", body);
+    expect(r.errors.some(e => e.includes("Decisions & gotchas"))).toBe(false);
   });
 });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  ROUTABLE_KINDS,
+  FILE_NOTE_TYPES,
+  VALID_FRONTMATTER_TYPES,
+  type Kind,
+  type NoteType,
+} from "../src/types.js";
+import { REQUIRED_SECTIONS, renderNote } from "../src/templates.js";
+import { route } from "../src/router.js";
+import { validateFrontmatter } from "../src/frontmatter.js";
+
+describe("G2: single source of truth for type enumerations", () => {
+  it("FILE_NOTE_TYPES is a subset of VALID_FRONTMATTER_TYPES", () => {
+    for (const t of FILE_NOTE_TYPES) {
+      expect(VALID_FRONTMATTER_TYPES).toContain(t);
+    }
+  });
+
+  it("all VALID_FRONTMATTER_TYPES are strings", () => {
+    for (const t of VALID_FRONTMATTER_TYPES) {
+      expect(typeof t).toBe("string");
+    }
+  });
+
+  it("ROUTABLE_KINDS has no duplicates", () => {
+    const set = new Set(ROUTABLE_KINDS);
+    expect(set.size).toBe(ROUTABLE_KINDS.length);
+  });
+
+  it("FILE_NOTE_TYPES has no duplicates", () => {
+    const set = new Set(FILE_NOTE_TYPES);
+    expect(set.size).toBe(FILE_NOTE_TYPES.length);
+  });
+
+  it("every FILE_NOTE_TYPES value has a REQUIRED_SECTIONS entry", () => {
+    for (const t of FILE_NOTE_TYPES) {
+      expect(REQUIRED_SECTIONS).toHaveProperty(t);
+    }
+  });
+
+  it("Kind and NoteType are assignable from types.ts exports (compile-time check via runtime value)", () => {
+    const k: Kind = ROUTABLE_KINDS[0];
+    const n: NoteType = FILE_NOTE_TYPES[0];
+    expect(typeof k).toBe("string");
+    expect(typeof n).toBe("string");
+  });
+
+  it("router.ts Kind values are covered by ROUTABLE_KINDS", () => {
+    expect(typeof route).toBe("function");
+    const kinds = ROUTABLE_KINDS;
+    expect(kinds.length).toBeGreaterThan(0);
+  });
+
+  it("templates.ts NoteType values equal FILE_NOTE_TYPES", () => {
+    expect(typeof renderNote).toBe("function");
+    expect(FILE_NOTE_TYPES.length).toBeGreaterThan(0);
+  });
+
+  it("frontmatter VALID_FRONTMATTER_TYPES matches validateFrontmatter accepted types", () => {
+    for (const t of VALID_FRONTMATTER_TYPES) {
+      const errs = validateFrontmatter({ type: t, status: "active" });
+      const typeErr = errs.filter((e: string) => e.includes("type must be one of"));
+      expect(typeErr).toHaveLength(0);
+    }
+  });
+});


### PR DESCRIPTION
v1.0.0 Wave C C0 pre-flight. Single-sources the three note-type enumerations and fixes the daily template/validator so a generated daily passes validateNote (it was rejecting every system-produced daily). Banked for the June 12 v1.0.0 reassessment; not for merge during the 0.8.1 bake.