### PR TITLE
fix: make the failure sentinel diagnosable (version stamp, bounded history, scoped hint)

### DIFF
--- a/bin/sb-session-start.ts
+++ b/bin/sb-session-start.ts
@@ -18,7 +18,14 @@ async function main() {
     let h: any = {}; try { h = JSON.parse(readStdin()) || {}; } catch { h = {}; }
     const fail = readAndClearFailure();
     const parts: string[] = [];
-    if (fail) parts.push(`⚠️ SuperBrain: last capture failed — ${fail.trim()} (fixed automatically next checkpoint; set ANTHROPIC_API_KEY if it persists).`);
+    if (fail) {
+      // The ANTHROPIC_API_KEY escape hatch only helps when the distiller's
+      // claude -p spawn failed (auth/quota). Appending it to every failure —
+      // index errors included — misled the 2026-06 incident diagnosis toward
+      // auth/quota, so scope it to distill failures.
+      const apiKeyHint = /distill/i.test(fail) ? "; set ANTHROPIC_API_KEY if it persists" : "";
+      parts.push(`⚠️ SuperBrain: last capture failed — ${fail.trim()} (fixed automatically next checkpoint${apiKeyHint}).`);
+    }
 
     const root = pluginRoot();
     if (!depsPresent(root)) {

--- a/dist/bin/sb-session-start.js
+++ b/dist/bin/sb-session-start.js
@@ -28,8 +28,14 @@ async function main() {
         }
         const fail = readAndClearFailure();
         const parts = [];
-        if (fail)
-            parts.push(`⚠️ SuperBrain: last capture failed — ${fail.trim()} (fixed automatically next checkpoint; set ANTHROPIC_API_KEY if it persists).`);
+        if (fail) {
+            // The ANTHROPIC_API_KEY escape hatch only helps when the distiller's
+            // claude -p spawn failed (auth/quota). Appending it to every failure —
+            // index errors included — misled the 2026-06 incident diagnosis toward
+            // auth/quota, so scope it to distill failures.
+            const apiKeyHint = /distill/i.test(fail) ? "; set ANTHROPIC_API_KEY if it persists" : "";
+            parts.push(`⚠️ SuperBrain: last capture failed — ${fail.trim()} (fixed automatically next checkpoint${apiKeyHint}).`);
+        }
         const root = pluginRoot();
         if (!depsPresent(root)) {
             runBootstrap(root);

--- a/dist/src/sentinel.js
+++ b/dist/src/sentinel.js
@@ -1,10 +1,54 @@
 import fs from "node:fs";
 import path from "node:path";
-import { sentinelPath } from "./paths.js";
+import { sentinelPath, dataDir, pluginRoot } from "./paths.js";
+/**
+ * Failure history cap. Mirrors the windowed-log pattern of the reject queue
+ * (rejectQueue.ts): keep the newest N entries, drop the oldest. 100 lines is
+ * weeks of failures while staying trivially greppable.
+ */
+export const MAX_FAILURE_LOG_LINES = 100;
+export function failureLogPath() {
+    return path.join(dataDir(), "failures.log");
+}
+// During the 2026-06 cross-version incident, multiple immutable plugin caches
+// (different versions) shared one ~/.superbrain — an unattributed failure
+// line could have been written by any of them. Stamp every line with the
+// version of the package that wrote it.
+let cachedVersion = null;
+function pluginVersion() {
+    if (cachedVersion)
+        return cachedVersion;
+    try {
+        const pkg = JSON.parse(fs.readFileSync(path.join(pluginRoot(), "package.json"), "utf8"));
+        cachedVersion = typeof pkg.version === "string" && pkg.version ? pkg.version : "unknown";
+    }
+    catch {
+        cachedVersion = "unknown";
+    }
+    return cachedVersion;
+}
 export function writeFailure(message) {
     const p = sentinelPath();
+    const line = `[${new Date().toISOString()}] [v${pluginVersion()}] ${message}\n`;
     fs.mkdirSync(path.dirname(p), { recursive: true });
-    fs.writeFileSync(p, `[${new Date().toISOString()}] ${message}\n`);
+    fs.writeFileSync(p, line);
+    // Failure HISTORY: last-failure.txt is read-and-clear and each write
+    // overwrites the previous one, which destroyed diagnosability during the
+    // incident. Also append to a bounded failures.log (never read-and-cleared).
+    // Best-effort: history must never break the sentinel write itself.
+    try {
+        const logP = failureLogPath();
+        let lines = [];
+        try {
+            lines = fs.readFileSync(logP, "utf8").split("\n").filter(Boolean);
+        }
+        catch { /* no log yet */ }
+        lines.push(line.trimEnd());
+        if (lines.length > MAX_FAILURE_LOG_LINES)
+            lines = lines.slice(-MAX_FAILURE_LOG_LINES);
+        fs.writeFileSync(logP, lines.join("\n") + "\n");
+    }
+    catch { /* best-effort */ }
 }
 export function readAndClearFailure() {
     const p = sentinelPath();

--- a/src/sentinel.ts
+++ b/src/sentinel.ts
@@ -1,11 +1,53 @@
 import fs from "node:fs";
 import path from "node:path";
-import { sentinelPath } from "./paths.js";
+import { sentinelPath, dataDir, pluginRoot } from "./paths.js";
+
+/**
+ * Failure history cap. Mirrors the windowed-log pattern of the reject queue
+ * (rejectQueue.ts): keep the newest N entries, drop the oldest. 100 lines is
+ * weeks of failures while staying trivially greppable.
+ */
+export const MAX_FAILURE_LOG_LINES = 100;
+
+export function failureLogPath(): string {
+  return path.join(dataDir(), "failures.log");
+}
+
+// During the 2026-06 cross-version incident, multiple immutable plugin caches
+// (different versions) shared one ~/.superbrain — an unattributed failure
+// line could have been written by any of them. Stamp every line with the
+// version of the package that wrote it.
+let cachedVersion: string | null = null;
+function pluginVersion(): string {
+  if (cachedVersion) return cachedVersion;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(pluginRoot(), "package.json"), "utf8"));
+    cachedVersion = typeof pkg.version === "string" && pkg.version ? pkg.version : "unknown";
+  } catch {
+    cachedVersion = "unknown";
+  }
+  return cachedVersion;
+}
 
 export function writeFailure(message: string): void {
   const p = sentinelPath();
+  const line = `[${new Date().toISOString()}] [v${pluginVersion()}] ${message}\n`;
   fs.mkdirSync(path.dirname(p), { recursive: true });
-  fs.writeFileSync(p, `[${new Date().toISOString()}] ${message}\n`);
+  fs.writeFileSync(p, line);
+  // Failure HISTORY: last-failure.txt is read-and-clear and each write
+  // overwrites the previous one, which destroyed diagnosability during the
+  // incident. Also append to a bounded failures.log (never read-and-cleared).
+  // Best-effort: history must never break the sentinel write itself.
+  try {
+    const logP = failureLogPath();
+    let lines: string[] = [];
+    try {
+      lines = fs.readFileSync(logP, "utf8").split("\n").filter(Boolean);
+    } catch { /* no log yet */ }
+    lines.push(line.trimEnd());
+    if (lines.length > MAX_FAILURE_LOG_LINES) lines = lines.slice(-MAX_FAILURE_LOG_LINES);
+    fs.writeFileSync(logP, lines.join("\n") + "\n");
+  } catch { /* best-effort */ }
 }
 export function readAndClearFailure(): string | null {
   const p = sentinelPath();

--- a/tests/sentinelHygiene.test.ts
+++ b/tests/sentinelHygiene.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Failure-sentinel diagnosability (C1 hardening).
+ *
+ * Incident follow-up (2026-06-09): during the cross-version index incident
+ * the sentinel was nearly useless for diagnosis —
+ *  - no clue WHICH plugin version wrote a failure line (multiple plugin
+ *    caches were writing to the same ~/.superbrain),
+ *  - last-failure.txt is read-and-clear, so each failure destroyed the
+ *    previous one (no history),
+ *  - SessionStart appended "set ANTHROPIC_API_KEY" to EVERY failure,
+ *    including index errors, steering diagnosis toward auth/quota.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { writeFailure, MAX_FAILURE_LOG_LINES } from "../src/sentinel";
+import { openIndex } from "../src/searchIndex";
+
+const PKG_VERSION: string = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "../package.json"), "utf8"),
+).version;
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-sentl-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-sentl-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+});
+
+describe("sentinel version stamp", () => {
+  it("every failure line carries the writing plugin's package version", () => {
+    writeFailure("index failed: boom");
+    const line = fs.readFileSync(path.join(TMP_DATA, "last-failure.txt"), "utf8");
+    expect(line).toContain(`[v${PKG_VERSION}]`);
+    expect(line).toContain("index failed: boom");
+  });
+});
+
+describe("failure history (failures.log)", () => {
+  it("appends every failure (sentinel overwrite no longer destroys history)", () => {
+    writeFailure("first failure");
+    writeFailure("second failure");
+    writeFailure("third failure");
+    const log = fs.readFileSync(path.join(TMP_DATA, "failures.log"), "utf8");
+    const lines = log.split("\n").filter(Boolean);
+    expect(lines.length).toBe(3);
+    expect(lines[0]).toContain("first failure");
+    expect(lines[2]).toContain("third failure");
+    for (const l of lines) expect(l).toContain(`[v${PKG_VERSION}]`);
+    // last-failure.txt still holds only the most recent one
+    expect(fs.readFileSync(path.join(TMP_DATA, "last-failure.txt"), "utf8"))
+      .toContain("third failure");
+  });
+
+  it(`stays bounded to the last ${100} lines`, () => {
+    for (let i = 1; i <= MAX_FAILURE_LOG_LINES + 20; i++) writeFailure(`failure number ${i}`);
+    const lines = fs.readFileSync(path.join(TMP_DATA, "failures.log"), "utf8")
+      .split("\n").filter(Boolean);
+    expect(MAX_FAILURE_LOG_LINES).toBe(100);
+    expect(lines.length).toBe(MAX_FAILURE_LOG_LINES);
+    expect(lines[0]).toContain("failure number 21");
+    expect(lines[lines.length - 1]).toContain(`failure number ${MAX_FAILURE_LOG_LINES + 20}`);
+  });
+});
+
+describe("SessionStart hint scoping", () => {
+  function runSessionStart(): string {
+    return execFileSync("npx", ["tsx", "bin/sb-session-start.ts"], {
+      input: JSON.stringify({ session_id: "S", hook_event_name: "SessionStart", source: "startup", cwd: "/p" }),
+      env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+             SUPERBRAIN_FAKE_DISTILLER: "1", SUPERBRAIN_EMBED_STUB: "1" },
+      encoding: "utf8",
+    });
+  }
+
+  it("does NOT append the ANTHROPIC_API_KEY hint to index failures", () => {
+    fs.writeFileSync(path.join(TMP_DATA, "last-failure.txt"),
+      "[t] [v0.7.1] index failed: expected int8, but a float32 vector was provided\n");
+    const out = runSessionStart();
+    expect(out).toMatch(/index failed/);
+    expect(out).not.toContain("ANTHROPIC_API_KEY");
+  });
+
+  it("keeps the ANTHROPIC_API_KEY hint for distill failures", () => {
+    fs.writeFileSync(path.join(TMP_DATA, "last-failure.txt"),
+      "[t] [v0.8.1] distill failed: usage limit reached\n");
+    const out = runSessionStart();
+    expect(out).toMatch(/distill failed/);
+    expect(out).toContain("ANTHROPIC_API_KEY");
+  });
+});
+
+describe("capture-failure surfacing (index error during distill)", () => {
+  it("a broken vec_chunks does not lose the note: .md written, exit 0, sentinel says index failed", () => {
+    // Establish a healthy store, then corrupt vec_chunks to a wrong dim while
+    // leaving embed_meta intact — every vector insert now throws inside
+    // sqlite-vec, exactly like the cross-version incident did.
+    const ix = openIndex();
+    ix.db.exec("DROP TABLE vec_chunks");
+    ix.db.exec("CREATE VIRTUAL TABLE vec_chunks USING vec0(chunk_id integer primary key, embedding int8[8])");
+    ix.close();
+
+    fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+    fs.writeFileSync(path.join(TMP_DATA, "sessions/S.ndjson"),
+      JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n");
+    const stub = path.join(TMP_DATA, "stub.json");
+    fs.writeFileSync(stub, JSON.stringify([
+      { kind: "decision", title: "Adopt sqlite-vec", project: "alpha-proj",
+        body: "## Decision\nAdopt sqlite-vec.\n## Why\n- Fast local KNN.\n## Alternatives considered\n- **Alt A** — rejected because slower.\n## Consequences\n- Better search.",
+        date: "2026-06-09", links: [] },
+    ]));
+    fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+
+    // execFileSync throws on non-zero exit — surviving this call IS the exit-0 assertion.
+    execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+      env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+        SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1" },
+      encoding: "utf8",
+    });
+
+    // The note .md must still have been written despite the index failure.
+    const mdFiles: string[] = [];
+    const walk = (d: string) => {
+      for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+        const p = path.join(d, e.name);
+        if (e.isDirectory()) walk(p);
+        else if (e.name.endsWith(".md")) mdFiles.push(p);
+      }
+    };
+    walk(TMP_VAULT);
+    const decision = mdFiles.find((f) => fs.readFileSync(f, "utf8").includes("Adopt sqlite-vec"));
+    expect(decision).toBeTruthy();
+
+    // And the sentinel attributes the failure to the index, with a version stamp.
+    const sentinel = fs.readFileSync(path.join(TMP_DATA, "last-failure.txt"), "utf8");
+    expect(sentinel).toContain("index failed");
+    expect(sentinel).toContain(`[v${PKG_VERSION}]`);
+  });
+});


### PR DESCRIPTION
## Context — diagnosed production incident (2026-06-09)

During the cross-version index incident (a stale pre-0.8 plugin cache writing v0.7 float vectors into the v0.8 `int8[256]` store — see the companion fence PR), the failure sentinel actively hindered diagnosis:

1. **No attribution** — multiple immutable plugin caches (different versions) share one `~/.superbrain`; an unattributed `last-failure.txt` line could have been written by any of them.
2. **No history** — `last-failure.txt` is overwrite-on-write and read-and-clear, so each failure destroyed the previous one.
3. **Misleading hint** — `sb-session-start` appended *"set ANTHROPIC_API_KEY if it persists"* to EVERY failure, including index errors, steering diagnosis toward auth/quota.

No data was lost in the incident; this PR is purely about diagnosability next time.

## Change

- `src/sentinel.ts` — `writeFailure()` stamps every failure line with the writing plugin's package version (`[vX.Y.Z]`, resolved via `pluginRoot()`, cached per process; `"unknown"` fallback).
- Failure **history**: every failure is also appended to `~/.superbrain/failures.log`, windowed to the last `MAX_FAILURE_LOG_LINES = 100` lines (same windowed-log pattern as the reject-queue cap). The log is never read-and-cleared, so history survives the SessionStart sentinel clear. Best-effort: history can never break the sentinel write.
- `bin/sb-session-start.ts` — the `ANTHROPIC_API_KEY` hint is now scoped to failures matching `/distill/i` (the only failures where the API-key escape hatch helps); all other failures keep the "fixed automatically next checkpoint" copy without it.

## Tests (red → green, `tests/sentinelHygiene.test.ts`)

- Version stamp present in `last-failure.txt` (was red: no stamp existed).
- History appends across multiple failures and stays bounded at exactly 100 lines, oldest rotated out (was red: no `failures.log`).
- Hint scoping: an index-failure message produces SessionStart output **without** `ANTHROPIC_API_KEY`; a distill-failure message keeps it (index case was red).
- Capture-failure surfacing E2E (this seam had no coverage): `vec_chunks` recreated as `int8[8]` to reproduce the incident's insert failure, then the real distill entrypoint (`bin/sb-distill.ts`) run with `SUPERBRAIN_DISTILL_STUB` — asserts the note `.md` IS written, exit code 0, and the sentinel contains `index failed` with the version stamp.

## Status

- Full suite: **120 files / 796 tests passed** (baseline at main: 119/790).
- `dist/` rebuilt and committed; `git diff --exit-code dist` clean after build.
- **Banked for the June 12 reassessment — DRAFT, do not merge, no release cut.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
