### PR TITLE
Fleet-memory remediation: attribution, scoped recall, concurrency fixes, archive ranking, GC

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ docs/superpowers/
 docs/assessments/
 docs/plans/
 docs/specs/
+
+# Alfred overseer board â private working machinery, never shipped
+/board/
+/bin/task
+/.claude/agents/

--- a/bin/sb-checkpoint.ts
+++ b/bin/sb-checkpoint.ts
@@ -41,7 +41,9 @@ function main() {
         // It runs claude -p itself (getItems), routes/writes/logs/advances cursor/releases lock.
         const rawCwd = h.cwd || process.cwd();
         const safeCwd = (rawCwd && fs.existsSync(rawCwd)) ? rawCwd : process.cwd();
-        const spec = buildDistillCommand({ sessionId: sid, cwd: safeCwd });
+        let lockToken: string | undefined;
+        try { lockToken = fs.readFileSync(path.join(dataDir(), "locks", "distill.lock", "token"), "utf8"); } catch { /* best-effort */ }
+        const spec = buildDistillCommand({ sessionId: sid, cwd: safeCwd, lockToken });
         const child = spawn(spec.cmd, spec.args, spec.options);
         child.on("error", (e) => { writeFailure(`distiller spawn failed: ${e.message}`); releaseLock("distill"); });
         child.unref(); // detached; sb-distill releases the lock when done

--- a/bin/sb-checkpoint.ts
+++ b/bin/sb-checkpoint.ts
@@ -30,7 +30,13 @@ function main() {
       }
     } catch { /* transcript copy best-effort */ }
 
-    if (!acquireLock("distill")) process.exit(0); // another distill in flight; cursor covers us next time
+    if (!acquireLock("distill")) {
+      try {
+        fs.mkdirSync(path.join(dataDir(), "sessions"), { recursive: true });
+        fs.writeFileSync(path.join(dataDir(), "sessions", `${sid}.needs-distill`), "1");
+      } catch { /* best-effort: flag write must never crash the hook */ }
+      process.exit(0);
+    }
 
     try {
       if (process.env.SUPERBRAIN_FAKE_DISTILLER === "1") {

--- a/bin/sb-distill.ts
+++ b/bin/sb-distill.ts
@@ -9,7 +9,7 @@ import { pluginRoot } from "../src/paths.js";
 async function main() {
   if (!depsPresent(pluginRoot())) {
     try { writeFailure("distill skipped: dependencies not yet installed (bootstrap pending)"); } catch { /* noop */ }
-    try { releaseLock("distill"); } catch { /* noop */ }
+    try { releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN); } catch { /* noop */ }
     process.exit(0);
   }
   try {
@@ -17,7 +17,7 @@ async function main() {
     await run.runDistill();
   } catch (e: any) {
     try { writeFailure(`distill failed: ${e?.message || e}`); } catch { /* noop */ }
-    try { releaseLock("distill"); } catch { /* noop */ }
+    try { releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN); } catch { /* noop */ }
   }
   process.exit(0);
 }

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -16,9 +16,17 @@ async function main() {
   const server = new McpServer({ name: "superbrain", version: "0.8.1" });
   server.tool(
     "superbrain_search",
-    "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).",
-    { query: z.string(), k: z.number().optional() },
-    async ({ query, k }: { query: string; k?: number }) => (await handleSearch({ query, k })) as any,
+    "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas). Optional scope: project (slug), type (note type e.g. decision/capture/lesson), since (ISO date, only newer notes), role (agent_role).",
+    {
+      query: z.string(),
+      k: z.number().optional(),
+      project: z.string().optional(),
+      type: z.string().optional(),
+      since: z.string().optional(),
+      role: z.string().optional(),
+    },
+    async ({ query, k, project, type, since, role }: { query: string; k?: number; project?: string; type?: string; since?: string; role?: string }) =>
+      (await handleSearch({ query, k, project, type, since, role })) as any,
   );
   const transport = new StdioServerTransport();
   server.connect(transport).catch(() => process.exit(1));

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -13,6 +13,7 @@ async function main() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
+  const { handleChildren } = await import("../src/mcpChildren.js");
   const server = new McpServer({ name: "superbrain", version: "0.8.1" });
   server.tool(
     "superbrain_search",
@@ -27,6 +28,13 @@ async function main() {
     },
     async ({ query, k, project, type, since, role }: { query: string; k?: number; project?: string; type?: string; since?: string; role?: string }) =>
       (await handleSearch({ query, k, project, type, since, role })) as any,
+  );
+  server.tool(
+    "superbrain_children",
+    "List the daily-state entries (open threads, projects) of the child sessions a given parent session dispatched on a date (defaults to today).",
+    { parentSessionId: z.string(), date: z.string().optional() },
+    async ({ parentSessionId, date }: { parentSessionId: string; date?: string }) =>
+      (await handleChildren({ parentSessionId, date })) as any,
   );
   const transport = new StdioServerTransport();
   server.connect(transport).catch(() => process.exit(1));

--- a/bin/sb-reconcile.ts
+++ b/bin/sb-reconcile.ts
@@ -30,6 +30,12 @@ async function main() {
     (e: any) => writeFailure(`auto-upgrade failed: ${e?.message || e}`)
   );
   await reconcile().catch((e: any) => writeFailure(`reconcile failed: ${e?.message || e}`));
+  try {
+    const { runSessionGcOncePerDay } = await import("../src/sessionGcRun.js");
+    runSessionGcOncePerDay(dataDir());
+  } catch (e: any) {
+    writeFailure(`session gc failed: ${e?.message || e}`);
+  }
   process.exit(0);
 }
 

--- a/dist/bin/sb-checkpoint.js
+++ b/dist/bin/sb-checkpoint.js
@@ -39,8 +39,14 @@ function main() {
             }
         }
         catch { /* transcript copy best-effort */ }
-        if (!acquireLock("distill"))
-            process.exit(0); // another distill in flight; cursor covers us next time
+        if (!acquireLock("distill")) {
+            try {
+                fs.mkdirSync(path.join(dataDir(), "sessions"), { recursive: true });
+                fs.writeFileSync(path.join(dataDir(), "sessions", `${sid}.needs-distill`), "1");
+            }
+            catch { /* best-effort: flag write must never crash the hook */ }
+            process.exit(0);
+        }
         try {
             if (process.env.SUPERBRAIN_FAKE_DISTILLER === "1") {
                 fs.writeFileSync(path.join(dataDir(), "distill-invoked"), String(event));
@@ -51,7 +57,12 @@ function main() {
                 // It runs claude -p itself (getItems), routes/writes/logs/advances cursor/releases lock.
                 const rawCwd = h.cwd || process.cwd();
                 const safeCwd = (rawCwd && fs.existsSync(rawCwd)) ? rawCwd : process.cwd();
-                const spec = buildDistillCommand({ sessionId: sid, cwd: safeCwd });
+                let lockToken;
+                try {
+                    lockToken = fs.readFileSync(path.join(dataDir(), "locks", "distill.lock", "token"), "utf8");
+                }
+                catch { /* best-effort */ }
+                const spec = buildDistillCommand({ sessionId: sid, cwd: safeCwd, lockToken });
                 const child = spawn(spec.cmd, spec.args, spec.options);
                 child.on("error", (e) => { writeFailure(`distiller spawn failed: ${e.message}`); releaseLock("distill"); });
                 child.unref(); // detached; sb-distill releases the lock when done

--- a/dist/bin/sb-distill.js
+++ b/dist/bin/sb-distill.js
@@ -12,7 +12,7 @@ async function main() {
         }
         catch { /* noop */ }
         try {
-            releaseLock("distill");
+            releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN);
         }
         catch { /* noop */ }
         process.exit(0);
@@ -27,7 +27,7 @@ async function main() {
         }
         catch { /* noop */ }
         try {
-            releaseLock("distill");
+            releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN);
         }
         catch { /* noop */ }
     }

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -13,7 +13,14 @@ async function main() {
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
     const server = new McpServer({ name: "superbrain", version: "0.8.1" });
-    server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas).", { query: z.string(), k: z.number().optional() }, async ({ query, k }) => (await handleSearch({ query, k })));
+    server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas). Optional scope: project (slug), type (note type e.g. decision/capture/lesson), since (ISO date, only newer notes), role (agent_role).", {
+        query: z.string(),
+        k: z.number().optional(),
+        project: z.string().optional(),
+        type: z.string().optional(),
+        since: z.string().optional(),
+        role: z.string().optional(),
+    }, async ({ query, k, project, type, since, role }) => (await handleSearch({ query, k, project, type, since, role })));
     const transport = new StdioServerTransport();
     server.connect(transport).catch(() => process.exit(1));
 }

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -12,6 +12,7 @@ async function main() {
     const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
+    const { handleChildren } = await import("../src/mcpChildren.js");
     const server = new McpServer({ name: "superbrain", version: "0.8.1" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas). Optional scope: project (slug), type (note type e.g. decision/capture/lesson), since (ISO date, only newer notes), role (agent_role).", {
         query: z.string(),
@@ -21,6 +22,7 @@ async function main() {
         since: z.string().optional(),
         role: z.string().optional(),
     }, async ({ query, k, project, type, since, role }) => (await handleSearch({ query, k, project, type, since, role })));
+    server.tool("superbrain_children", "List the daily-state entries (open threads, projects) of the child sessions a given parent session dispatched on a date (defaults to today).", { parentSessionId: z.string(), date: z.string().optional() }, async ({ parentSessionId, date }) => (await handleChildren({ parentSessionId, date })));
     const transport = new StdioServerTransport();
     server.connect(transport).catch(() => process.exit(1));
 }

--- a/dist/bin/sb-reconcile.js
+++ b/dist/bin/sb-reconcile.js
@@ -25,6 +25,13 @@ async function main() {
     const { dataDir } = await import("../src/paths.js");
     await runCheapUpgradeSteps(dataDir(), version).catch((e) => writeFailure(`auto-upgrade failed: ${e?.message || e}`));
     await reconcile().catch((e) => writeFailure(`reconcile failed: ${e?.message || e}`));
+    try {
+        const { runSessionGcOncePerDay } = await import("../src/sessionGcRun.js");
+        runSessionGcOncePerDay(dataDir());
+    }
+    catch (e) {
+        writeFailure(`session gc failed: ${e?.message || e}`);
+    }
     process.exit(0);
 }
 main();

--- a/dist/src/atomicWrite.js
+++ b/dist/src/atomicWrite.js
@@ -27,3 +27,20 @@ export function readWithChecksum(file) {
         return null;
     }
 }
+export function casWrite(file, produce, opts = {}) {
+    const maxAttempts = opts.maxAttempts ?? 5;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const before = readWithChecksum(file);
+        const next = produce(before ? before.content : null);
+        const after = readWithChecksum(file);
+        const beforeSum = before ? before.checksum : null;
+        const afterSum = after ? after.checksum : null;
+        if (beforeSum === afterSum) {
+            atomicWrite(file, next);
+            return { ok: true, attempts: attempt };
+        }
+    }
+    const last = readWithChecksum(file);
+    atomicWrite(file, produce(last ? last.content : null));
+    return { ok: true, attempts: maxAttempts };
+}

--- a/dist/src/attribution.js
+++ b/dist/src/attribution.js
@@ -1,0 +1,10 @@
+export function attributionFromEnv() {
+    const out = {};
+    const sid = process.env.SUPERBRAIN_SESSION_ID;
+    const role = process.env.SUPERBRAIN_AGENT_ROLE;
+    if (sid)
+        out.session_id = sid;
+    if (role)
+        out.agent_role = role;
+    return out;
+}

--- a/dist/src/dailyState.js
+++ b/dist/src/dailyState.js
@@ -19,3 +19,12 @@ export function upsertDay(date, sessionId, entry) {
     cur[sessionId] = entry;
     fs.writeFileSync(f, JSON.stringify(cur));
 }
+export function childrenOf(date, parentId) {
+    if (!parentId)
+        return [];
+    const day = readDay(date);
+    return Object.keys(day)
+        .filter((sid) => day[sid].parentSessionId === parentId)
+        .sort()
+        .map((sid) => ({ sessionId: sid, entry: day[sid] }));
+}

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -32,6 +32,7 @@ import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
 import { classifyPath, basenameSlug } from "./projectDetect.js";
 import { slug, asText } from "./router.js";
+import { buildProjectIndex } from "./projectIndex.js";
 export function resolveSessionProject(events) {
     const countBySlug = new Map();
     for (const e of events) {
@@ -248,6 +249,7 @@ export async function distillFromEvents(sid, events) {
     const items = env.items;
     const routedByDate = {};
     let notesWritten = 0;
+    const touchedProjects = new Set();
     for (const it of items) {
         try {
             if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.all.length === 1 && sessionProj.dominant) {
@@ -293,6 +295,11 @@ export async function distillFromEvents(sid, events) {
                     }
                     (routedByDate[it.date] ||= []).push(r.relPath);
                     notesWritten++;
+                    if (it.project)
+                        touchedProjects.add(it.project);
+                    const projMatch = r.relPath.match(/^projects\/([^/_][^/]*)\.md$/);
+                    if (projMatch)
+                        touchedProjects.add(projMatch[1]);
                     if (it.kind === "preference") {
                         try {
                             emitPreferencesCore(it.body ?? "");
@@ -399,6 +406,11 @@ export async function distillFromEvents(sid, events) {
                 }
                 (routedByDate[it.date] ||= []).push(writeRelPath);
                 notesWritten++;
+                if (it.project)
+                    touchedProjects.add(it.project);
+                const projMatch2 = writeRelPath.match(/^projects\/([^/_][^/]*)\.md$/);
+                if (projMatch2)
+                    touchedProjects.add(projMatch2[1]);
             }
         }
         catch (e) {
@@ -410,6 +422,22 @@ export async function distillFromEvents(sid, events) {
                 excerpt: asText(it?.body).slice(0, 500),
             });
             writeFailure(`item dropped: ${e?.message || e}`);
+        }
+    }
+    for (const projSlug of touchedProjects) {
+        try {
+            const { relPath: idxRelPath, changed } = buildProjectIndex(projSlug);
+            if (changed) {
+                try {
+                    await indexNote(idxRelPath);
+                }
+                catch (e) {
+                    writeFailure(`index failed: ${e?.message || e}`);
+                }
+            }
+        }
+        catch (e) {
+            writeFailure(`project index build failed for '${projSlug}': ${e?.message || e}`);
         }
     }
     try {

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -226,14 +226,14 @@ function logDistillSkip(sid, reason) {
 export function readKnownProjectSlugs(vault) {
     const override = process.env.SUPERBRAIN_KNOWN_SLUGS_OVERRIDE;
     if (override !== undefined) {
-        return new Set(override.split(",").map(s => s.trim().toLowerCase()).filter(Boolean));
+        return new Set(override.split(",").map(s => s.trim()).filter(Boolean).map(s => slug(s)));
     }
     const projectsDir = path.join(vault, "projects");
     const slugs = new Set();
     try {
         for (const entry of fs.readdirSync(projectsDir)) {
             if (entry.endsWith(".md") && !entry.startsWith("_")) {
-                slugs.add(entry.slice(0, -3).toLowerCase());
+                slugs.add(slug(entry.slice(0, -3)));
             }
         }
     }

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -299,7 +299,7 @@ export async function distillFromEvents(sid, events) {
                         touchedProjects.add(it.project);
                     const projMatch = r.relPath.match(/^projects\/([^/_][^/]*)\.md$/);
                     if (projMatch)
-                        touchedProjects.add(projMatch[1]);
+                        touchedProjects.add(slug(projMatch[1]));
                     if (it.kind === "preference") {
                         try {
                             emitPreferencesCore(it.body ?? "");
@@ -410,7 +410,7 @@ export async function distillFromEvents(sid, events) {
                     touchedProjects.add(it.project);
                 const projMatch2 = writeRelPath.match(/^projects\/([^/_][^/]*)\.md$/);
                 if (projMatch2)
-                    touchedProjects.add(projMatch2[1]);
+                    touchedProjects.add(slug(projMatch2[1]));
             }
         }
         catch (e) {

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -26,6 +26,7 @@ import { classify } from "./classification.js";
 import { recordRejection } from "./rejectQueue.js";
 import { serializeNote } from "./frontmatter.js";
 import { attributionFromEnv } from "./attribution.js";
+import { parentSessionId, attributionFields } from "./sessionAttribution.js";
 import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
@@ -242,6 +243,7 @@ export async function distillFromEvents(sid, events) {
     const attribution = attributionFromEnv();
     const env = getEnvelope(JSON.stringify(events));
     const sessionProj = resolveSessionProject(events);
+    const parent = parentSessionId();
     const PROJECT_SCOPED_KINDS = new Set(["project_fact", "gotcha", "decision", "capture"]);
     const items = env.items;
     const routedByDate = {};
@@ -281,7 +283,7 @@ export async function distillFromEvents(sid, events) {
             }
             const r = route(it);
             if (r.mode !== "create") {
-                const res0 = writeNote(r.relPath, { frontmatter: { ...r.frontmatter, ...attribution }, body: r.body, mode: r.mode });
+                const res0 = writeNote(r.relPath, { frontmatter: { ...r.frontmatter, ...attribution, ...attributionFields() }, body: r.body, mode: r.mode });
                 if (res0.ok && res0.reason !== "duplicate-skipped") {
                     try {
                         await indexNote(r.relPath);
@@ -387,7 +389,7 @@ export async function distillFromEvents(sid, events) {
                     writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
                 }
             }
-            const res = writeNote(writeRelPath, { frontmatter: { ...writeFrontmatter, ...attribution }, body: writeBody, mode: r.mode });
+            const res = writeNote(writeRelPath, { frontmatter: { ...writeFrontmatter, ...attribution, ...attributionFields() }, body: writeBody, mode: r.mode });
             if (res.ok && res.reason !== "duplicate-skipped") {
                 try {
                     await indexNote(writeRelPath);
@@ -421,6 +423,7 @@ export async function distillFromEvents(sid, events) {
                 openThreads: env.openThreads,
                 ...(sessionProj.dominant !== undefined ? { project: sessionProj.dominant } : {}),
                 ...(sessionProj.all.length > 1 ? { projects: sessionProj.all } : {}),
+                ...(parent !== undefined ? { parentSessionId: parent } : {}),
             });
             const dn = buildDailyNote(d);
             writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -21,9 +21,11 @@ import { filterToUniversal } from "./preferenceClassify.js";
 import { resolveLinks } from "./wikilink.js";
 import { gcTranscript } from "./transcriptStore.js";
 import { pruneSessionFiles } from "./sessionGc.js";
+import { sweepPendingDistills, clearFlag } from "./distillSweep.js";
 import { classify } from "./classification.js";
 import { recordRejection } from "./rejectQueue.js";
 import { serializeNote } from "./frontmatter.js";
+import { attributionFromEnv } from "./attribution.js";
 import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
@@ -237,6 +239,7 @@ export function readKnownProjectSlugs(vault) {
     return slugs;
 }
 export async function distillFromEvents(sid, events) {
+    const attribution = attributionFromEnv();
     const env = getEnvelope(JSON.stringify(events));
     const sessionProj = resolveSessionProject(events);
     const PROJECT_SCOPED_KINDS = new Set(["project_fact", "gotcha", "decision", "capture"]);
@@ -278,7 +281,7 @@ export async function distillFromEvents(sid, events) {
             }
             const r = route(it);
             if (r.mode !== "create") {
-                const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
+                const res0 = writeNote(r.relPath, { frontmatter: { ...r.frontmatter, ...attribution }, body: r.body, mode: r.mode });
                 if (res0.ok && res0.reason !== "duplicate-skipped") {
                     try {
                         await indexNote(r.relPath);
@@ -384,7 +387,7 @@ export async function distillFromEvents(sid, events) {
                     writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
                 }
             }
-            const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
+            const res = writeNote(writeRelPath, { frontmatter: { ...writeFrontmatter, ...attribution }, body: writeBody, mode: r.mode });
             if (res.ok && res.reason !== "duplicate-skipped") {
                 try {
                     await indexNote(writeRelPath);
@@ -434,6 +437,24 @@ export async function distillFromEvents(sid, events) {
     }
     return { notesWritten };
 }
+async function distillSession(sid) {
+    const from = readCursor(sid);
+    const { events, newOffset } = readDelta(sid, from);
+    if (events.length === 0) {
+        writeCursor(sid, newOffset);
+        return;
+    }
+    if (!process.env.SUPERBRAIN_DISTILL_STUB) {
+        const sk = shouldSkipDistill(events);
+        if (sk.skip) {
+            logDistillSkip(sid, sk.reason);
+            writeCursor(sid, newOffset);
+            return;
+        }
+    }
+    await distillFromEvents(sid, events);
+    writeCursor(sid, newOffset);
+}
 export async function runDistill() {
     const sid = process.env.SUPERBRAIN_SESSION_ID
         || (() => { try {
@@ -443,34 +464,18 @@ export async function runDistill() {
             return "unknown";
         } })();
     try {
-        const from = readCursor(sid);
-        const { events, newOffset } = readDelta(sid, from);
-        if (events.length === 0) {
-            releaseLock("distill");
-            process.exit(0);
-        }
-        // Pre-LLM skip check. Test stubs (SUPERBRAIN_DISTILL_STUB) bypass this so
-        // fixtures that supply a small canned envelope still go through the full
-        // routing path.
-        if (!process.env.SUPERBRAIN_DISTILL_STUB) {
-            const sk = shouldSkipDistill(events);
-            if (sk.skip) {
-                logDistillSkip(sid, sk.reason);
-                writeCursor(sid, newOffset);
-                releaseLock("distill");
-                return;
-            }
-        }
-        await distillFromEvents(sid, events);
-        writeCursor(sid, newOffset);
-        // GC the transcript snapshot now that distillation succeeded. Best-effort:
-        // a missing snapshot is fine (checkpoint may not have run), and a deletion
-        // failure must never abort an otherwise-successful distill.
+        await distillSession(sid);
+        clearFlag(sid);
         try {
             gcTranscript(path.join(dataDir(), "transcripts"), sid);
         }
         catch { /* best-effort */ }
-        // GC old session files. Best-effort: never abort an otherwise-successful distill.
+        try {
+            await sweepPendingDistills(sid, distillSession);
+        }
+        catch (e) {
+            writeFailure(`sweep failed: ${e?.message || e}`);
+        }
         try {
             pruneSessionFiles(dataDir());
         }
@@ -480,6 +485,6 @@ export async function runDistill() {
         writeFailure(`distill failed: ${e?.message || e}`);
     }
     finally {
-        releaseLock("distill");
+        releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN);
     }
 }

--- a/dist/src/distillSweep.js
+++ b/dist/src/distillSweep.js
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+import { sessionsDir } from "./paths.js";
+import { writeFailure } from "./sentinel.js";
+const FLAG_EXT = ".needs-distill";
+export function flagPath(sid) {
+    return path.join(sessionsDir(), `${sid}${FLAG_EXT}`);
+}
+export function listFlaggedSessions() {
+    try {
+        return fs.readdirSync(sessionsDir())
+            .filter((f) => f.endsWith(FLAG_EXT))
+            .map((f) => f.slice(0, f.length - FLAG_EXT.length));
+    }
+    catch {
+        return [];
+    }
+}
+export function clearFlag(sid) {
+    try {
+        fs.rmSync(flagPath(sid), { force: true });
+    }
+    catch { /* best-effort */ }
+}
+export async function sweepPendingDistills(excludeSid, distillOne) {
+    for (const sid of listFlaggedSessions()) {
+        if (sid === excludeSid) {
+            clearFlag(sid);
+            continue;
+        }
+        try {
+            await distillOne(sid);
+            clearFlag(sid);
+        }
+        catch (e) {
+            writeFailure(`sweep distill failed for ${sid}: ${e?.message || e}`);
+        }
+    }
+}

--- a/dist/src/distillerEngine.js
+++ b/dist/src/distillerEngine.js
@@ -7,17 +7,14 @@ export function distillScriptPath() {
     return fileURLToPath(new URL("../bin/sb-distill.js", import.meta.url));
 }
 export function buildDistillCommand(opts) {
-    // Spawn the in-process writer (bin/sb-distill.ts). It performs the real
-    // `claude -p` LLM call itself (getItems), then routes/writes/advances
-    // cursor/releases the lock. ANTHROPIC_API_KEY (if set) is inherited so the
-    // claude CLI uses the API path automatically — escape hatch, no command change.
     const env = {
         ...process.env,
         SUPERBRAIN_CHILD: "1",
         SUPERBRAIN_SESSION_ID: opts.sessionId,
+        ...(opts.lockToken ? { SUPERBRAIN_LOCK_TOKEN: opts.lockToken } : {}),
     };
     return {
-        cmd: process.execPath, // node
+        cmd: process.execPath,
         args: [distillScriptPath()],
         options: { cwd: opts.cwd, env, detached: true, stdio: "ignore" },
     };

--- a/dist/src/indexer.js
+++ b/dist/src/indexer.js
@@ -8,6 +8,7 @@ import { openIndex } from "./searchIndex.js";
 import { parseNote } from "./frontmatter.js";
 import { deriveEdges, deleteEdgesFrom, upsertEdges } from "./edges.js";
 import { slug as routerSlug } from "./router.js";
+import { buildProjectIndex, enumerateProjectSlugs } from "./projectIndex.js";
 const EXCLUDED = new Set([".trash", ".obsidian", ".git", "node_modules"]);
 function walk(dir, root, acc) {
     for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -186,6 +187,21 @@ export async function reconcile() {
                 ix.deleteNote(rel);
                 res.deleted++;
             }
+        const slugs = enumerateProjectSlugs(root);
+        for (const projSlug of slugs) {
+            try {
+                const { relPath: idxRel, changed } = buildProjectIndex(projSlug);
+                if (changed) {
+                    const wasPresent = presentSet.has(idxRel);
+                    await indexInto(ix, idxRel);
+                    if (wasPresent)
+                        res.updated++;
+                    else
+                        res.added++;
+                }
+            }
+            catch { /* swallow per-project errors */ }
+        }
         return res;
     }
     finally {

--- a/dist/src/indexer.js
+++ b/dist/src/indexer.js
@@ -40,7 +40,7 @@ async function indexInto(ix, relPath) {
     const created = typeof fm.created === "string" ? fm.created
         : fm.created instanceof Date ? fm.created.toISOString()
             : undefined;
-    ix.upsertNote(relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs, fm.project, created);
+    ix.upsertNote(relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs, fm.project, created, typeof fm.type === "string" ? fm.type : undefined, typeof fm.agent_role === "string" ? fm.agent_role : undefined);
     upsertEdges(ix.db, deriveEdges(relPath, fm));
 }
 export async function indexNote(relPath) {

--- a/dist/src/indexer.js
+++ b/dist/src/indexer.js
@@ -41,7 +41,7 @@ async function indexInto(ix, relPath) {
     const created = typeof fm.created === "string" ? fm.created
         : fm.created instanceof Date ? fm.created.toISOString()
             : undefined;
-    ix.upsertNote(relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs, fm.project, created, typeof fm.type === "string" ? fm.type : undefined, typeof fm.agent_role === "string" ? fm.agent_role : undefined);
+    ix.upsertNote(relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs, fm.project, created, typeof fm.type === "string" ? fm.type : undefined, typeof fm.agent_role === "string" ? fm.agent_role : undefined, fm.generated === true);
     upsertEdges(ix.db, deriveEdges(relPath, fm));
 }
 export async function indexNote(relPath) {

--- a/dist/src/lockfile.js
+++ b/dist/src/lockfile.js
@@ -1,12 +1,25 @@
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { lockDir } from "./paths.js";
+const owned = new Map();
+function readToken(dir) {
+    try {
+        return fs.readFileSync(path.join(dir, "token"), "utf8");
+    }
+    catch {
+        return null;
+    }
+}
 export function acquireLock(name, opts = {}) {
     const dir = lockDir(name);
     fs.mkdirSync(path.dirname(dir), { recursive: true });
+    const token = process.env.SUPERBRAIN_LOCK_TOKEN || crypto.randomUUID();
     try {
         fs.mkdirSync(dir);
         fs.writeFileSync(path.join(dir, "pid"), String(process.pid));
+        fs.writeFileSync(path.join(dir, "token"), token);
+        owned.set(name, token);
         return true;
     }
     catch {
@@ -14,8 +27,11 @@ export function acquireLock(name, opts = {}) {
         try {
             const age = Date.now() - fs.statSync(dir).mtimeMs;
             if (age > maxAgeMs) {
-                releaseLock(name);
+                forceRelease(name);
                 fs.mkdirSync(dir);
+                fs.writeFileSync(path.join(dir, "pid"), String(process.pid));
+                fs.writeFileSync(path.join(dir, "token"), token);
+                owned.set(name, token);
                 return true;
             }
         }
@@ -23,6 +39,20 @@ export function acquireLock(name, opts = {}) {
         return false;
     }
 }
-export function releaseLock(name) {
+export function releaseLock(name, token) {
+    const dir = lockDir(name);
+    const onDisk = readToken(dir);
+    if (onDisk === null) {
+        forceRelease(name);
+        return;
+    }
+    const mine = owned.get(name);
+    const presented = token ?? mine;
+    if (presented !== undefined && presented === onDisk) {
+        forceRelease(name);
+    }
+}
+function forceRelease(name) {
     fs.rmSync(lockDir(name), { recursive: true, force: true });
+    owned.delete(name);
 }

--- a/dist/src/mcpChildren.js
+++ b/dist/src/mcpChildren.js
@@ -1,0 +1,19 @@
+import { childrenOf } from "./dailyState.js";
+export async function handleChildren(args) {
+    const parent = (args?.parentSessionId || "").trim();
+    if (!parent)
+        return { content: [{ type: "text", text: "No parent session id provided." }] };
+    const date = args?.date || new Date().toISOString().slice(0, 10);
+    const kids = childrenOf(date, parent);
+    if (!kids.length) {
+        return { content: [{ type: "text", text: `No child sessions for parent "${parent}" on ${date}.` }] };
+    }
+    const lines = kids.map(({ sessionId, entry }) => {
+        const projects = entry.projects?.length
+            ? entry.projects.join(", ")
+            : (entry.project || "—");
+        const threads = entry.openThreads.length ? entry.openThreads.join("; ") : "none";
+        return `- ${sessionId} [${projects}] — open: ${threads}`;
+    }).join("\n");
+    return { content: [{ type: "text", text: `Children of "${parent}" on ${date}:\n${lines}` }] };
+}

--- a/dist/src/mcpSearch.js
+++ b/dist/src/mcpSearch.js
@@ -4,9 +4,15 @@ export async function handleSearch(args) {
     const k = Math.min(Math.max(args?.k ?? 8, 1), 20);
     if (!q)
         return { content: [{ type: "text", text: "No query provided." }] };
+    const opts = {
+        projectSlug: args.project?.trim() || undefined,
+        type: args.type?.trim() || undefined,
+        since: args.since?.trim() || undefined,
+        role: args.role?.trim() || undefined,
+    };
     let hits;
     try {
-        hits = await hybridRecall(q, k);
+        hits = await hybridRecall(q, k, opts);
     }
     catch {
         hits = [];

--- a/dist/src/projectIndex.js
+++ b/dist/src/projectIndex.js
@@ -4,7 +4,6 @@ import { vaultPath } from "./paths.js";
 import { parseNote, serializeNote } from "./frontmatter.js";
 import { atomicWrite } from "./atomicWrite.js";
 const WALK_EXCLUDE = new Set([".trash", ".obsidian", ".git", "node_modules"]);
-const ENUMERATE_EXCLUDE = new Set(["maps", "daily"]);
 const TYPE_ORDER = ["project", "decision", "lesson", "gotcha", "person", "capture"];
 const TYPE_PLURAL = {
     project: "Projects",
@@ -20,21 +19,9 @@ function walkVault(dir, root, acc) {
             if (WALK_EXCLUDE.has(e.name))
                 continue;
             const rel = path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/");
-            if (rel === "maps" || rel === "daily" || rel.startsWith("projects/_archive"))
+            if (rel === "maps" || rel === "daily" || rel === "projects/_archive" || rel.startsWith("projects/_archive/"))
                 continue;
-            walk(path.join(dir, e.name), root, acc);
-        }
-        else if (e.name.endsWith(".md")) {
-            acc.push(path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/"));
-        }
-    }
-}
-function walk(dir, root, acc) {
-    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
-        if (e.isDirectory()) {
-            if (WALK_EXCLUDE.has(e.name))
-                continue;
-            walk(path.join(dir, e.name), root, acc);
+            walkVault(path.join(dir, e.name), root, acc);
         }
         else if (e.name.endsWith(".md")) {
             acc.push(path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/"));

--- a/dist/src/projectIndex.js
+++ b/dist/src/projectIndex.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { vaultPath } from "./paths.js";
 import { parseNote, serializeNote } from "./frontmatter.js";
 import { atomicWrite } from "./atomicWrite.js";
+import { slug } from "./router.js";
 const WALK_EXCLUDE = new Set([".trash", ".obsidian", ".git", "node_modules"]);
 const TYPE_ORDER = ["project", "decision", "lesson", "gotcha", "person", "capture"];
 const TYPE_PLURAL = {
@@ -30,11 +31,11 @@ function walkVault(dir, root, acc) {
 }
 export function projectOfNote(relPath, fm) {
     if (fm.project && typeof fm.project === "string" && fm.project.trim()) {
-        return fm.project.trim().toLowerCase();
+        return slug(fm.project);
     }
     const parts = relPath.split("/");
     if (parts[0] === "projects" && parts.length === 2 && !parts[1].startsWith("_")) {
-        return parts[1].replace(/\.md$/, "").toLowerCase();
+        return slug(parts[1].replace(/\.md$/, ""));
     }
     return null;
 }
@@ -107,7 +108,7 @@ export function enumerateProjectSlugs(vaultRoot) {
     try {
         for (const entry of fs.readdirSync(projectsDir)) {
             if (entry.endsWith(".md") && !entry.startsWith("_")) {
-                slugs.add(entry.slice(0, -3).toLowerCase());
+                slugs.add(slug(entry.slice(0, -3)));
             }
         }
     }

--- a/dist/src/projectIndex.js
+++ b/dist/src/projectIndex.js
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import path from "node:path";
+import { vaultPath } from "./paths.js";
+import { parseNote, serializeNote } from "./frontmatter.js";
+import { atomicWrite } from "./atomicWrite.js";
+const WALK_EXCLUDE = new Set([".trash", ".obsidian", ".git", "node_modules"]);
+const ENUMERATE_EXCLUDE = new Set(["maps", "daily"]);
+const TYPE_ORDER = ["project", "decision", "lesson", "gotcha", "person", "capture"];
+const TYPE_PLURAL = {
+    project: "Projects",
+    decision: "Decisions",
+    lesson: "Lessons",
+    gotcha: "Gotchas",
+    person: "People",
+    capture: "Captures",
+};
+function walkVault(dir, root, acc) {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (e.isDirectory()) {
+            if (WALK_EXCLUDE.has(e.name))
+                continue;
+            const rel = path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/");
+            if (rel === "maps" || rel === "daily" || rel.startsWith("projects/_archive"))
+                continue;
+            walk(path.join(dir, e.name), root, acc);
+        }
+        else if (e.name.endsWith(".md")) {
+            acc.push(path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/"));
+        }
+    }
+}
+function walk(dir, root, acc) {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (e.isDirectory()) {
+            if (WALK_EXCLUDE.has(e.name))
+                continue;
+            walk(path.join(dir, e.name), root, acc);
+        }
+        else if (e.name.endsWith(".md")) {
+            acc.push(path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/"));
+        }
+    }
+}
+export function projectOfNote(relPath, fm) {
+    if (fm.project && typeof fm.project === "string" && fm.project.trim()) {
+        return fm.project.trim().toLowerCase();
+    }
+    const parts = relPath.split("/");
+    if (parts[0] === "projects" && parts.length === 2 && !parts[1].startsWith("_")) {
+        return parts[1].replace(/\.md$/, "").toLowerCase();
+    }
+    return null;
+}
+function extractHook(content, fm, relPath) {
+    const lines = content.split("\n");
+    for (const line of lines) {
+        const m = line.match(/^#{1,2}\s+(.+)/);
+        if (m)
+            return m[1].trim();
+    }
+    if (fm.title && typeof fm.title === "string")
+        return fm.title.trim();
+    return path.basename(relPath, ".md");
+}
+export function collectProjectNotes(vaultRoot, slug) {
+    const allPaths = [];
+    walkVault(vaultRoot, vaultRoot, allPaths);
+    const indexRelPath = `maps/${slug}-index.md`;
+    const results = [];
+    for (const relPath of allPaths) {
+        if (relPath === indexRelPath)
+            continue;
+        const abs = path.join(vaultRoot, relPath);
+        let raw;
+        try {
+            raw = fs.readFileSync(abs, "utf8");
+        }
+        catch {
+            continue;
+        }
+        const { data: fm, content } = parseNote(raw);
+        const proj = projectOfNote(relPath, fm);
+        if (proj !== slug)
+            continue;
+        const type = typeof fm.type === "string" ? fm.type : "capture";
+        const hook = extractHook(content, fm, relPath);
+        results.push({ relPath, type, hook });
+    }
+    return results;
+}
+export function renderProjectIndexBody(slug, notes) {
+    const byType = {};
+    for (const n of notes) {
+        (byType[n.type] ||= []).push({ relPath: n.relPath, hook: n.hook });
+    }
+    for (const type of Object.keys(byType)) {
+        byType[type].sort((a, b) => a.relPath.localeCompare(b.relPath));
+    }
+    let body = `# ${slug} — index\n\n`;
+    for (const type of TYPE_ORDER) {
+        const entries = byType[type];
+        if (!entries || entries.length === 0)
+            continue;
+        const heading = TYPE_PLURAL[type] ?? (type.charAt(0).toUpperCase() + type.slice(1) + "s");
+        body += `## ${heading}\n\n`;
+        for (const e of entries) {
+            const noMd = e.relPath.replace(/\.md$/, "");
+            body += `- [[${noMd}]] — ${e.hook}\n`;
+        }
+        body += "\n";
+    }
+    return body;
+}
+export function projectIndexRelPath(slug) {
+    return `maps/${slug}-index.md`;
+}
+export function enumerateProjectSlugs(vaultRoot) {
+    const slugs = new Set();
+    const projectsDir = path.join(vaultRoot, "projects");
+    try {
+        for (const entry of fs.readdirSync(projectsDir)) {
+            if (entry.endsWith(".md") && !entry.startsWith("_")) {
+                slugs.add(entry.slice(0, -3).toLowerCase());
+            }
+        }
+    }
+    catch { /* projects dir absent */ }
+    const allPaths = [];
+    try {
+        walkVault(vaultRoot, vaultRoot, allPaths);
+    }
+    catch { /* vault absent */ }
+    for (const relPath of allPaths) {
+        const abs = path.join(vaultRoot, relPath);
+        try {
+            const raw = fs.readFileSync(abs, "utf8");
+            const { data: fm } = parseNote(raw);
+            const proj = projectOfNote(relPath, fm);
+            if (proj)
+                slugs.add(proj);
+        }
+        catch { /* skip unreadable */ }
+    }
+    return Array.from(slugs).sort();
+}
+export function buildProjectIndex(slug) {
+    const root = vaultPath();
+    const notes = collectProjectNotes(root, slug);
+    const body = renderProjectIndexBody(slug, notes);
+    const relPath = projectIndexRelPath(slug);
+    const abs = path.join(root, relPath);
+    let existingBody = null;
+    if (fs.existsSync(abs)) {
+        try {
+            const raw = fs.readFileSync(abs, "utf8");
+            existingBody = parseNote(raw).content;
+        }
+        catch { /* treat as missing */ }
+    }
+    if (existingBody === body) {
+        return { relPath, changed: false };
+    }
+    const today = new Date().toISOString().slice(0, 10);
+    const fm = {
+        type: "map",
+        project: slug,
+        superbrain: true,
+        generated: true,
+        created: today,
+        updated: today,
+    };
+    atomicWrite(abs, serializeNote(fm, body));
+    return { relPath, changed: true };
+}

--- a/dist/src/recall.js
+++ b/dist/src/recall.js
@@ -113,13 +113,16 @@ async function hybridRecallWithProject(ix, query, k, projectSlug, excludeSlugs, 
                 ...background.map((p) => `${p.relPath}#${p.anchor}`),
             ]);
             const need = bgSlots - background.length;
-            const fallbackHits = ix.globalFallbackNotes(need + fgAndBgKeys.size);
+            const fallbackHits = ix.globalFallbackNotes((need + fgAndBgKeys.size) * 3);
             const fallbackRelPaths = fallbackHits.map((h) => h.relPath);
             const fallbackMeta = ix.getFilterMeta(fallbackRelPaths);
             const fallbackRoleActive = !!filters.role && fallbackRelPaths.some((p) => fallbackMeta.get(p)?.agentRole != null);
-            const extra = toPointers(fallbackHits.filter((h) => !fgAndBgKeys.has(`${h.relPath}#${h.anchor}`) &&
+            const extra = toPointers(fallbackHits
+                .filter((h) => !fgAndBgKeys.has(`${h.relPath}#${h.anchor}`) &&
                 !excludeSlugs.includes(h.relPath) &&
-                passesMeta(fallbackMeta.get(h.relPath), filters, fallbackRoleActive))).slice(0, need);
+                passesMeta(fallbackMeta.get(h.relPath), filters, fallbackRoleActive))
+                .sort((a, b) => archivePenalty(b.relPath) - archivePenalty(a.relPath))
+                .slice(0, need));
             background = [...background, ...extra];
         }
     }

--- a/dist/src/recall.js
+++ b/dist/src/recall.js
@@ -22,16 +22,16 @@ export async function hybridRecall(query, k, opts) {
     let ix;
     try {
         ix = openIndex();
-        // --- Embed the query (always; bm25Only is removed) ---
         let qv;
         try {
             [qv] = await embed([query]);
         }
         catch { /* degrade to bm25-only if embedding fails */ }
+        const filters = { type: opts?.type, since: opts?.since, role: opts?.role };
         if (opts?.projectSlug) {
-            return await hybridRecallWithProject(ix, query, k, opts.projectSlug, opts.excludeSlugs ?? [], qv);
+            return await hybridRecallWithProject(ix, query, k, opts.projectSlug, opts.excludeSlugs ?? [], qv, filters);
         }
-        return hybridRecallUnscoped(ix, query, k, opts?.excludeSlugs ?? [], qv);
+        return hybridRecallUnscoped(ix, query, k, opts?.excludeSlugs ?? [], qv, filters);
     }
     catch {
         return [];
@@ -44,7 +44,7 @@ export async function hybridRecall(query, k, opts) {
  * Unscoped recall: no project filter, all k slots go to the best-matching notes.
  * No background reservation when projectSlug is absent.
  */
-function hybridRecallUnscoped(ix, query, k, excludeSlugs, qv) {
+function hybridRecallUnscoped(ix, query, k, excludeSlugs, qv, filters) {
     const bm = ix.bm25(query, k * 2);
     let vec = [];
     if (qv) {
@@ -59,14 +59,14 @@ function hybridRecallUnscoped(ix, query, k, excludeSlugs, qv) {
     // Gate fix: return empty only when BOTH arms return nothing.
     if (bm.length === 0 && vec.length === 0)
         return [];
-    return applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, undefined);
+    return applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, undefined, filters);
 }
 /**
  * Project-scoped recall: foreground (75%) from project notes + background (25%)
  * from a separate global-restricted query. The background is RESERVED — it is
  * filled even when project notes dominate and would otherwise fill all k slots.
  */
-async function hybridRecallWithProject(ix, query, k, projectSlug, excludeSlugs, qv) {
+async function hybridRecallWithProject(ix, query, k, projectSlug, excludeSlugs, qv, filters) {
     const fgSlots = Math.round(k * 0.75);
     const bgSlots = k - fgSlots;
     // Foreground: project-scoped query
@@ -79,7 +79,7 @@ async function hybridRecallWithProject(ix, query, k, projectSlug, excludeSlugs, 
     // Gate fix: if BM25 empty and vec empty, fall through to background only
     let foreground = [];
     if (bm.length > 0 || vec.length > 0) {
-        foreground = applyFusionAndFilter(ix, bm, vec, fgSlots, excludeSlugs, projectSlug);
+        foreground = applyFusionAndFilter(ix, bm, vec, fgSlots, excludeSlugs, projectSlug, filters);
     }
     // Background: separate global-restricted query (always runs, never starved).
     // When the hybrid query yields fewer than bgSlots results, fill remaining
@@ -93,7 +93,7 @@ async function hybridRecallWithProject(ix, query, k, projectSlug, excludeSlugs, 
             bgVec = ix.vectorKNNGlobal(qv, bgSlots * 3);
         }
         if (bgBm.length > 0 || bgVec.length > 0) {
-            background = applyFusionAndFilter(ix, bgBm, bgVec, bgSlots, excludeSlugs, undefined);
+            background = applyFusionAndFilter(ix, bgBm, bgVec, bgSlots, excludeSlugs, undefined, filters);
         }
         // Fill remaining background slots from any available global notes.
         if (background.length < bgSlots) {
@@ -103,8 +103,12 @@ async function hybridRecallWithProject(ix, query, k, projectSlug, excludeSlugs, 
             ]);
             const need = bgSlots - background.length;
             const fallbackHits = ix.globalFallbackNotes(need + fgAndBgKeys.size);
+            const fallbackRelPaths = fallbackHits.map((h) => h.relPath);
+            const fallbackMeta = ix.getFilterMeta(fallbackRelPaths);
+            const fallbackRoleActive = !!filters.role && fallbackRelPaths.some((p) => fallbackMeta.get(p)?.agentRole != null);
             const extra = toPointers(fallbackHits.filter((h) => !fgAndBgKeys.has(`${h.relPath}#${h.anchor}`) &&
-                !excludeSlugs.includes(h.relPath))).slice(0, need);
+                !excludeSlugs.includes(h.relPath) &&
+                passesMeta(fallbackMeta.get(h.relPath), filters, fallbackRoleActive))).slice(0, need);
             background = [...background, ...extra];
         }
     }
@@ -117,11 +121,23 @@ async function hybridRecallWithProject(ix, query, k, projectSlug, excludeSlugs, 
     const combined = [...foreground, ...finalBg].slice(0, k);
     return combined;
 }
+function passesMeta(m, filters, roleActive) {
+    if (filters.type && m?.type !== filters.type)
+        return false;
+    if (filters.since) {
+        const c = m?.created ? Date.parse(m.created) : NaN;
+        if (isNaN(c) || c < Date.parse(filters.since))
+            return false;
+    }
+    if (roleActive && m?.agentRole !== filters.role)
+        return false;
+    return true;
+}
 /**
  * Apply RRF fusion of bm25 and vector arms, then filter, score, and slice to k.
  * When projectSlug is set, the isCrossProject filter is applied (fail-closed).
  */
-function applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, projectSlug) {
+function applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, projectSlug, filters = {}) {
     if (bm.length === 0 && vec.length === 0)
         return [];
     if (vec.length === 0) {
@@ -129,14 +145,17 @@ function applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, projectSlug) {
         const exclude = new Set(excludeSlugs);
         const relPaths = [...new Set(bm.map((h) => h.relPath))];
         const projects = projectSlug ? ix.getProjectsForPaths(relPaths) : new Map();
-        const created = ix.getCreatedForPaths(relPaths);
+        const meta = ix.getFilterMeta(relPaths);
+        const roleActive = !!filters.role && relPaths.some((p) => meta.get(p)?.agentRole != null);
         const now = Date.now();
         const scored = bm
             .filter((h) => !exclude.has(h.relPath))
             .filter((h) => !projectSlug || !isCrossProject(projects.get(h.relPath), projectSlug))
+            .filter((h) => passesMeta(meta.get(h.relPath), filters, roleActive))
             .map((h) => {
+            const created = meta.get(h.relPath)?.created ?? undefined;
             let score = boostScore(1, projects.get(h.relPath), projectSlug);
-            score *= decayFactor(created.get(h.relPath), now);
+            score *= decayFactor(created, now);
             return { h, score };
         })
             .sort((a, b) => b.score - a.score)
@@ -148,15 +167,18 @@ function applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, projectSlug) {
         const exclude = new Set(excludeSlugs);
         const relPaths = [...new Set(vec.map((h) => h.relPath))];
         const projects = projectSlug ? ix.getProjectsForPaths(relPaths) : new Map();
-        const created = ix.getCreatedForPaths(relPaths);
+        const meta = ix.getFilterMeta(relPaths);
+        const roleActive = !!filters.role && relPaths.some((p) => meta.get(p)?.agentRole != null);
         const now = Date.now();
         const scored = vec
             .filter((h) => h.distance == null || h.distance <= VECTOR_DISTANCE_CUTOFF)
             .filter((h) => !exclude.has(h.relPath))
             .filter((h) => !projectSlug || !isCrossProject(projects.get(h.relPath), projectSlug))
+            .filter((h) => passesMeta(meta.get(h.relPath), filters, roleActive))
             .map((h) => {
+            const created = meta.get(h.relPath)?.created ?? undefined;
             let score = boostScore(1, projects.get(h.relPath), projectSlug);
-            score *= decayFactor(created.get(h.relPath), now);
+            score *= decayFactor(created, now);
             return { h, score };
         })
             .sort((a, b) => b.score - a.score)
@@ -171,7 +193,8 @@ function applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, projectSlug) {
     const projects = projectSlug
         ? ix.getProjectsForPaths(candidateRelPaths)
         : new Map();
-    const created = ix.getCreatedForPaths(candidateRelPaths);
+    const meta = ix.getFilterMeta(candidateRelPaths);
+    const roleActive = !!filters.role && candidateRelPaths.some((p) => meta.get(p)?.agentRole != null);
     const now = Date.now();
     const exclude = new Set(excludeSlugs);
     const decayed = fused
@@ -183,8 +206,11 @@ function applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, projectSlug) {
             return null;
         if (projectSlug && isCrossProject(projects.get(hit.relPath), projectSlug))
             return null;
+        if (!passesMeta(meta.get(hit.relPath), filters, roleActive))
+            return null;
+        const created = meta.get(hit.relPath)?.created ?? undefined;
         let score = boostScore(e.score, projects.get(hit.relPath), projectSlug);
-        score *= decayFactor(created.get(hit.relPath), now);
+        score *= decayFactor(created, now);
         return { id: e.id, score };
     })
         .filter((e) => e !== null)

--- a/dist/src/recall.js
+++ b/dist/src/recall.js
@@ -1,6 +1,17 @@
 import { openIndex, rrfWithScores } from "./searchIndex.js";
 import { embed } from "./embed.js";
 const VECTOR_DISTANCE_CUTOFF = 1.0;
+const ARCHIVE_PENALTY_DEFAULT = 0.1;
+export function isArchivePath(relPath) {
+    const norm = relPath.replace(/\\/g, "/");
+    return norm === "_archive" || norm.startsWith("_archive/") || norm.includes("/_archive/");
+}
+function archivePenalty(relPath) {
+    if (!isArchivePath(relPath))
+        return 1;
+    const v = Number(process.env.SUPERBRAIN_ARCHIVE_PENALTY);
+    return Number.isFinite(v) && v > 0 ? v : ARCHIVE_PENALTY_DEFAULT;
+}
 function toPointers(hits) {
     return hits.map((h) => ({
         relPath: h.relPath, headingPath: h.headingPath, anchor: h.anchor,
@@ -156,6 +167,7 @@ function applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, projectSlug, filters
             const created = meta.get(h.relPath)?.created ?? undefined;
             let score = boostScore(1, projects.get(h.relPath), projectSlug);
             score *= decayFactor(created, now);
+            score *= archivePenalty(h.relPath);
             return { h, score };
         })
             .sort((a, b) => b.score - a.score)
@@ -179,6 +191,7 @@ function applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, projectSlug, filters
             const created = meta.get(h.relPath)?.created ?? undefined;
             let score = boostScore(1, projects.get(h.relPath), projectSlug);
             score *= decayFactor(created, now);
+            score *= archivePenalty(h.relPath);
             return { h, score };
         })
             .sort((a, b) => b.score - a.score)
@@ -211,6 +224,7 @@ function applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, projectSlug, filters
         const created = meta.get(hit.relPath)?.created ?? undefined;
         let score = boostScore(e.score, projects.get(hit.relPath), projectSlug);
         score *= decayFactor(created, now);
+        score *= archivePenalty(hit.relPath);
         return { id: e.id, score };
     })
         .filter((e) => e !== null)

--- a/dist/src/recall.js
+++ b/dist/src/recall.js
@@ -136,6 +136,8 @@ async function hybridRecallWithProject(ix, query, k, projectSlug, excludeSlugs, 
     return combined;
 }
 function passesMeta(m, filters, roleActive) {
+    if (m?.generated)
+        return false;
     if (filters.type && m?.type !== filters.type)
         return false;
     if (filters.since) {

--- a/dist/src/searchIndex.js
+++ b/dist/src/searchIndex.js
@@ -41,7 +41,7 @@ export function rrfWithScores(lists, k, c = 60) {
 function ensureVecTable(db) {
     db.exec(`
     CREATE TABLE IF NOT EXISTS embed_meta (key TEXT PRIMARY KEY, value TEXT);
-    CREATE TABLE IF NOT EXISTS notes (rel_path TEXT PRIMARY KEY, mtime INTEGER, hash TEXT, project TEXT, created TEXT, note_type TEXT, agent_role TEXT);
+    CREATE TABLE IF NOT EXISTS notes (rel_path TEXT PRIMARY KEY, mtime INTEGER, hash TEXT, project TEXT, created TEXT, note_type TEXT, agent_role TEXT, generated INTEGER);
     CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY, rel_path TEXT, heading_path TEXT, anchor TEXT, text TEXT);
     CREATE INDEX IF NOT EXISTS chunks_rel ON chunks(rel_path);
@@ -83,6 +83,8 @@ export function openIndex() {
         db.exec("ALTER TABLE notes ADD COLUMN note_type TEXT");
     if (!cols.includes("agent_role"))
         db.exec("ALTER TABLE notes ADD COLUMN agent_role TEXT");
+    if (!cols.includes("generated"))
+        db.exec("ALTER TABLE notes ADD COLUMN generated INTEGER");
     ensureEdgesTable(db);
     const delByPath = db.transaction((relPath) => {
         const rows = db.prepare("SELECT id, heading_path, text FROM chunks WHERE rel_path=?").all(relPath);
@@ -96,8 +98,8 @@ export function openIndex() {
     const insChunk = db.prepare("INSERT INTO chunks(rel_path,heading_path,anchor,text) VALUES (?,?,?,?)");
     const insFts = db.prepare("INSERT INTO chunks_fts(rowid,text) VALUES (?,?)");
     const insVec = db.prepare("INSERT INTO vec_chunks(chunk_id,embedding) VALUES (?,vec_int8(?))");
-    const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created,note_type,agent_role) VALUES (?,?,?,?,?,?,?)");
-    const upsert = db.transaction((relPath, mtime, hash, chunks, embs, project, created, noteType, agentRole) => {
+    const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created,note_type,agent_role,generated) VALUES (?,?,?,?,?,?,?,?)");
+    const upsert = db.transaction((relPath, mtime, hash, chunks, embs, project, created, noteType, agentRole, generated) => {
         delByPath(relPath);
         const capped = chunks.slice(0, CHUNK_CAP);
         capped.forEach((c, i) => {
@@ -105,7 +107,7 @@ export function openIndex() {
             insFts.run(id, (c.headingPath ? c.headingPath + " " : "") + c.text);
             insVec.run(BigInt(id), serializeInt8ForSql(quantizeToInt8(embs[i])));
         });
-        insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null), toScalarString(noteType ?? null), toScalarString(agentRole ?? null));
+        insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null), toScalarString(noteType ?? null), toScalarString(agentRole ?? null), generated ? 1 : 0);
     });
     const hydrate = (ids) => ids.map((id) => {
         const r = db.prepare("SELECT rel_path,heading_path,anchor,text FROM chunks WHERE id=?").get(id);
@@ -113,7 +115,7 @@ export function openIndex() {
     }).filter(Boolean);
     return {
         db,
-        upsertNote: (rp, mt, h, c, e, project, created, noteType, agentRole) => upsert(rp, mt, h, c, e, project, created, noteType, agentRole),
+        upsertNote: (rp, mt, h, c, e, project, created, noteType, agentRole, generated) => upsert(rp, mt, h, c, e, project, created, noteType, agentRole, generated),
         deleteNote: (rp) => delByPath(rp),
         bm25: (q, k) => {
             const terms = q.replace(/[^\w\s]/g, " ").trim().split(/\s+/).filter(Boolean);
@@ -207,9 +209,9 @@ export function openIndex() {
             if (relPaths.length === 0)
                 return new Map();
             const placeholders = relPaths.map(() => "?").join(",");
-            const rows = db.prepare(`SELECT rel_path, project, created, note_type, agent_role FROM notes WHERE rel_path IN (${placeholders})`).all(...relPaths);
+            const rows = db.prepare(`SELECT rel_path, project, created, note_type, agent_role, generated FROM notes WHERE rel_path IN (${placeholders})`).all(...relPaths);
             return new Map(rows.map((r) => [r.rel_path, {
-                    project: r.project, created: r.created, type: r.note_type, agentRole: r.agent_role,
+                    project: r.project, created: r.created, type: r.note_type, agentRole: r.agent_role, generated: r.generated === 1,
                 }]));
         },
         getNoteMeta: (rp) => {

--- a/dist/src/searchIndex.js
+++ b/dist/src/searchIndex.js
@@ -41,7 +41,7 @@ export function rrfWithScores(lists, k, c = 60) {
 function ensureVecTable(db) {
     db.exec(`
     CREATE TABLE IF NOT EXISTS embed_meta (key TEXT PRIMARY KEY, value TEXT);
-    CREATE TABLE IF NOT EXISTS notes (rel_path TEXT PRIMARY KEY, mtime INTEGER, hash TEXT, project TEXT, created TEXT);
+    CREATE TABLE IF NOT EXISTS notes (rel_path TEXT PRIMARY KEY, mtime INTEGER, hash TEXT, project TEXT, created TEXT, note_type TEXT, agent_role TEXT);
     CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY, rel_path TEXT, heading_path TEXT, anchor TEXT, text TEXT);
     CREATE INDEX IF NOT EXISTS chunks_rel ON chunks(rel_path);
@@ -79,6 +79,10 @@ export function openIndex() {
         db.exec("ALTER TABLE notes ADD COLUMN project TEXT");
     if (!cols.includes("created"))
         db.exec("ALTER TABLE notes ADD COLUMN created TEXT");
+    if (!cols.includes("note_type"))
+        db.exec("ALTER TABLE notes ADD COLUMN note_type TEXT");
+    if (!cols.includes("agent_role"))
+        db.exec("ALTER TABLE notes ADD COLUMN agent_role TEXT");
     ensureEdgesTable(db);
     const delByPath = db.transaction((relPath) => {
         const rows = db.prepare("SELECT id, heading_path, text FROM chunks WHERE rel_path=?").all(relPath);
@@ -92,8 +96,8 @@ export function openIndex() {
     const insChunk = db.prepare("INSERT INTO chunks(rel_path,heading_path,anchor,text) VALUES (?,?,?,?)");
     const insFts = db.prepare("INSERT INTO chunks_fts(rowid,text) VALUES (?,?)");
     const insVec = db.prepare("INSERT INTO vec_chunks(chunk_id,embedding) VALUES (?,vec_int8(?))");
-    const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created) VALUES (?,?,?,?,?)");
-    const upsert = db.transaction((relPath, mtime, hash, chunks, embs, project, created) => {
+    const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created,note_type,agent_role) VALUES (?,?,?,?,?,?,?)");
+    const upsert = db.transaction((relPath, mtime, hash, chunks, embs, project, created, noteType, agentRole) => {
         delByPath(relPath);
         const capped = chunks.slice(0, CHUNK_CAP);
         capped.forEach((c, i) => {
@@ -101,7 +105,7 @@ export function openIndex() {
             insFts.run(id, (c.headingPath ? c.headingPath + " " : "") + c.text);
             insVec.run(BigInt(id), serializeInt8ForSql(quantizeToInt8(embs[i])));
         });
-        insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null));
+        insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null), toScalarString(noteType ?? null), toScalarString(agentRole ?? null));
     });
     const hydrate = (ids) => ids.map((id) => {
         const r = db.prepare("SELECT rel_path,heading_path,anchor,text FROM chunks WHERE id=?").get(id);
@@ -109,7 +113,7 @@ export function openIndex() {
     }).filter(Boolean);
     return {
         db,
-        upsertNote: (rp, mt, h, c, e, project, created) => upsert(rp, mt, h, c, e, project, created),
+        upsertNote: (rp, mt, h, c, e, project, created, noteType, agentRole) => upsert(rp, mt, h, c, e, project, created, noteType, agentRole),
         deleteNote: (rp) => delByPath(rp),
         bm25: (q, k) => {
             const terms = q.replace(/[^\w\s]/g, " ").trim().split(/\s+/).filter(Boolean);
@@ -198,6 +202,15 @@ export function openIndex() {
             const placeholders = relPaths.map(() => "?").join(",");
             const rows = db.prepare(`SELECT rel_path, created FROM notes WHERE rel_path IN (${placeholders}) AND created IS NOT NULL`).all(...relPaths);
             return new Map(rows.map((r) => [r.rel_path, r.created]));
+        },
+        getFilterMeta: (relPaths) => {
+            if (relPaths.length === 0)
+                return new Map();
+            const placeholders = relPaths.map(() => "?").join(",");
+            const rows = db.prepare(`SELECT rel_path, project, created, note_type, agent_role FROM notes WHERE rel_path IN (${placeholders})`).all(...relPaths);
+            return new Map(rows.map((r) => [r.rel_path, {
+                    project: r.project, created: r.created, type: r.note_type, agentRole: r.agent_role,
+                }]));
         },
         getNoteMeta: (rp) => {
             const r = db.prepare("SELECT mtime,hash FROM notes WHERE rel_path=?").get(rp);

--- a/dist/src/sessionAttribution.js
+++ b/dist/src/sessionAttribution.js
@@ -1,0 +1,11 @@
+export function parentSessionId(env = process.env) {
+    const v = env.SUPERBRAIN_PARENT_SESSION_ID;
+    if (typeof v !== "string")
+        return undefined;
+    const t = v.trim();
+    return t ? t : undefined;
+}
+export function attributionFields(env = process.env) {
+    const p = parentSessionId(env);
+    return p ? { parent_session_id: p } : {};
+}

--- a/dist/src/sessionGc.js
+++ b/dist/src/sessionGc.js
@@ -4,6 +4,7 @@ const KNOWN_EXTENSIONS = new Set([
     ".ndjson",
     ".cursor",
     ".pending",
+    ".needs-distill",
     ".salience.json",
     ".injected.json",
     ".turns.json",

--- a/dist/src/sessionGcRun.js
+++ b/dist/src/sessionGcRun.js
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pruneSessionFiles } from "./sessionGc.js";
+const STAMP_FILE = "session-gc.stamp";
+const DEFAULT_MIN_INTERVAL_HOURS = 24;
+function envNumber(name, fallback) {
+    const raw = process.env[name];
+    if (raw == null || raw === "")
+        return fallback;
+    const v = Number(raw);
+    return Number.isFinite(v) ? v : fallback;
+}
+export function runSessionGcOncePerDay(dataDirPath, opts) {
+    if (process.env.SUPERBRAIN_GC_DISABLE === "1") {
+        return { ran: false, skippedByCadence: false };
+    }
+    const now = opts?.now ?? Date.now();
+    const minIntervalHours = envNumber("SUPERBRAIN_GC_MIN_INTERVAL_HOURS", DEFAULT_MIN_INTERVAL_HOURS);
+    const minIntervalMs = minIntervalHours * 60 * 60 * 1000;
+    const stampPath = path.join(dataDirPath, STAMP_FILE);
+    if (minIntervalMs > 0) {
+        try {
+            const stat = fs.statSync(stampPath);
+            if (now - stat.mtimeMs < minIntervalMs) {
+                return { ran: false, skippedByCadence: true };
+            }
+        }
+        catch {
+            // no stamp yet — first run
+        }
+    }
+    const maxAgeDays = envNumber("SUPERBRAIN_GC_MAX_AGE_DAYS", 30);
+    const dryRun = process.env.SUPERBRAIN_GC_DRY_RUN === "1";
+    const result = pruneSessionFiles(dataDirPath, { maxAgeDays, dryRun });
+    try {
+        fs.mkdirSync(dataDirPath, { recursive: true });
+        fs.writeFileSync(stampPath, new Date(now).toISOString());
+    }
+    catch {
+        // stamp write failure is non-fatal
+    }
+    return { ran: true, skippedByCadence: false, result };
+}

--- a/dist/src/vaultWriter.js
+++ b/dist/src/vaultWriter.js
@@ -49,6 +49,8 @@ export function writeNote(rel, args) {
             let archived = [];
             let dedupHit = false;
             casWrite(abs, (currentRaw) => {
+                dedupHit = false;
+                archived = [];
                 let currentBody;
                 let baseFm;
                 if (currentRaw) {
@@ -121,6 +123,7 @@ export function writeNote(rel, args) {
     }
     let dedupHit = false;
     casWrite(abs, (currentRaw) => {
+        dedupHit = false;
         const parsed = parseNote(currentRaw ?? "");
         const newNorm = normBody(args.body);
         if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {

--- a/dist/src/vaultWriter.js
+++ b/dist/src/vaultWriter.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { vaultPath } from "./paths.js";
 import { serializeNote, parseNote, validateFrontmatter } from "./frontmatter.js";
-import { atomicWrite, readWithChecksum } from "./atomicWrite.js";
+import { atomicWrite, readWithChecksum, casWrite } from "./atomicWrite.js";
 import { appendDatedSectionWithArchive, initializeProjectNote } from "./projectWriter.js";
 const ALLOWED_EXT = new Set([".md"]);
 const EXCLUDED = ["/.obsidian/", "/.git/", "/node_modules/", "/.trash/"];
@@ -41,44 +41,47 @@ export function writeNote(rel, args) {
         return { ok: true, path: abs };
     }
     const existing = readWithChecksum(abs);
-    // Project notes (projects/<slug>.md) get structured dated subsections under
-    // "## Recent activity" with auto-archiving when the file exceeds 20 KB.
     const relNorm = rel.replace(/\\/g, "/");
     if (relNorm.startsWith("projects/") && !relNorm.startsWith("projects/_archive/")) {
         const stamp = new Date().toISOString().slice(0, 10);
         const date = args.frontmatter.created || stamp;
         try {
-            // Determine current body (content portion only, no frontmatter)
-            let currentBody;
-            let baseFm;
-            if (existing) {
-                const parsed = parseNote(existing.content);
-                // Dedup: skip if the normalized new body already appears in the file.
-                const newNorm = normBody(args.body);
-                if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {
-                    return { ok: true, path: abs, reason: "duplicate-skipped" };
+            let archived = [];
+            let dedupHit = false;
+            casWrite(abs, (currentRaw) => {
+                let currentBody;
+                let baseFm;
+                if (currentRaw) {
+                    const parsed = parseNote(currentRaw);
+                    const newNorm = normBody(args.body);
+                    if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {
+                        dedupHit = true;
+                        return currentRaw;
+                    }
+                    currentBody = parsed.content;
+                    baseFm = parsed.data;
                 }
-                currentBody = parsed.content;
-                baseFm = parsed.data;
-            }
-            else {
-                const slug = path.basename(abs, ".md");
-                currentBody = initializeProjectNote(slug, args.frontmatter);
-                baseFm = {};
-            }
-            // Backfill ## Recent activity if the note pre-dates this feature
-            if (!currentBody.includes("\n## Recent activity\n") &&
-                !currentBody.endsWith("## Recent activity") &&
-                !currentBody.startsWith("## Recent activity\n")) {
-                currentBody = currentBody.replace(/\s+$/, "") + "\n\n## Recent activity\n";
-            }
-            const mergedFm = { ...baseFm, ...args.frontmatter, updated: stamp };
-            const fmOverhead = Buffer.byteLength(serializeNote(mergedFm, ""), "utf8");
-            const r = appendDatedSectionWithArchive(currentBody, date, args.body, {
-                sizeCap: Math.max(8192, (Number(process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES) || 32 * 1024) - fmOverhead),
+                else {
+                    const slug = path.basename(abs, ".md");
+                    currentBody = initializeProjectNote(slug, args.frontmatter);
+                    baseFm = {};
+                }
+                if (!currentBody.includes("\n## Recent activity\n") &&
+                    !currentBody.endsWith("## Recent activity") &&
+                    !currentBody.startsWith("## Recent activity\n")) {
+                    currentBody = currentBody.replace(/\s+$/, "") + "\n\n## Recent activity\n";
+                }
+                const mergedFm = { ...baseFm, ...args.frontmatter, updated: stamp };
+                const fmOverhead = Buffer.byteLength(serializeNote(mergedFm, ""), "utf8");
+                const r = appendDatedSectionWithArchive(currentBody, date, args.body, {
+                    sizeCap: Math.max(8192, (Number(process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES) || 32 * 1024) - fmOverhead),
+                });
+                archived = r.archived;
+                return serializeNote(mergedFm, r.body);
             });
-            atomicWrite(abs, serializeNote(mergedFm, r.body));
-            for (const a of r.archived) {
+            if (dedupHit)
+                return { ok: true, path: abs, reason: "duplicate-skipped" };
+            for (const a of archived) {
                 const year = a.date === "0000-00-00"
                     ? new Date().toISOString().slice(0, 4)
                     : a.date.slice(0, 4);
@@ -99,16 +102,16 @@ export function writeNote(rel, args) {
             return { ok: true, path: abs };
         }
         catch (_e) {
-            // Fail open: fall back to legacy plain append so the distiller never crashes
             if (!existing) {
                 atomicWrite(abs, serializeNote(args.frontmatter, args.body));
                 return { ok: true, path: abs };
             }
-            const stamp2 = new Date().toISOString().slice(0, 16).replace("T", " ");
-            const parsed = parseNote(existing.content);
-            const mergedFm = { ...parsed.data, ...args.frontmatter, updated: stamp2.slice(0, 10) };
-            const appended = `${parsed.content.replace(/\s+$/, "")}\n\n## ${stamp2}\n\n${args.body}\n`;
-            atomicWrite(abs, serializeNote(mergedFm, appended));
+            casWrite(abs, (currentRaw) => {
+                const stamp2 = new Date().toISOString().slice(0, 16).replace("T", " ");
+                const parsed = parseNote(currentRaw ?? "");
+                const mergedFm = { ...parsed.data, ...args.frontmatter, updated: stamp2.slice(0, 10) };
+                return serializeNote(mergedFm, `${parsed.content.replace(/\s+$/, "")}\n\n## ${stamp2}\n\n${args.body}\n`);
+            });
             return { ok: true, path: abs };
         }
     }
@@ -116,20 +119,20 @@ export function writeNote(rel, args) {
         atomicWrite(abs, serializeNote(args.frontmatter, args.body));
         return { ok: true, path: abs };
     }
-    // Existing file: never blind-overwrite. Append distilled body under a dated section.
-    const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
-    const parsed = parseNote(existing.content);
-    // Dedup: the distiller can re-emit the same project_fact / gotcha across
-    // adjacent runs (the model has no memory of prior emissions). Skip the
-    // append if the normalized new body already appears in the file. The 40-
-    // char floor avoids false positives on generic phrasing.
-    const newNorm = normBody(args.body);
-    if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {
+    let dedupHit = false;
+    casWrite(abs, (currentRaw) => {
+        const parsed = parseNote(currentRaw ?? "");
+        const newNorm = normBody(args.body);
+        if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {
+            dedupHit = true;
+            return currentRaw ?? "";
+        }
+        const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
+        const mergedFm = { ...parsed.data, ...args.frontmatter, updated: stamp.slice(0, 10) };
+        return serializeNote(mergedFm, `${parsed.content.replace(/\s+$/, "")}\n\n## ${stamp}\n\n${args.body}\n`);
+    });
+    if (dedupHit)
         return { ok: true, path: abs, reason: "duplicate-skipped" };
-    }
-    const mergedFm = { ...parsed.data, ...args.frontmatter, updated: stamp.slice(0, 10) };
-    const appended = `${parsed.content.replace(/\s+$/, "")}\n\n## ${stamp}\n\n${args.body}\n`;
-    atomicWrite(abs, serializeNote(mergedFm, appended));
     return { ok: true, path: abs };
 }
 export function softDelete(rel) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superbrain",
-  "version": "0.7.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superbrain",
-      "version": "0.7.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",

--- a/src/atomicWrite.ts
+++ b/src/atomicWrite.ts
@@ -19,3 +19,27 @@ export function readWithChecksum(file: string): { content: string; checksum: str
     return { content, checksum: sha256(content) };
   } catch { return null; }
 }
+
+export interface CasResult { ok: boolean; attempts: number }
+
+export function casWrite(
+  file: string,
+  produce: (current: string | null) => string,
+  opts: { maxAttempts?: number } = {},
+): CasResult {
+  const maxAttempts = opts.maxAttempts ?? 5;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const before = readWithChecksum(file);
+    const next = produce(before ? before.content : null);
+    const after = readWithChecksum(file);
+    const beforeSum = before ? before.checksum : null;
+    const afterSum = after ? after.checksum : null;
+    if (beforeSum === afterSum) {
+      atomicWrite(file, next);
+      return { ok: true, attempts: attempt };
+    }
+  }
+  const last = readWithChecksum(file);
+  atomicWrite(file, produce(last ? last.content : null));
+  return { ok: true, attempts: maxAttempts };
+}

--- a/src/attribution.ts
+++ b/src/attribution.ts
@@ -1,0 +1,13 @@
+export interface Attribution {
+  session_id?: string;
+  agent_role?: string;
+}
+
+export function attributionFromEnv(): Attribution {
+  const out: Attribution = {};
+  const sid = process.env.SUPERBRAIN_SESSION_ID;
+  const role = process.env.SUPERBRAIN_AGENT_ROLE;
+  if (sid) out.session_id = sid;
+  if (role) out.agent_role = role;
+  return out;
+}

--- a/src/dailyState.ts
+++ b/src/dailyState.ts
@@ -9,6 +9,7 @@ export interface DaySessionEntry {
   openThreads: string[];
   project?: string;
   projects?: string[];
+  parentSessionId?: string;
 }
 export type DayState = Record<string, DaySessionEntry>;
 
@@ -27,4 +28,15 @@ export function upsertDay(date: string, sessionId: string, entry: DaySessionEntr
   const cur = readDay(date);
   cur[sessionId] = entry;
   fs.writeFileSync(f, JSON.stringify(cur));
+}
+
+export interface ChildEntry { sessionId: string; entry: DaySessionEntry; }
+
+export function childrenOf(date: string, parentId: string): ChildEntry[] {
+  if (!parentId) return [];
+  const day = readDay(date);
+  return Object.keys(day)
+    .filter((sid) => day[sid].parentSessionId === parentId)
+    .sort()
+    .map((sid) => ({ sessionId: sid, entry: day[sid] }));
 }

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -433,7 +433,7 @@ export async function runDistill(): Promise<void> {
   try {
     const from = readCursor(sid);
     const { events, newOffset } = readDelta(sid, from);
-    if (events.length === 0) { releaseLock("distill"); process.exit(0); }
+    if (events.length === 0) { releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN); process.exit(0); }
     // Pre-LLM skip check. Test stubs (SUPERBRAIN_DISTILL_STUB) bypass this so
     // fixtures that supply a small canned envelope still go through the full
     // routing path.
@@ -442,7 +442,7 @@ export async function runDistill(): Promise<void> {
       if (sk.skip) {
         logDistillSkip(sid, sk.reason);
         writeCursor(sid, newOffset);
-        releaseLock("distill");
+        releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN);
         return;
       }
     }
@@ -457,6 +457,6 @@ export async function runDistill(): Promise<void> {
   } catch (e: any) {
     writeFailure(`distill failed: ${e?.message || e}`);
   } finally {
-    releaseLock("distill");
+    releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN);
   }
 }

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -23,6 +23,7 @@ import { filterToUniversal } from "./preferenceClassify.js";
 import { resolveLinks } from "./wikilink.js";
 import { gcTranscript } from "./transcriptStore.js";
 import { pruneSessionFiles } from "./sessionGc.js";
+import { sweepPendingDistills, clearFlag } from "./distillSweep.js";
 import { classify } from "./classification.js";
 import { recordRejection } from "./rejectQueue.js";
 import { type NoteType } from "./templates.js";
@@ -427,32 +428,26 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
   return { notesWritten };
 }
 
+async function distillSession(sid: string): Promise<void> {
+  const from = readCursor(sid);
+  const { events, newOffset } = readDelta(sid, from);
+  if (events.length === 0) { writeCursor(sid, newOffset); return; }
+  if (!process.env.SUPERBRAIN_DISTILL_STUB) {
+    const sk = shouldSkipDistill(events);
+    if (sk.skip) { logDistillSkip(sid, sk.reason); writeCursor(sid, newOffset); return; }
+  }
+  await distillFromEvents(sid, events);
+  writeCursor(sid, newOffset);
+}
+
 export async function runDistill(): Promise<void> {
   const sid = process.env.SUPERBRAIN_SESSION_ID
     || (() => { try { return JSON.parse(fs.readFileSync(0, "utf8")).session_id; } catch { return "unknown"; } })();
   try {
-    const from = readCursor(sid);
-    const { events, newOffset } = readDelta(sid, from);
-    if (events.length === 0) { releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN); process.exit(0); }
-    // Pre-LLM skip check. Test stubs (SUPERBRAIN_DISTILL_STUB) bypass this so
-    // fixtures that supply a small canned envelope still go through the full
-    // routing path.
-    if (!process.env.SUPERBRAIN_DISTILL_STUB) {
-      const sk = shouldSkipDistill(events);
-      if (sk.skip) {
-        logDistillSkip(sid, sk.reason);
-        writeCursor(sid, newOffset);
-        releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN);
-        return;
-      }
-    }
-    await distillFromEvents(sid, events);
-    writeCursor(sid, newOffset);
-    // GC the transcript snapshot now that distillation succeeded. Best-effort:
-    // a missing snapshot is fine (checkpoint may not have run), and a deletion
-    // failure must never abort an otherwise-successful distill.
+    await distillSession(sid);
+    clearFlag(sid);
     try { gcTranscript(path.join(dataDir(), "transcripts"), sid); } catch { /* best-effort */ }
-    // GC old session files. Best-effort: never abort an otherwise-successful distill.
+    try { await sweepPendingDistills(sid, distillSession); } catch (e: any) { writeFailure(`sweep failed: ${e?.message || e}`); }
     try { pruneSessionFiles(dataDir()); } catch { /* best-effort */ }
   } catch (e: any) {
     writeFailure(`distill failed: ${e?.message || e}`);

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -35,6 +35,7 @@ import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
 import { classifyPath, basenameSlug } from "./projectDetect.js";
 import { slug, asText } from "./router.js";
+import { buildProjectIndex, projectIndexRelPath } from "./projectIndex.js";
 
 export interface SessionProjectResult {
   dominant: string | undefined;
@@ -273,6 +274,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
   const items = env.items;
   const routedByDate: Record<string, string[]> = {};
   let notesWritten = 0;
+  const touchedProjects = new Set<string>();
   for (const it of items) {
     try {
       if (!it.project && PROJECT_SCOPED_KINDS.has(it.kind) && sessionProj.all.length === 1 && sessionProj.dominant) {
@@ -310,6 +312,9 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
           try { await indexNote(r.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
           (routedByDate[it.date] ||= []).push(r.relPath);
           notesWritten++;
+          if (it.project) touchedProjects.add(it.project);
+          const projMatch = r.relPath.match(/^projects\/([^/_][^/]*)\.md$/);
+          if (projMatch) touchedProjects.add(projMatch[1]);
           if (it.kind === "preference") {
             try { emitPreferencesCore(it.body ?? ""); } catch { /* best-effort */ }
           }
@@ -400,6 +405,9 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
         try { await indexNote(writeRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
         (routedByDate[it.date] ||= []).push(writeRelPath);
         notesWritten++;
+        if (it.project) touchedProjects.add(it.project);
+        const projMatch2 = writeRelPath.match(/^projects\/([^/_][^/]*)\.md$/);
+        if (projMatch2) touchedProjects.add(projMatch2[1]);
       }
     } catch (e: any) {
       recordRejection(vaultPath(), {
@@ -411,6 +419,14 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
       });
       writeFailure(`item dropped: ${e?.message || e}`);
     }
+  }
+  for (const projSlug of touchedProjects) {
+    try {
+      const { relPath: idxRelPath, changed } = buildProjectIndex(projSlug);
+      if (changed) {
+        try { await indexNote(idxRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
+      }
+    } catch (e: any) { writeFailure(`project index build failed for '${projSlug}': ${e?.message || e}`); }
   }
   try {
     const dates = Object.keys(routedByDate);

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -35,7 +35,7 @@ import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
 import { classifyPath, basenameSlug } from "./projectDetect.js";
 import { slug, asText } from "./router.js";
-import { buildProjectIndex, projectIndexRelPath } from "./projectIndex.js";
+import { buildProjectIndex } from "./projectIndex.js";
 
 export interface SessionProjectResult {
   dominant: string | undefined;
@@ -314,7 +314,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
           notesWritten++;
           if (it.project) touchedProjects.add(it.project);
           const projMatch = r.relPath.match(/^projects\/([^/_][^/]*)\.md$/);
-          if (projMatch) touchedProjects.add(projMatch[1]);
+          if (projMatch) touchedProjects.add(slug(projMatch[1]));
           if (it.kind === "preference") {
             try { emitPreferencesCore(it.body ?? ""); } catch { /* best-effort */ }
           }
@@ -407,7 +407,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
         notesWritten++;
         if (it.project) touchedProjects.add(it.project);
         const projMatch2 = writeRelPath.match(/^projects\/([^/_][^/]*)\.md$/);
-        if (projMatch2) touchedProjects.add(projMatch2[1]);
+        if (projMatch2) touchedProjects.add(slug(projMatch2[1]));
       }
     } catch (e: any) {
       recordRejection(vaultPath(), {

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -251,14 +251,14 @@ export interface DistillEventsResult {
 export function readKnownProjectSlugs(vault: string): Set<string> {
   const override = process.env.SUPERBRAIN_KNOWN_SLUGS_OVERRIDE;
   if (override !== undefined) {
-    return new Set(override.split(",").map(s => s.trim().toLowerCase()).filter(Boolean));
+    return new Set(override.split(",").map(s => s.trim()).filter(Boolean).map(s => slug(s)));
   }
   const projectsDir = path.join(vault, "projects");
   const slugs = new Set<string>();
   try {
     for (const entry of fs.readdirSync(projectsDir)) {
       if (entry.endsWith(".md") && !entry.startsWith("_")) {
-        slugs.add(entry.slice(0, -3).toLowerCase());
+        slugs.add(slug(entry.slice(0, -3)));
       }
     }
   } catch { /* projects dir absent */ }

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -29,6 +29,7 @@ import { recordRejection } from "./rejectQueue.js";
 import { type NoteType } from "./templates.js";
 import { serializeNote } from "./frontmatter.js";
 import { attributionFromEnv } from "./attribution.js";
+import { parentSessionId, attributionFields } from "./sessionAttribution.js";
 import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
@@ -267,6 +268,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
   const attribution = attributionFromEnv();
   const env = getEnvelope(JSON.stringify(events));
   const sessionProj = resolveSessionProject(events);
+  const parent = parentSessionId();
   const PROJECT_SCOPED_KINDS = new Set<string>(["project_fact", "gotcha", "decision", "capture"]);
   const items = env.items;
   const routedByDate: Record<string, string[]> = {};
@@ -303,7 +305,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
       }
       const r = route(it);
       if (r.mode !== "create") {
-        const res0 = writeNote(r.relPath, { frontmatter: { ...r.frontmatter, ...attribution }, body: r.body, mode: r.mode });
+        const res0 = writeNote(r.relPath, { frontmatter: { ...r.frontmatter, ...attribution, ...attributionFields() }, body: r.body, mode: r.mode });
         if (res0.ok && res0.reason !== "duplicate-skipped") {
           try { await indexNote(r.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
           (routedByDate[it.date] ||= []).push(r.relPath);
@@ -393,7 +395,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
           writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
         }
       }
-      const res = writeNote(writeRelPath, { frontmatter: { ...writeFrontmatter, ...attribution }, body: writeBody, mode: r.mode });
+      const res = writeNote(writeRelPath, { frontmatter: { ...writeFrontmatter, ...attribution, ...attributionFields() }, body: writeBody, mode: r.mode });
       if (res.ok && res.reason !== "duplicate-skipped") {
         try { await indexNote(writeRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
         (routedByDate[it.date] ||= []).push(writeRelPath);
@@ -421,6 +423,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
         openThreads: env.openThreads,
         ...(sessionProj.dominant !== undefined ? { project: sessionProj.dominant } : {}),
         ...(sessionProj.all.length > 1 ? { projects: sessionProj.all } : {}),
+        ...(parent !== undefined ? { parentSessionId: parent } : {}),
       });
       const dn = buildDailyNote(d);
       writeNote(dn.relPath, { frontmatter: dn.frontmatter, body: dn.body, mode: dn.mode });

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -28,6 +28,7 @@ import { classify } from "./classification.js";
 import { recordRejection } from "./rejectQueue.js";
 import { type NoteType } from "./templates.js";
 import { serializeNote } from "./frontmatter.js";
+import { attributionFromEnv } from "./attribution.js";
 import { dedupAgainstVault } from "./distillDedup.js";
 import { openIndex } from "./searchIndex.js";
 import { embed } from "./embed.js";
@@ -263,6 +264,7 @@ export function readKnownProjectSlugs(vault: string): Set<string> {
 }
 
 export async function distillFromEvents(sid: string, events: any[]): Promise<DistillEventsResult> {
+  const attribution = attributionFromEnv();
   const env = getEnvelope(JSON.stringify(events));
   const sessionProj = resolveSessionProject(events);
   const PROJECT_SCOPED_KINDS = new Set<string>(["project_fact", "gotcha", "decision", "capture"]);
@@ -301,7 +303,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
       }
       const r = route(it);
       if (r.mode !== "create") {
-        const res0 = writeNote(r.relPath, { frontmatter: r.frontmatter, body: r.body, mode: r.mode });
+        const res0 = writeNote(r.relPath, { frontmatter: { ...r.frontmatter, ...attribution }, body: r.body, mode: r.mode });
         if (res0.ok && res0.reason !== "duplicate-skipped") {
           try { await indexNote(r.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
           (routedByDate[it.date] ||= []).push(r.relPath);
@@ -391,7 +393,7 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
           writeFailure(`classify failed for '${it.title}': ${e?.message || e}`);
         }
       }
-      const res = writeNote(writeRelPath, { frontmatter: writeFrontmatter, body: writeBody, mode: r.mode });
+      const res = writeNote(writeRelPath, { frontmatter: { ...writeFrontmatter, ...attribution }, body: writeBody, mode: r.mode });
       if (res.ok && res.reason !== "duplicate-skipped") {
         try { await indexNote(writeRelPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
         (routedByDate[it.date] ||= []).push(writeRelPath);

--- a/src/distillSweep.ts
+++ b/src/distillSweep.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+import { sessionsDir } from "./paths.js";
+import { writeFailure } from "./sentinel.js";
+
+const FLAG_EXT = ".needs-distill";
+
+export function flagPath(sid: string): string {
+  return path.join(sessionsDir(), `${sid}${FLAG_EXT}`);
+}
+
+export function listFlaggedSessions(): string[] {
+  try {
+    return fs.readdirSync(sessionsDir())
+      .filter((f) => f.endsWith(FLAG_EXT))
+      .map((f) => f.slice(0, f.length - FLAG_EXT.length));
+  } catch { return []; }
+}
+
+export function clearFlag(sid: string): void {
+  try { fs.rmSync(flagPath(sid), { force: true }); } catch { /* best-effort */ }
+}
+
+export async function sweepPendingDistills(
+  excludeSid: string,
+  distillOne: (sid: string) => Promise<void>,
+): Promise<void> {
+  for (const sid of listFlaggedSessions()) {
+    if (sid === excludeSid) { clearFlag(sid); continue; }
+    try {
+      await distillOne(sid);
+      clearFlag(sid);
+    } catch (e: any) {
+      writeFailure(`sweep distill failed for ${sid}: ${e?.message || e}`);
+    }
+  }
+}

--- a/src/distillerEngine.ts
+++ b/src/distillerEngine.ts
@@ -12,18 +12,15 @@ export function distillScriptPath(): string {
   // dist/src/distillerEngine.js  ->  dist/bin/sb-distill.js
   return fileURLToPath(new URL("../bin/sb-distill.js", import.meta.url));
 }
-export function buildDistillCommand(opts: { sessionId: string; cwd: string }): SpawnSpec {
-  // Spawn the in-process writer (bin/sb-distill.ts). It performs the real
-  // `claude -p` LLM call itself (getItems), then routes/writes/advances
-  // cursor/releases the lock. ANTHROPIC_API_KEY (if set) is inherited so the
-  // claude CLI uses the API path automatically — escape hatch, no command change.
+export function buildDistillCommand(opts: { sessionId: string; cwd: string; lockToken?: string }): SpawnSpec {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     SUPERBRAIN_CHILD: "1",
     SUPERBRAIN_SESSION_ID: opts.sessionId,
+    ...(opts.lockToken ? { SUPERBRAIN_LOCK_TOKEN: opts.lockToken } : {}),
   };
   return {
-    cmd: process.execPath, // node
+    cmd: process.execPath,
     args: [distillScriptPath()],
     options: { cwd: opts.cwd, env, detached: true, stdio: "ignore" },
   };

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -38,7 +38,12 @@ async function indexInto(ix: ReturnType<typeof openIndex>, relPath: string) {
   const created = typeof fm.created === "string" ? fm.created
     : fm.created instanceof Date ? (fm.created as Date).toISOString()
     : undefined;
-  ix.upsertNote(relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs, fm.project as string | undefined, created);
+  ix.upsertNote(
+    relPath, Math.floor(fs.statSync(abs).mtimeMs), sha(raw), chunks, embs,
+    fm.project as string | undefined, created,
+    typeof fm.type === "string" ? fm.type : undefined,
+    typeof fm.agent_role === "string" ? fm.agent_role : undefined,
+  );
   upsertEdges(ix.db, deriveEdges(relPath, fm));
 }
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -8,7 +8,7 @@ import { openIndex } from "./searchIndex.js";
 import { parseNote } from "./frontmatter.js";
 import { deriveEdges, deleteEdgesFrom, upsertEdges } from "./edges.js";
 import { slug as routerSlug } from "./router.js";
-import { buildProjectIndex, enumerateProjectSlugs, projectIndexRelPath } from "./projectIndex.js";
+import { buildProjectIndex, enumerateProjectSlugs } from "./projectIndex.js";
 
 const EXCLUDED = new Set([".trash", ".obsidian", ".git", "node_modules"]);
 
@@ -44,6 +44,7 @@ async function indexInto(ix: ReturnType<typeof openIndex>, relPath: string) {
     fm.project as string | undefined, created,
     typeof fm.type === "string" ? fm.type : undefined,
     typeof fm.agent_role === "string" ? fm.agent_role : undefined,
+    fm.generated === true,
   );
   upsertEdges(ix.db, deriveEdges(relPath, fm));
 }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -8,6 +8,7 @@ import { openIndex } from "./searchIndex.js";
 import { parseNote } from "./frontmatter.js";
 import { deriveEdges, deleteEdgesFrom, upsertEdges } from "./edges.js";
 import { slug as routerSlug } from "./router.js";
+import { buildProjectIndex, enumerateProjectSlugs, projectIndexRelPath } from "./projectIndex.js";
 
 const EXCLUDED = new Set([".trash", ".obsidian", ".git", "node_modules"]);
 
@@ -171,6 +172,17 @@ export async function reconcile(): Promise<{ added: number; updated: number; del
     }
     for (const rel of ix.allIndexedPaths())
       if (!presentSet.has(rel)) { ix.deleteNote(rel); res.deleted++; }
+    const slugs = enumerateProjectSlugs(root);
+    for (const projSlug of slugs) {
+      try {
+        const { relPath: idxRel, changed } = buildProjectIndex(projSlug);
+        if (changed) {
+          const wasPresent = presentSet.has(idxRel);
+          await indexInto(ix, idxRel);
+          if (wasPresent) res.updated++; else res.added++;
+        }
+      } catch { /* swallow per-project errors */ }
+    }
     return res;
   } finally { ix.close(); }
 }

--- a/src/lockfile.ts
+++ b/src/lockfile.ts
@@ -1,23 +1,51 @@
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { lockDir } from "./paths.js";
+
+const owned = new Map<string, string>();
+
+function readToken(dir: string): string | null {
+  try { return fs.readFileSync(path.join(dir, "token"), "utf8"); } catch { return null; }
+}
 
 export function acquireLock(name: string, opts: { maxAgeMs?: number } = {}): boolean {
   const dir = lockDir(name);
   fs.mkdirSync(path.dirname(dir), { recursive: true });
+  const token = process.env.SUPERBRAIN_LOCK_TOKEN || crypto.randomUUID();
   try {
     fs.mkdirSync(dir);
     fs.writeFileSync(path.join(dir, "pid"), String(process.pid));
+    fs.writeFileSync(path.join(dir, "token"), token);
+    owned.set(name, token);
     return true;
   } catch {
     const maxAgeMs = opts.maxAgeMs ?? 15 * 60 * 1000;
     try {
       const age = Date.now() - fs.statSync(dir).mtimeMs;
-      if (age > maxAgeMs) { releaseLock(name); fs.mkdirSync(dir); return true; }
+      if (age > maxAgeMs) {
+        forceRelease(name);
+        fs.mkdirSync(dir);
+        fs.writeFileSync(path.join(dir, "pid"), String(process.pid));
+        fs.writeFileSync(path.join(dir, "token"), token);
+        owned.set(name, token);
+        return true;
+      }
     } catch { /* race: someone removed it */ }
     return false;
   }
 }
-export function releaseLock(name: string): void {
+
+export function releaseLock(name: string, token?: string): void {
+  const dir = lockDir(name);
+  const onDisk = readToken(dir);
+  if (onDisk === null) { forceRelease(name); return; }
+  const mine = owned.get(name);
+  const presented = token ?? mine;
+  if (presented !== undefined && presented === onDisk) { forceRelease(name); }
+}
+
+function forceRelease(name: string): void {
   fs.rmSync(lockDir(name), { recursive: true, force: true });
+  owned.delete(name);
 }

--- a/src/mcpChildren.ts
+++ b/src/mcpChildren.ts
@@ -1,0 +1,23 @@
+import { childrenOf } from "./dailyState.js";
+
+export interface McpText { content: { type: "text"; text: string }[]; }
+
+export async function handleChildren(
+  args: { parentSessionId: string; date?: string },
+): Promise<McpText> {
+  const parent = (args?.parentSessionId || "").trim();
+  if (!parent) return { content: [{ type: "text", text: "No parent session id provided." }] };
+  const date = args?.date || new Date().toISOString().slice(0, 10);
+  const kids = childrenOf(date, parent);
+  if (!kids.length) {
+    return { content: [{ type: "text", text: `No child sessions for parent "${parent}" on ${date}.` }] };
+  }
+  const lines = kids.map(({ sessionId, entry }) => {
+    const projects = entry.projects?.length
+      ? entry.projects.join(", ")
+      : (entry.project || "—");
+    const threads = entry.openThreads.length ? entry.openThreads.join("; ") : "none";
+    return `- ${sessionId} [${projects}] — open: ${threads}`;
+  }).join("\n");
+  return { content: [{ type: "text", text: `Children of "${parent}" on ${date}:\n${lines}` }] };
+}

--- a/src/mcpSearch.ts
+++ b/src/mcpSearch.ts
@@ -2,12 +2,18 @@ import { hybridRecall, type Pointer } from "./recall.js";
 
 export interface McpText { content: { type: "text"; text: string }[]; }
 
-export async function handleSearch(args: { query: string; k?: number }): Promise<McpText> {
+export async function handleSearch(args: { query: string; k?: number; project?: string; type?: string; since?: string; role?: string }): Promise<McpText> {
   const q = (args?.query || "").trim();
   const k = Math.min(Math.max(args?.k ?? 8, 1), 20);
   if (!q) return { content: [{ type: "text", text: "No query provided." }] };
+  const opts = {
+    projectSlug: args.project?.trim() || undefined,
+    type: args.type?.trim() || undefined,
+    since: args.since?.trim() || undefined,
+    role: args.role?.trim() || undefined,
+  };
   let hits: Pointer[];
-  try { hits = await hybridRecall(q, k); } catch { hits = []; }
+  try { hits = await hybridRecall(q, k, opts); } catch { hits = []; }
   if (!hits.length) return { content: [{ type: "text", text: `No results for "${q}".` }] };
   const body = hits.map((p, i) =>
     `${i + 1}. [[${p.relPath.replace(/\.md$/, "")}]]${p.headingPath ? " › " + p.headingPath : ""}\n   ${p.excerpt}`

--- a/src/projectIndex.ts
+++ b/src/projectIndex.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { vaultPath } from "./paths.js";
 import { parseNote, serializeNote } from "./frontmatter.js";
 import { atomicWrite } from "./atomicWrite.js";
+import { slug } from "./router.js";
 
 const WALK_EXCLUDE = new Set([".trash", ".obsidian", ".git", "node_modules"]);
 const TYPE_ORDER = ["project", "decision", "lesson", "gotcha", "person", "capture"];
@@ -30,11 +31,11 @@ function walkVault(dir: string, root: string, acc: string[]) {
 
 export function projectOfNote(relPath: string, fm: Record<string, any>): string | null {
   if (fm.project && typeof fm.project === "string" && fm.project.trim()) {
-    return fm.project.trim().toLowerCase();
+    return slug(fm.project);
   }
   const parts = relPath.split("/");
   if (parts[0] === "projects" && parts.length === 2 && !parts[1].startsWith("_")) {
-    return parts[1].replace(/\.md$/, "").toLowerCase();
+    return slug(parts[1].replace(/\.md$/, ""));
   }
   return null;
 }
@@ -112,7 +113,7 @@ export function enumerateProjectSlugs(vaultRoot: string): string[] {
   try {
     for (const entry of fs.readdirSync(projectsDir)) {
       if (entry.endsWith(".md") && !entry.startsWith("_")) {
-        slugs.add(entry.slice(0, -3).toLowerCase());
+        slugs.add(slug(entry.slice(0, -3)));
       }
     }
   } catch { /* projects dir absent */ }

--- a/src/projectIndex.ts
+++ b/src/projectIndex.ts
@@ -5,7 +5,6 @@ import { parseNote, serializeNote } from "./frontmatter.js";
 import { atomicWrite } from "./atomicWrite.js";
 
 const WALK_EXCLUDE = new Set([".trash", ".obsidian", ".git", "node_modules"]);
-const ENUMERATE_EXCLUDE = new Set(["maps", "daily"]);
 const TYPE_ORDER = ["project", "decision", "lesson", "gotcha", "person", "capture"];
 const TYPE_PLURAL: Record<string, string> = {
   project: "Projects",
@@ -21,19 +20,8 @@ function walkVault(dir: string, root: string, acc: string[]) {
     if (e.isDirectory()) {
       if (WALK_EXCLUDE.has(e.name)) continue;
       const rel = path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/");
-      if (rel === "maps" || rel === "daily" || rel.startsWith("projects/_archive")) continue;
-      walk(path.join(dir, e.name), root, acc);
-    } else if (e.name.endsWith(".md")) {
-      acc.push(path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/"));
-    }
-  }
-}
-
-function walk(dir: string, root: string, acc: string[]) {
-  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (e.isDirectory()) {
-      if (WALK_EXCLUDE.has(e.name)) continue;
-      walk(path.join(dir, e.name), root, acc);
+      if (rel === "maps" || rel === "daily" || rel === "projects/_archive" || rel.startsWith("projects/_archive/")) continue;
+      walkVault(path.join(dir, e.name), root, acc);
     } else if (e.name.endsWith(".md")) {
       acc.push(path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/"));
     }

--- a/src/projectIndex.ts
+++ b/src/projectIndex.ts
@@ -1,0 +1,177 @@
+import fs from "node:fs";
+import path from "node:path";
+import { vaultPath } from "./paths.js";
+import { parseNote, serializeNote } from "./frontmatter.js";
+import { atomicWrite } from "./atomicWrite.js";
+
+const WALK_EXCLUDE = new Set([".trash", ".obsidian", ".git", "node_modules"]);
+const ENUMERATE_EXCLUDE = new Set(["maps", "daily"]);
+const TYPE_ORDER = ["project", "decision", "lesson", "gotcha", "person", "capture"];
+const TYPE_PLURAL: Record<string, string> = {
+  project: "Projects",
+  decision: "Decisions",
+  lesson: "Lessons",
+  gotcha: "Gotchas",
+  person: "People",
+  capture: "Captures",
+};
+
+function walkVault(dir: string, root: string, acc: string[]) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) {
+      if (WALK_EXCLUDE.has(e.name)) continue;
+      const rel = path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/");
+      if (rel === "maps" || rel === "daily" || rel.startsWith("projects/_archive")) continue;
+      walk(path.join(dir, e.name), root, acc);
+    } else if (e.name.endsWith(".md")) {
+      acc.push(path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/"));
+    }
+  }
+}
+
+function walk(dir: string, root: string, acc: string[]) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) {
+      if (WALK_EXCLUDE.has(e.name)) continue;
+      walk(path.join(dir, e.name), root, acc);
+    } else if (e.name.endsWith(".md")) {
+      acc.push(path.relative(root, path.join(dir, e.name)).replace(/\\/g, "/"));
+    }
+  }
+}
+
+export function projectOfNote(relPath: string, fm: Record<string, any>): string | null {
+  if (fm.project && typeof fm.project === "string" && fm.project.trim()) {
+    return fm.project.trim().toLowerCase();
+  }
+  const parts = relPath.split("/");
+  if (parts[0] === "projects" && parts.length === 2 && !parts[1].startsWith("_")) {
+    return parts[1].replace(/\.md$/, "").toLowerCase();
+  }
+  return null;
+}
+
+function extractHook(content: string, fm: Record<string, any>, relPath: string): string {
+  const lines = content.split("\n");
+  for (const line of lines) {
+    const m = line.match(/^#{1,2}\s+(.+)/);
+    if (m) return m[1].trim();
+  }
+  if (fm.title && typeof fm.title === "string") return fm.title.trim();
+  return path.basename(relPath, ".md");
+}
+
+export function collectProjectNotes(
+  vaultRoot: string,
+  slug: string,
+): { relPath: string; type: string; hook: string }[] {
+  const allPaths: string[] = [];
+  walkVault(vaultRoot, vaultRoot, allPaths);
+
+  const indexRelPath = `maps/${slug}-index.md`;
+  const results: { relPath: string; type: string; hook: string }[] = [];
+
+  for (const relPath of allPaths) {
+    if (relPath === indexRelPath) continue;
+    const abs = path.join(vaultRoot, relPath);
+    let raw: string;
+    try { raw = fs.readFileSync(abs, "utf8"); } catch { continue; }
+    const { data: fm, content } = parseNote(raw);
+    const proj = projectOfNote(relPath, fm);
+    if (proj !== slug) continue;
+    const type = typeof fm.type === "string" ? fm.type : "capture";
+    const hook = extractHook(content, fm, relPath);
+    results.push({ relPath, type, hook });
+  }
+
+  return results;
+}
+
+export function renderProjectIndexBody(
+  slug: string,
+  notes: { relPath: string; type: string; hook: string }[],
+): string {
+  const byType: Record<string, { relPath: string; hook: string }[]> = {};
+  for (const n of notes) {
+    (byType[n.type] ||= []).push({ relPath: n.relPath, hook: n.hook });
+  }
+  for (const type of Object.keys(byType)) {
+    byType[type].sort((a, b) => a.relPath.localeCompare(b.relPath));
+  }
+
+  let body = `# ${slug} — index\n\n`;
+  for (const type of TYPE_ORDER) {
+    const entries = byType[type];
+    if (!entries || entries.length === 0) continue;
+    const heading = TYPE_PLURAL[type] ?? (type.charAt(0).toUpperCase() + type.slice(1) + "s");
+    body += `## ${heading}\n\n`;
+    for (const e of entries) {
+      const noMd = e.relPath.replace(/\.md$/, "");
+      body += `- [[${noMd}]] — ${e.hook}\n`;
+    }
+    body += "\n";
+  }
+  return body;
+}
+
+export function projectIndexRelPath(slug: string): string {
+  return `maps/${slug}-index.md`;
+}
+
+export function enumerateProjectSlugs(vaultRoot: string): string[] {
+  const slugs = new Set<string>();
+  const projectsDir = path.join(vaultRoot, "projects");
+  try {
+    for (const entry of fs.readdirSync(projectsDir)) {
+      if (entry.endsWith(".md") && !entry.startsWith("_")) {
+        slugs.add(entry.slice(0, -3).toLowerCase());
+      }
+    }
+  } catch { /* projects dir absent */ }
+
+  const allPaths: string[] = [];
+  try { walkVault(vaultRoot, vaultRoot, allPaths); } catch { /* vault absent */ }
+  for (const relPath of allPaths) {
+    const abs = path.join(vaultRoot, relPath);
+    try {
+      const raw = fs.readFileSync(abs, "utf8");
+      const { data: fm } = parseNote(raw);
+      const proj = projectOfNote(relPath, fm);
+      if (proj) slugs.add(proj);
+    } catch { /* skip unreadable */ }
+  }
+
+  return Array.from(slugs).sort();
+}
+
+export function buildProjectIndex(slug: string): { relPath: string; changed: boolean } {
+  const root = vaultPath();
+  const notes = collectProjectNotes(root, slug);
+  const body = renderProjectIndexBody(slug, notes);
+  const relPath = projectIndexRelPath(slug);
+  const abs = path.join(root, relPath);
+
+  let existingBody: string | null = null;
+  if (fs.existsSync(abs)) {
+    try {
+      const raw = fs.readFileSync(abs, "utf8");
+      existingBody = parseNote(raw).content;
+    } catch { /* treat as missing */ }
+  }
+
+  if (existingBody === body) {
+    return { relPath, changed: false };
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const fm: Record<string, any> = {
+    type: "map",
+    project: slug,
+    superbrain: true,
+    generated: true,
+    created: today,
+    updated: today,
+  };
+  atomicWrite(abs, serializeNote(fm, body));
+  return { relPath, changed: true };
+}

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -4,6 +4,18 @@ import { embed } from "./embed.js";
 export interface Pointer { relPath: string; headingPath: string; anchor: string; excerpt: string; }
 
 const VECTOR_DISTANCE_CUTOFF = 1.0;
+const ARCHIVE_PENALTY_DEFAULT = 0.1;
+
+export function isArchivePath(relPath: string): boolean {
+  const norm = relPath.replace(/\\/g, "/");
+  return norm === "_archive" || norm.startsWith("_archive/") || norm.includes("/_archive/");
+}
+
+function archivePenalty(relPath: string): number {
+  if (!isArchivePath(relPath)) return 1;
+  const v = Number(process.env.SUPERBRAIN_ARCHIVE_PENALTY);
+  return Number.isFinite(v) && v > 0 ? v : ARCHIVE_PENALTY_DEFAULT;
+}
 
 function toPointers(hits: Hit[]): Pointer[] {
   return hits.map((h) => ({

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -169,13 +169,14 @@ async function hybridRecallWithProject(
   return combined;
 }
 
-type FilterMeta = { project: string | null; created: string | null; type: string | null; agentRole: string | null } | undefined;
+type FilterMeta = { project: string | null; created: string | null; type: string | null; agentRole: string | null; generated: boolean } | undefined;
 
 function passesMeta(
   m: FilterMeta,
   filters: { type?: string; since?: string; role?: string },
   roleActive: boolean,
 ): boolean {
+  if (m?.generated) return false;
   if (filters.type && m?.type !== filters.type) return false;
   if (filters.since) {
     const c = m?.created ? Date.parse(m.created) : NaN;

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -26,22 +26,23 @@ function isCrossProject(noteProject: string | undefined, projectSlug: string): b
 export async function hybridRecall(
   query: string,
   k: number,
-  opts?: { projectSlug?: string; excludeSlugs?: string[] },
+  opts?: { projectSlug?: string; excludeSlugs?: string[]; type?: string; since?: string; role?: string },
 ): Promise<Pointer[]> {
   let ix: Index | undefined;
   try {
     ix = openIndex();
 
-    // --- Embed the query (always; bm25Only is removed) ---
     let qv: Float32Array | undefined;
     try {
       [qv] = await embed([query]);
     } catch { /* degrade to bm25-only if embedding fails */ }
 
+    const filters = { type: opts?.type, since: opts?.since, role: opts?.role };
+
     if (opts?.projectSlug) {
-      return await hybridRecallWithProject(ix, query, k, opts.projectSlug, opts.excludeSlugs ?? [], qv);
+      return await hybridRecallWithProject(ix, query, k, opts.projectSlug, opts.excludeSlugs ?? [], qv, filters);
     }
-    return hybridRecallUnscoped(ix, query, k, opts?.excludeSlugs ?? [], qv);
+    return hybridRecallUnscoped(ix, query, k, opts?.excludeSlugs ?? [], qv, filters);
   } catch { return []; }
   finally { ix?.close(); }
 }
@@ -56,6 +57,7 @@ function hybridRecallUnscoped(
   k: number,
   excludeSlugs: string[],
   qv: Float32Array | undefined,
+  filters: { type?: string; since?: string; role?: string },
 ): Pointer[] {
   const bm = ix.bm25(query, k * 2);
   let vec: Hit[] = [];
@@ -72,7 +74,7 @@ function hybridRecallUnscoped(
   // Gate fix: return empty only when BOTH arms return nothing.
   if (bm.length === 0 && vec.length === 0) return [];
 
-  return applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, undefined);
+  return applyFusionAndFilter(ix, bm, vec, k, excludeSlugs, undefined, filters);
 }
 
 /**
@@ -87,6 +89,7 @@ async function hybridRecallWithProject(
   projectSlug: string,
   excludeSlugs: string[],
   qv: Float32Array | undefined,
+  filters: { type?: string; since?: string; role?: string },
 ): Promise<Pointer[]> {
   const fgSlots = Math.round(k * 0.75);
   const bgSlots = k - fgSlots;
@@ -102,7 +105,7 @@ async function hybridRecallWithProject(
   // Gate fix: if BM25 empty and vec empty, fall through to background only
   let foreground: Pointer[] = [];
   if (bm.length > 0 || vec.length > 0) {
-    foreground = applyFusionAndFilter(ix, bm, vec, fgSlots, excludeSlugs, projectSlug);
+    foreground = applyFusionAndFilter(ix, bm, vec, fgSlots, excludeSlugs, projectSlug, filters);
   }
 
   // Background: separate global-restricted query (always runs, never starved).
@@ -117,7 +120,7 @@ async function hybridRecallWithProject(
       bgVec = ix.vectorKNNGlobal(qv, bgSlots * 3);
     }
     if (bgBm.length > 0 || bgVec.length > 0) {
-      background = applyFusionAndFilter(ix, bgBm, bgVec, bgSlots, excludeSlugs, undefined);
+      background = applyFusionAndFilter(ix, bgBm, bgVec, bgSlots, excludeSlugs, undefined, filters);
     }
     // Fill remaining background slots from any available global notes.
     if (background.length < bgSlots) {
@@ -127,9 +130,13 @@ async function hybridRecallWithProject(
       ]);
       const need = bgSlots - background.length;
       const fallbackHits = ix.globalFallbackNotes(need + fgAndBgKeys.size);
+      const fallbackRelPaths = fallbackHits.map((h) => h.relPath);
+      const fallbackMeta = ix.getFilterMeta(fallbackRelPaths);
+      const fallbackRoleActive = !!filters.role && fallbackRelPaths.some((p) => fallbackMeta.get(p)?.agentRole != null);
       const extra = toPointers(fallbackHits.filter(
         (h) => !fgAndBgKeys.has(`${h.relPath}#${h.anchor}`) &&
-          !excludeSlugs.includes(h.relPath),
+          !excludeSlugs.includes(h.relPath) &&
+          passesMeta(fallbackMeta.get(h.relPath), filters, fallbackRoleActive),
       )).slice(0, need);
       background = [...background, ...extra];
     }
@@ -145,6 +152,22 @@ async function hybridRecallWithProject(
   return combined;
 }
 
+type FilterMeta = { project: string | null; created: string | null; type: string | null; agentRole: string | null } | undefined;
+
+function passesMeta(
+  m: FilterMeta,
+  filters: { type?: string; since?: string; role?: string },
+  roleActive: boolean,
+): boolean {
+  if (filters.type && m?.type !== filters.type) return false;
+  if (filters.since) {
+    const c = m?.created ? Date.parse(m.created) : NaN;
+    if (isNaN(c) || c < Date.parse(filters.since)) return false;
+  }
+  if (roleActive && m?.agentRole !== filters.role) return false;
+  return true;
+}
+
 /**
  * Apply RRF fusion of bm25 and vector arms, then filter, score, and slice to k.
  * When projectSlug is set, the isCrossProject filter is applied (fail-closed).
@@ -156,6 +179,7 @@ function applyFusionAndFilter(
   k: number,
   excludeSlugs: string[],
   projectSlug: string | undefined,
+  filters: { type?: string; since?: string; role?: string } = {},
 ): Pointer[] {
   if (bm.length === 0 && vec.length === 0) return [];
 
@@ -164,14 +188,17 @@ function applyFusionAndFilter(
     const exclude = new Set(excludeSlugs);
     const relPaths = [...new Set(bm.map((h) => h.relPath))];
     const projects = projectSlug ? ix.getProjectsForPaths(relPaths) : new Map<string, string>();
-    const created = ix.getCreatedForPaths(relPaths);
+    const meta = ix.getFilterMeta(relPaths);
+    const roleActive = !!filters.role && relPaths.some((p) => meta.get(p)?.agentRole != null);
     const now = Date.now();
     const scored = bm
       .filter((h) => !exclude.has(h.relPath))
       .filter((h) => !projectSlug || !isCrossProject(projects.get(h.relPath), projectSlug))
+      .filter((h) => passesMeta(meta.get(h.relPath), filters, roleActive))
       .map((h) => {
+        const created = meta.get(h.relPath)?.created ?? undefined;
         let score = boostScore(1, projects.get(h.relPath), projectSlug);
-        score *= decayFactor(created.get(h.relPath), now);
+        score *= decayFactor(created, now);
         return { h, score };
       })
       .sort((a, b) => b.score - a.score)
@@ -184,15 +211,18 @@ function applyFusionAndFilter(
     const exclude = new Set(excludeSlugs);
     const relPaths = [...new Set(vec.map((h) => h.relPath))];
     const projects = projectSlug ? ix.getProjectsForPaths(relPaths) : new Map<string, string>();
-    const created = ix.getCreatedForPaths(relPaths);
+    const meta = ix.getFilterMeta(relPaths);
+    const roleActive = !!filters.role && relPaths.some((p) => meta.get(p)?.agentRole != null);
     const now = Date.now();
     const scored = vec
       .filter((h) => h.distance == null || h.distance <= VECTOR_DISTANCE_CUTOFF)
       .filter((h) => !exclude.has(h.relPath))
       .filter((h) => !projectSlug || !isCrossProject(projects.get(h.relPath), projectSlug))
+      .filter((h) => passesMeta(meta.get(h.relPath), filters, roleActive))
       .map((h) => {
+        const created = meta.get(h.relPath)?.created ?? undefined;
         let score = boostScore(1, projects.get(h.relPath), projectSlug);
-        score *= decayFactor(created.get(h.relPath), now);
+        score *= decayFactor(created, now);
         return { h, score };
       })
       .sort((a, b) => b.score - a.score)
@@ -211,7 +241,8 @@ function applyFusionAndFilter(
   const projects = projectSlug
     ? ix.getProjectsForPaths(candidateRelPaths)
     : new Map<string, string>();
-  const created = ix.getCreatedForPaths(candidateRelPaths);
+  const meta = ix.getFilterMeta(candidateRelPaths);
+  const roleActive = !!filters.role && candidateRelPaths.some((p) => meta.get(p)?.agentRole != null);
   const now = Date.now();
   const exclude = new Set(excludeSlugs);
   const decayed = fused
@@ -220,8 +251,10 @@ function applyFusionAndFilter(
       if (!hit) return null;
       if (exclude.has(hit.relPath)) return null;
       if (projectSlug && isCrossProject(projects.get(hit.relPath), projectSlug)) return null;
+      if (!passesMeta(meta.get(hit.relPath), filters, roleActive)) return null;
+      const created = meta.get(hit.relPath)?.created ?? undefined;
       let score = boostScore(e.score, projects.get(hit.relPath), projectSlug);
-      score *= decayFactor(created.get(hit.relPath), now);
+      score *= decayFactor(created, now);
       return { id: e.id, score };
     })
     .filter((e): e is { id: string; score: number } => e !== null)

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -211,6 +211,7 @@ function applyFusionAndFilter(
         const created = meta.get(h.relPath)?.created ?? undefined;
         let score = boostScore(1, projects.get(h.relPath), projectSlug);
         score *= decayFactor(created, now);
+        score *= archivePenalty(h.relPath);
         return { h, score };
       })
       .sort((a, b) => b.score - a.score)
@@ -235,6 +236,7 @@ function applyFusionAndFilter(
         const created = meta.get(h.relPath)?.created ?? undefined;
         let score = boostScore(1, projects.get(h.relPath), projectSlug);
         score *= decayFactor(created, now);
+        score *= archivePenalty(h.relPath);
         return { h, score };
       })
       .sort((a, b) => b.score - a.score)
@@ -267,6 +269,7 @@ function applyFusionAndFilter(
       const created = meta.get(hit.relPath)?.created ?? undefined;
       let score = boostScore(e.score, projects.get(hit.relPath), projectSlug);
       score *= decayFactor(created, now);
+      score *= archivePenalty(hit.relPath);
       return { id: e.id, score };
     })
     .filter((e): e is { id: string; score: number } => e !== null)

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -141,15 +141,20 @@ async function hybridRecallWithProject(
         ...background.map((p) => `${p.relPath}#${p.anchor}`),
       ]);
       const need = bgSlots - background.length;
-      const fallbackHits = ix.globalFallbackNotes(need + fgAndBgKeys.size);
+      const fallbackHits = ix.globalFallbackNotes((need + fgAndBgKeys.size) * 3);
       const fallbackRelPaths = fallbackHits.map((h) => h.relPath);
       const fallbackMeta = ix.getFilterMeta(fallbackRelPaths);
       const fallbackRoleActive = !!filters.role && fallbackRelPaths.some((p) => fallbackMeta.get(p)?.agentRole != null);
-      const extra = toPointers(fallbackHits.filter(
-        (h) => !fgAndBgKeys.has(`${h.relPath}#${h.anchor}`) &&
-          !excludeSlugs.includes(h.relPath) &&
-          passesMeta(fallbackMeta.get(h.relPath), filters, fallbackRoleActive),
-      )).slice(0, need);
+      const extra = toPointers(
+        fallbackHits
+          .filter(
+            (h) => !fgAndBgKeys.has(`${h.relPath}#${h.anchor}`) &&
+              !excludeSlugs.includes(h.relPath) &&
+              passesMeta(fallbackMeta.get(h.relPath), filters, fallbackRoleActive),
+          )
+          .sort((a, b) => archivePenalty(b.relPath) - archivePenalty(a.relPath))
+          .slice(0, need),
+      );
       background = [...background, ...extra];
     }
   } catch { /* background is best-effort */ }

--- a/src/searchIndex.ts
+++ b/src/searchIndex.ts
@@ -40,7 +40,8 @@ export interface Index {
              project?: unknown,
              created?: unknown,
              noteType?: unknown,
-             agentRole?: unknown): void;
+             agentRole?: unknown,
+             generated?: boolean): void;
   deleteNote(relPath: string): void;
   bm25(query: string, k: number): Hit[];
   vectorKNN(v: Float32Array, k: number): Hit[];
@@ -53,7 +54,7 @@ export interface Index {
   getNoteMeta(relPath: string): { mtime: number; hash: string } | null;
   getProjectsForPaths(relPaths: string[]): Map<string, string>;
   getCreatedForPaths(relPaths: string[]): Map<string, string>;
-  getFilterMeta(relPaths: string[]): Map<string, { project: string | null; created: string | null; type: string | null; agentRole: string | null }>;
+  getFilterMeta(relPaths: string[]): Map<string, { project: string | null; created: string | null; type: string | null; agentRole: string | null; generated: boolean }>;
   allIndexedPaths(): string[];
   close(): void;
 }
@@ -72,7 +73,7 @@ export function rrfWithScores(lists: string[][], k: number, c = 60): { id: strin
 function ensureVecTable(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS embed_meta (key TEXT PRIMARY KEY, value TEXT);
-    CREATE TABLE IF NOT EXISTS notes (rel_path TEXT PRIMARY KEY, mtime INTEGER, hash TEXT, project TEXT, created TEXT, note_type TEXT, agent_role TEXT);
+    CREATE TABLE IF NOT EXISTS notes (rel_path TEXT PRIMARY KEY, mtime INTEGER, hash TEXT, project TEXT, created TEXT, note_type TEXT, agent_role TEXT, generated INTEGER);
     CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY, rel_path TEXT, heading_path TEXT, anchor TEXT, text TEXT);
     CREATE INDEX IF NOT EXISTS chunks_rel ON chunks(rel_path);
@@ -115,6 +116,7 @@ export function openIndex(): Index {
   if (!cols.includes("created")) db.exec("ALTER TABLE notes ADD COLUMN created TEXT");
   if (!cols.includes("note_type")) db.exec("ALTER TABLE notes ADD COLUMN note_type TEXT");
   if (!cols.includes("agent_role")) db.exec("ALTER TABLE notes ADD COLUMN agent_role TEXT");
+  if (!cols.includes("generated")) db.exec("ALTER TABLE notes ADD COLUMN generated INTEGER");
   ensureEdgesTable(db);
 
   const delByPath = db.transaction((relPath: string) => {
@@ -130,11 +132,11 @@ export function openIndex(): Index {
   const insChunk = db.prepare("INSERT INTO chunks(rel_path,heading_path,anchor,text) VALUES (?,?,?,?)");
   const insFts = db.prepare("INSERT INTO chunks_fts(rowid,text) VALUES (?,?)");
   const insVec = db.prepare("INSERT INTO vec_chunks(chunk_id,embedding) VALUES (?,vec_int8(?))");
-  const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created,note_type,agent_role) VALUES (?,?,?,?,?,?,?)");
+  const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created,note_type,agent_role,generated) VALUES (?,?,?,?,?,?,?,?)");
 
   const upsert = db.transaction((relPath: string, mtime: number, hash: string,
       chunks: { headingPath: string; anchor: string; text: string }[], embs: Float32Array[],
-      project?: unknown, created?: unknown, noteType?: unknown, agentRole?: unknown) => {
+      project?: unknown, created?: unknown, noteType?: unknown, agentRole?: unknown, generated?: boolean) => {
     delByPath(relPath);
     const capped = chunks.slice(0, CHUNK_CAP);
     capped.forEach((c, i) => {
@@ -142,7 +144,7 @@ export function openIndex(): Index {
       insFts.run(id, (c.headingPath ? c.headingPath + " " : "") + c.text);
       insVec.run(BigInt(id), serializeInt8ForSql(quantizeToInt8(embs[i])));
     });
-    insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null), toScalarString(noteType ?? null), toScalarString(agentRole ?? null));
+    insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null), toScalarString(noteType ?? null), toScalarString(agentRole ?? null), generated ? 1 : 0);
   });
 
   const hydrate = (ids: number[]): Hit[] => ids.map((id) => {
@@ -152,7 +154,7 @@ export function openIndex(): Index {
 
   return {
     db,
-    upsertNote: (rp: string, mt: number, h: string, c: { headingPath: string; anchor: string; text: string }[], e: Float32Array[], project?: unknown, created?: unknown, noteType?: unknown, agentRole?: unknown) => upsert(rp, mt, h, c, e, project, created, noteType, agentRole),
+    upsertNote: (rp: string, mt: number, h: string, c: { headingPath: string; anchor: string; text: string }[], e: Float32Array[], project?: unknown, created?: unknown, noteType?: unknown, agentRole?: unknown, generated?: boolean) => upsert(rp, mt, h, c, e, project, created, noteType, agentRole, generated),
     deleteNote: (rp) => delByPath(rp),
     bm25: (q, k) => {
       const terms = q.replace(/[^\w\s]/g, " ").trim().split(/\s+/).filter(Boolean);
@@ -254,10 +256,10 @@ export function openIndex(): Index {
       if (relPaths.length === 0) return new Map();
       const placeholders = relPaths.map(() => "?").join(",");
       const rows = db.prepare(
-        `SELECT rel_path, project, created, note_type, agent_role FROM notes WHERE rel_path IN (${placeholders})`
-      ).all(...relPaths) as { rel_path: string; project: string | null; created: string | null; note_type: string | null; agent_role: string | null }[];
+        `SELECT rel_path, project, created, note_type, agent_role, generated FROM notes WHERE rel_path IN (${placeholders})`
+      ).all(...relPaths) as { rel_path: string; project: string | null; created: string | null; note_type: string | null; agent_role: string | null; generated: number | null }[];
       return new Map(rows.map((r) => [r.rel_path, {
-        project: r.project, created: r.created, type: r.note_type, agentRole: r.agent_role,
+        project: r.project, created: r.created, type: r.note_type, agentRole: r.agent_role, generated: r.generated === 1,
       }]));
     },
     getNoteMeta: (rp) => {

--- a/src/searchIndex.ts
+++ b/src/searchIndex.ts
@@ -38,7 +38,9 @@ export interface Index {
              chunks: { headingPath: string; anchor: string; text: string }[],
              embeddings: Float32Array[],
              project?: unknown,
-             created?: unknown): void;
+             created?: unknown,
+             noteType?: unknown,
+             agentRole?: unknown): void;
   deleteNote(relPath: string): void;
   bm25(query: string, k: number): Hit[];
   vectorKNN(v: Float32Array, k: number): Hit[];
@@ -51,6 +53,7 @@ export interface Index {
   getNoteMeta(relPath: string): { mtime: number; hash: string } | null;
   getProjectsForPaths(relPaths: string[]): Map<string, string>;
   getCreatedForPaths(relPaths: string[]): Map<string, string>;
+  getFilterMeta(relPaths: string[]): Map<string, { project: string | null; created: string | null; type: string | null; agentRole: string | null }>;
   allIndexedPaths(): string[];
   close(): void;
 }
@@ -69,7 +72,7 @@ export function rrfWithScores(lists: string[][], k: number, c = 60): { id: strin
 function ensureVecTable(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS embed_meta (key TEXT PRIMARY KEY, value TEXT);
-    CREATE TABLE IF NOT EXISTS notes (rel_path TEXT PRIMARY KEY, mtime INTEGER, hash TEXT, project TEXT, created TEXT);
+    CREATE TABLE IF NOT EXISTS notes (rel_path TEXT PRIMARY KEY, mtime INTEGER, hash TEXT, project TEXT, created TEXT, note_type TEXT, agent_role TEXT);
     CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY, rel_path TEXT, heading_path TEXT, anchor TEXT, text TEXT);
     CREATE INDEX IF NOT EXISTS chunks_rel ON chunks(rel_path);
@@ -110,6 +113,8 @@ export function openIndex(): Index {
   const cols = (db.pragma("table_info(notes)") as { name: string }[]).map((c) => c.name);
   if (!cols.includes("project")) db.exec("ALTER TABLE notes ADD COLUMN project TEXT");
   if (!cols.includes("created")) db.exec("ALTER TABLE notes ADD COLUMN created TEXT");
+  if (!cols.includes("note_type")) db.exec("ALTER TABLE notes ADD COLUMN note_type TEXT");
+  if (!cols.includes("agent_role")) db.exec("ALTER TABLE notes ADD COLUMN agent_role TEXT");
   ensureEdgesTable(db);
 
   const delByPath = db.transaction((relPath: string) => {
@@ -125,11 +130,11 @@ export function openIndex(): Index {
   const insChunk = db.prepare("INSERT INTO chunks(rel_path,heading_path,anchor,text) VALUES (?,?,?,?)");
   const insFts = db.prepare("INSERT INTO chunks_fts(rowid,text) VALUES (?,?)");
   const insVec = db.prepare("INSERT INTO vec_chunks(chunk_id,embedding) VALUES (?,vec_int8(?))");
-  const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created) VALUES (?,?,?,?,?)");
+  const insNote = db.prepare("INSERT OR REPLACE INTO notes(rel_path,mtime,hash,project,created,note_type,agent_role) VALUES (?,?,?,?,?,?,?)");
 
   const upsert = db.transaction((relPath: string, mtime: number, hash: string,
       chunks: { headingPath: string; anchor: string; text: string }[], embs: Float32Array[],
-      project?: unknown, created?: unknown) => {
+      project?: unknown, created?: unknown, noteType?: unknown, agentRole?: unknown) => {
     delByPath(relPath);
     const capped = chunks.slice(0, CHUNK_CAP);
     capped.forEach((c, i) => {
@@ -137,7 +142,7 @@ export function openIndex(): Index {
       insFts.run(id, (c.headingPath ? c.headingPath + " " : "") + c.text);
       insVec.run(BigInt(id), serializeInt8ForSql(quantizeToInt8(embs[i])));
     });
-    insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null));
+    insNote.run(relPath, mtime, hash, toScalarString(project ?? null), toScalarString(created ?? null), toScalarString(noteType ?? null), toScalarString(agentRole ?? null));
   });
 
   const hydrate = (ids: number[]): Hit[] => ids.map((id) => {
@@ -147,7 +152,7 @@ export function openIndex(): Index {
 
   return {
     db,
-    upsertNote: (rp: string, mt: number, h: string, c: { headingPath: string; anchor: string; text: string }[], e: Float32Array[], project?: unknown, created?: unknown) => upsert(rp, mt, h, c, e, project, created),
+    upsertNote: (rp: string, mt: number, h: string, c: { headingPath: string; anchor: string; text: string }[], e: Float32Array[], project?: unknown, created?: unknown, noteType?: unknown, agentRole?: unknown) => upsert(rp, mt, h, c, e, project, created, noteType, agentRole),
     deleteNote: (rp) => delByPath(rp),
     bm25: (q, k) => {
       const terms = q.replace(/[^\w\s]/g, " ").trim().split(/\s+/).filter(Boolean);
@@ -244,6 +249,16 @@ export function openIndex(): Index {
         `SELECT rel_path, created FROM notes WHERE rel_path IN (${placeholders}) AND created IS NOT NULL`
       ).all(...relPaths) as { rel_path: string; created: string }[];
       return new Map(rows.map((r) => [r.rel_path, r.created]));
+    },
+    getFilterMeta: (relPaths: string[]) => {
+      if (relPaths.length === 0) return new Map();
+      const placeholders = relPaths.map(() => "?").join(",");
+      const rows = db.prepare(
+        `SELECT rel_path, project, created, note_type, agent_role FROM notes WHERE rel_path IN (${placeholders})`
+      ).all(...relPaths) as { rel_path: string; project: string | null; created: string | null; note_type: string | null; agent_role: string | null }[];
+      return new Map(rows.map((r) => [r.rel_path, {
+        project: r.project, created: r.created, type: r.note_type, agentRole: r.agent_role,
+      }]));
     },
     getNoteMeta: (rp) => {
       const r = db.prepare("SELECT mtime,hash FROM notes WHERE rel_path=?").get(rp) as any;

--- a/src/sessionAttribution.ts
+++ b/src/sessionAttribution.ts
@@ -1,0 +1,11 @@
+export function parentSessionId(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const v = env.SUPERBRAIN_PARENT_SESSION_ID;
+  if (typeof v !== "string") return undefined;
+  const t = v.trim();
+  return t ? t : undefined;
+}
+
+export function attributionFields(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const p = parentSessionId(env);
+  return p ? { parent_session_id: p } : {};
+}

--- a/src/sessionGc.ts
+++ b/src/sessionGc.ts
@@ -16,6 +16,7 @@ const KNOWN_EXTENSIONS = new Set([
   ".ndjson",
   ".cursor",
   ".pending",
+  ".needs-distill",
   ".salience.json",
   ".injected.json",
   ".turns.json",

--- a/src/sessionGcRun.ts
+++ b/src/sessionGcRun.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pruneSessionFiles, type SessionGcResult } from "./sessionGc.js";
+
+const STAMP_FILE = "session-gc.stamp";
+const DEFAULT_MIN_INTERVAL_HOURS = 24;
+
+export interface SessionGcRunResult {
+  ran: boolean;
+  skippedByCadence: boolean;
+  result?: SessionGcResult;
+}
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return fallback;
+  const v = Number(raw);
+  return Number.isFinite(v) ? v : fallback;
+}
+
+export function runSessionGcOncePerDay(
+  dataDirPath: string,
+  opts?: { now?: number },
+): SessionGcRunResult {
+  if (process.env.SUPERBRAIN_GC_DISABLE === "1") {
+    return { ran: false, skippedByCadence: false };
+  }
+
+  const now = opts?.now ?? Date.now();
+  const minIntervalHours = envNumber("SUPERBRAIN_GC_MIN_INTERVAL_HOURS", DEFAULT_MIN_INTERVAL_HOURS);
+  const minIntervalMs = minIntervalHours * 60 * 60 * 1000;
+  const stampPath = path.join(dataDirPath, STAMP_FILE);
+
+  if (minIntervalMs > 0) {
+    try {
+      const stat = fs.statSync(stampPath);
+      if (now - stat.mtimeMs < minIntervalMs) {
+        return { ran: false, skippedByCadence: true };
+      }
+    } catch {
+      // no stamp yet — first run
+    }
+  }
+
+  const maxAgeDays = envNumber("SUPERBRAIN_GC_MAX_AGE_DAYS", 30);
+  const dryRun = process.env.SUPERBRAIN_GC_DRY_RUN === "1";
+
+  const result = pruneSessionFiles(dataDirPath, { maxAgeDays, dryRun });
+
+  try {
+    fs.mkdirSync(dataDirPath, { recursive: true });
+    fs.writeFileSync(stampPath, new Date(now).toISOString());
+  } catch {
+    // stamp write failure is non-fatal
+  }
+
+  return { ran: true, skippedByCadence: false, result };
+}

--- a/src/vaultWriter.ts
+++ b/src/vaultWriter.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { vaultPath } from "./paths.js";
 import { serializeNote, parseNote, validateFrontmatter } from "./frontmatter.js";
-import { atomicWrite, readWithChecksum } from "./atomicWrite.js";
-import { appendDatedSectionWithArchive, initializeProjectNote } from "./projectWriter.js";
+import { atomicWrite, readWithChecksum, casWrite } from "./atomicWrite.js";
+import { appendDatedSectionWithArchive, initializeProjectNote, ArchivedSection } from "./projectWriter.js";
 
 const ALLOWED_EXT = new Set([".md"]);
 const EXCLUDED = ["/.obsidian/", "/.git/", "/node_modules/", "/.trash/"];
@@ -49,45 +49,47 @@ export function writeNote(rel: string, args: WriteArgs): WriteResult {
 
   const existing = readWithChecksum(abs);
 
-  // Project notes (projects/<slug>.md) get structured dated subsections under
-  // "## Recent activity" with auto-archiving when the file exceeds 20 KB.
   const relNorm = rel.replace(/\\/g, "/");
   if (relNorm.startsWith("projects/") && !relNorm.startsWith("projects/_archive/")) {
     const stamp = new Date().toISOString().slice(0, 10);
     const date = (args.frontmatter.created as string | undefined) || stamp;
     try {
-      // Determine current body (content portion only, no frontmatter)
-      let currentBody: string;
-      let baseFm: Record<string, any>;
-      if (existing) {
-        const parsed = parseNote(existing.content);
-        // Dedup: skip if the normalized new body already appears in the file.
-        const newNorm = normBody(args.body);
-        if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {
-          return { ok: true, path: abs, reason: "duplicate-skipped" };
+      let archived: ArchivedSection[] = [];
+      let dedupHit = false;
+      casWrite(abs, (currentRaw) => {
+        let currentBody: string;
+        let baseFm: Record<string, any>;
+        if (currentRaw) {
+          const parsed = parseNote(currentRaw);
+          const newNorm = normBody(args.body);
+          if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {
+            dedupHit = true;
+            return currentRaw;
+          }
+          currentBody = parsed.content;
+          baseFm = parsed.data;
+        } else {
+          const slug = path.basename(abs, ".md");
+          currentBody = initializeProjectNote(slug, args.frontmatter);
+          baseFm = {};
         }
-        currentBody = parsed.content;
-        baseFm = parsed.data;
-      } else {
-        const slug = path.basename(abs, ".md");
-        currentBody = initializeProjectNote(slug, args.frontmatter);
-        baseFm = {};
-      }
-      // Backfill ## Recent activity if the note pre-dates this feature
-      if (
-        !currentBody.includes("\n## Recent activity\n") &&
-        !currentBody.endsWith("## Recent activity") &&
-        !currentBody.startsWith("## Recent activity\n")
-      ) {
-        currentBody = currentBody.replace(/\s+$/, "") + "\n\n## Recent activity\n";
-      }
-      const mergedFm = { ...baseFm, ...args.frontmatter, updated: stamp };
-      const fmOverhead = Buffer.byteLength(serializeNote(mergedFm, ""), "utf8");
-      const r = appendDatedSectionWithArchive(currentBody, date, args.body, {
-        sizeCap: Math.max(8192, (Number(process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES) || 32 * 1024) - fmOverhead),
+        if (
+          !currentBody.includes("\n## Recent activity\n") &&
+          !currentBody.endsWith("## Recent activity") &&
+          !currentBody.startsWith("## Recent activity\n")
+        ) {
+          currentBody = currentBody.replace(/\s+$/, "") + "\n\n## Recent activity\n";
+        }
+        const mergedFm = { ...baseFm, ...args.frontmatter, updated: stamp };
+        const fmOverhead = Buffer.byteLength(serializeNote(mergedFm, ""), "utf8");
+        const r = appendDatedSectionWithArchive(currentBody, date, args.body, {
+          sizeCap: Math.max(8192, (Number(process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES) || 32 * 1024) - fmOverhead),
+        });
+        archived = r.archived;
+        return serializeNote(mergedFm, r.body);
       });
-      atomicWrite(abs, serializeNote(mergedFm, r.body));
-      for (const a of r.archived) {
+      if (dedupHit) return { ok: true, path: abs, reason: "duplicate-skipped" };
+      for (const a of archived) {
         const year = a.date === "0000-00-00"
           ? new Date().toISOString().slice(0, 4)
           : a.date.slice(0, 4);
@@ -115,16 +117,16 @@ export function writeNote(rel: string, args: WriteArgs): WriteResult {
       }
       return { ok: true, path: abs };
     } catch (_e) {
-      // Fail open: fall back to legacy plain append so the distiller never crashes
       if (!existing) {
         atomicWrite(abs, serializeNote(args.frontmatter, args.body));
         return { ok: true, path: abs };
       }
-      const stamp2 = new Date().toISOString().slice(0, 16).replace("T", " ");
-      const parsed = parseNote(existing.content);
-      const mergedFm = { ...parsed.data, ...args.frontmatter, updated: stamp2.slice(0, 10) };
-      const appended = `${parsed.content.replace(/\s+$/, "")}\n\n## ${stamp2}\n\n${args.body}\n`;
-      atomicWrite(abs, serializeNote(mergedFm, appended));
+      casWrite(abs, (currentRaw) => {
+        const stamp2 = new Date().toISOString().slice(0, 16).replace("T", " ");
+        const parsed = parseNote(currentRaw ?? "");
+        const mergedFm = { ...parsed.data, ...args.frontmatter, updated: stamp2.slice(0, 10) };
+        return serializeNote(mergedFm, `${parsed.content.replace(/\s+$/, "")}\n\n## ${stamp2}\n\n${args.body}\n`);
+      });
       return { ok: true, path: abs };
     }
   }
@@ -133,20 +135,19 @@ export function writeNote(rel: string, args: WriteArgs): WriteResult {
     atomicWrite(abs, serializeNote(args.frontmatter, args.body));
     return { ok: true, path: abs };
   }
-  // Existing file: never blind-overwrite. Append distilled body under a dated section.
-  const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
-  const parsed = parseNote(existing.content);
-  // Dedup: the distiller can re-emit the same project_fact / gotcha across
-  // adjacent runs (the model has no memory of prior emissions). Skip the
-  // append if the normalized new body already appears in the file. The 40-
-  // char floor avoids false positives on generic phrasing.
-  const newNorm = normBody(args.body);
-  if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {
-    return { ok: true, path: abs, reason: "duplicate-skipped" };
-  }
-  const mergedFm = { ...parsed.data, ...args.frontmatter, updated: stamp.slice(0, 10) };
-  const appended = `${parsed.content.replace(/\s+$/, "")}\n\n## ${stamp}\n\n${args.body}\n`;
-  atomicWrite(abs, serializeNote(mergedFm, appended));
+  let dedupHit = false;
+  casWrite(abs, (currentRaw) => {
+    const parsed = parseNote(currentRaw ?? "");
+    const newNorm = normBody(args.body);
+    if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {
+      dedupHit = true;
+      return currentRaw ?? "";
+    }
+    const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
+    const mergedFm = { ...parsed.data, ...args.frontmatter, updated: stamp.slice(0, 10) };
+    return serializeNote(mergedFm, `${parsed.content.replace(/\s+$/, "")}\n\n## ${stamp}\n\n${args.body}\n`);
+  });
+  if (dedupHit) return { ok: true, path: abs, reason: "duplicate-skipped" };
   return { ok: true, path: abs };
 }
 

--- a/src/vaultWriter.ts
+++ b/src/vaultWriter.ts
@@ -57,6 +57,8 @@ export function writeNote(rel: string, args: WriteArgs): WriteResult {
       let archived: ArchivedSection[] = [];
       let dedupHit = false;
       casWrite(abs, (currentRaw) => {
+        dedupHit = false;
+        archived = [];
         let currentBody: string;
         let baseFm: Record<string, any>;
         if (currentRaw) {
@@ -137,6 +139,7 @@ export function writeNote(rel: string, args: WriteArgs): WriteResult {
   }
   let dedupHit = false;
   casWrite(abs, (currentRaw) => {
+    dedupHit = false;
     const parsed = parseNote(currentRaw ?? "");
     const newNorm = normBody(args.body);
     if (newNorm.length >= 40 && normBody(parsed.content).includes(newNorm)) {

--- a/tests/attribution.test.ts
+++ b/tests/attribution.test.ts
@@ -1,0 +1,43 @@
+import { it, expect, afterEach } from "vitest";
+import { attributionFromEnv } from "../src/attribution";
+
+const SAVED = { ...process.env };
+afterEach(() => {
+  delete process.env.SUPERBRAIN_SESSION_ID;
+  delete process.env.SUPERBRAIN_AGENT_ROLE;
+  Object.assign(process.env, SAVED);
+});
+
+it("returns both fields when both env vars are set", () => {
+  process.env.SUPERBRAIN_SESSION_ID = "S1";
+  process.env.SUPERBRAIN_AGENT_ROLE = "engineer";
+  expect(attributionFromEnv()).toEqual({ session_id: "S1", agent_role: "engineer" });
+});
+
+it("omits agent_role when SUPERBRAIN_AGENT_ROLE is unset", () => {
+  process.env.SUPERBRAIN_SESSION_ID = "S1";
+  delete process.env.SUPERBRAIN_AGENT_ROLE;
+  const r = attributionFromEnv();
+  expect(r).toEqual({ session_id: "S1" });
+  expect("agent_role" in r).toBe(false);
+});
+
+it("returns an empty object when neither env var is set", () => {
+  delete process.env.SUPERBRAIN_SESSION_ID;
+  delete process.env.SUPERBRAIN_AGENT_ROLE;
+  expect(Object.keys(attributionFromEnv())).toHaveLength(0);
+});
+
+it("omits session_id when only agent_role is set", () => {
+  delete process.env.SUPERBRAIN_SESSION_ID;
+  process.env.SUPERBRAIN_AGENT_ROLE = "qa";
+  const r = attributionFromEnv();
+  expect("session_id" in r).toBe(false);
+  expect(r.agent_role).toBe("qa");
+});
+
+it("treats empty-string env values as unset", () => {
+  process.env.SUPERBRAIN_SESSION_ID = "";
+  process.env.SUPERBRAIN_AGENT_ROLE = "";
+  expect(Object.keys(attributionFromEnv())).toHaveLength(0);
+});

--- a/tests/attributionDistill.test.ts
+++ b/tests/attributionDistill.test.ts
@@ -1,0 +1,89 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-attr-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-attr-vault-"));
+});
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+function seedSession(sid: string) {
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  fs.writeFileSync(
+    path.join(TMP_DATA, `sessions/${sid}.ndjson`),
+    JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n",
+  );
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+  fs.writeFileSync(path.join(TMP_DATA, `sessions/${sid}.prompt.json`), "{}");
+}
+
+const STUB_ITEMS = [
+  { kind: "decision", title: "Pick X", project: "attrproj",
+    body: "## Decision\nPick X.\n## Why\n- Best fit.\n## Alternatives considered\n- **Alt A** — rejected because cost.\n## Consequences\n- Trade-offs apply.",
+    date: "2026-05-19", links: [] },
+  { kind: "lesson", title: "Always verify the live path",
+    rule: "Resolve the real data dir before claiming breakage.",
+    why: "A full misdiagnosis came from inspecting the fallback path.",
+    whenApplies: "Whenever a plugin appears not to be writing data.",
+    date: "2026-05-19", links: [] },
+  { kind: "project_fact", title: "Single writer", project: "attrproj",
+    body: "The distiller is the only writer for vault notes.",
+    date: "2026-05-19", links: [] },
+];
+
+it("stamps session_id and agent_role on create- and append-mode notes when both env vars present", () => {
+  seedSession("SESS-AAA");
+  const stub = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(stub, JSON.stringify(STUB_ITEMS));
+
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT, SUPERBRAIN_DISTILL_STUB: stub,
+      SUPERBRAIN_SESSION_ID: "SESS-AAA", SUPERBRAIN_AGENT_ROLE: "engineer",
+      SUPERBRAIN_EMBED_STUB: "1" },
+    encoding: "utf8",
+  });
+
+  const dec = fs.readFileSync(path.join(TMP_VAULT, "decisions/2026-05-19-pick-x.md"), "utf8");
+  expect(dec).toMatch(/^session_id: SESS-AAA$/m);
+  expect(dec).toMatch(/^agent_role: engineer$/m);
+
+  const lessonDir = path.join(TMP_VAULT, "lessons");
+  const lessonFile = fs.readdirSync(lessonDir).find((f) => f.endsWith(".md"))!;
+  const les = fs.readFileSync(path.join(lessonDir, lessonFile), "utf8");
+  expect(les).toMatch(/^session_id: SESS-AAA$/m);
+  expect(les).toMatch(/^agent_role: engineer$/m);
+
+  const proj = fs.readFileSync(path.join(TMP_VAULT, "projects/attrproj.md"), "utf8");
+  expect(proj).toMatch(/^session_id: SESS-AAA$/m);
+  expect(proj).toMatch(/^agent_role: engineer$/m);
+
+  const daily = fs.readFileSync(path.join(TMP_VAULT, "daily/2026-05-19.md"), "utf8");
+  expect(daily).not.toMatch(/session_id|agent_role/);
+});
+
+it("stamps session_id only and omits agent_role when SUPERBRAIN_AGENT_ROLE is unset", () => {
+  seedSession("SESS-BBB");
+  const stub = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(stub, JSON.stringify(STUB_ITEMS));
+
+  const env = { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA,
+    SUPERBRAIN_VAULT_DIR: TMP_VAULT, SUPERBRAIN_DISTILL_STUB: stub,
+    SUPERBRAIN_SESSION_ID: "SESS-BBB", SUPERBRAIN_EMBED_STUB: "1" } as NodeJS.ProcessEnv;
+  delete env.SUPERBRAIN_AGENT_ROLE;
+
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], { env, encoding: "utf8" });
+
+  const dec = fs.readFileSync(path.join(TMP_VAULT, "decisions/2026-05-19-pick-x.md"), "utf8");
+  expect(dec).toMatch(/^session_id: SESS-BBB$/m);
+  expect(dec).not.toMatch(/agent_role/);
+});

--- a/tests/casWrite.test.ts
+++ b/tests/casWrite.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { casWrite } from "../src/atomicWrite";
+
+let DIR: string;
+let FILE: string;
+
+beforeEach(() => {
+  DIR = fs.mkdtempSync(path.join(os.tmpdir(), "sb-cas-"));
+  FILE = path.join(DIR, "demo.md");
+});
+afterEach(() => { fs.rmSync(DIR, { recursive: true, force: true }); });
+
+describe("casWrite", () => {
+  it("does not drop a concurrent peer write landing between read and rename", () => {
+    fs.writeFileSync(FILE, "SEED\n");
+    let firstCall = true;
+    const result = casWrite(FILE, (current) => {
+      if (firstCall) {
+        firstCall = false;
+        fs.writeFileSync(FILE, (current ?? "") + "PEER-B\n");
+      }
+      return (current ?? "") + "WRITER-A\n";
+    });
+    expect(result.ok).toBe(true);
+    const final = fs.readFileSync(FILE, "utf8");
+    expect(final).toContain("SEED");
+    expect(final).toContain("PEER-B");
+    expect(final).toContain("WRITER-A");
+  });
+
+  it("writes once when there is no contention", () => {
+    const r = casWrite(FILE, (current) => (current ?? "") + "ONLY\n");
+    expect(r.ok).toBe(true);
+    expect(fs.readFileSync(FILE, "utf8")).toBe("ONLY\n");
+  });
+});

--- a/tests/checkpoint.test.ts
+++ b/tests/checkpoint.test.ts
@@ -44,6 +44,21 @@ describe("sb-checkpoint", () => {
     expect(fs.existsSync(path.join(TMP, "distill-invoked"))).toBe(false);
   });
 
+  it("contended checkpoint flags the session needs-distill and exits 0", () => {
+    fs.mkdirSync(path.join(TMP, "sessions"), { recursive: true });
+    fs.writeFileSync(path.join(TMP, "sessions/S.pending"), "1");
+    fs.mkdirSync(path.join(TMP, "locks/distill.lock"), { recursive: true });
+    run({ session_id: "S", hook_event_name: "Stop", cwd: "/p", transcript_path: "/dev/null" });
+    expect(fs.existsSync(path.join(TMP, "distill-invoked"))).toBe(false);
+    expect(fs.existsSync(path.join(TMP, "sessions/S.needs-distill"))).toBe(true);
+    expect(fs.existsSync(path.join(TMP, "sessions/S.pending"))).toBe(true);
+  });
+
+  it("uncontended checkpoint writes no needs-distill flag", () => {
+    run({ session_id: "S", hook_event_name: "PreCompact", cwd: "/p", transcript_path: "/dev/null" });
+    expect(fs.existsSync(path.join(TMP, "sessions/S.needs-distill"))).toBe(false);
+  });
+
   it("multiple checkpoints for the same session produce exactly one snapshot file (no timestamped suffix)", () => {
     const sid = "sid-overwrite-test";
     const transcriptsDir = path.join(TMP, "transcripts");

--- a/tests/dedupRetryGeneral.test.ts
+++ b/tests/dedupRetryGeneral.test.ts
@@ -1,0 +1,57 @@
+import { it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { serializeNote } from "../src/frontmatter";
+
+let TMP: string;
+let ABS: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dedup-gen-"));
+  process.env.SUPERBRAIN_VAULT_DIR = TMP;
+  ABS = path.join(TMP, "daily", "2026-05-19.md");
+  fs.mkdirSync(path.dirname(ABS), { recursive: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+it("does not stick dedup-skip on the general path across a forced retry", async () => {
+  const NEW_BODY = "general note body that comfortably exceeds the forty character dedup floor";
+
+  const seeded = serializeNote(
+    { type: "daily", created: "2026-05-19", updated: "2026-05-19" },
+    `# 2026-05-19\n\n## 2026-05-19 09:00\n\n${NEW_BODY}\n`,
+  );
+  fs.writeFileSync(ABS, seeded);
+
+  const peer = serializeNote(
+    { type: "daily", created: "2026-05-19", updated: "2026-05-19" },
+    `# 2026-05-19\n\n## 2026-05-19 08:00\n\nunrelated earlier note here padding\n`,
+  );
+
+  const realRead = fs.readFileSync.bind(fs);
+  let absReads = 0;
+  vi.spyOn(fs, "readFileSync").mockImplementation(((p: any, ...rest: any[]) => {
+    if (typeof p === "string" && path.resolve(p) === path.resolve(ABS)) {
+      absReads += 1;
+      if (absReads === 3) fs.writeFileSync(ABS, peer);
+    }
+    return (realRead as any)(p, ...rest);
+  }) as any);
+
+  const { writeNote } = await import("../src/vaultWriter");
+  const r = writeNote("daily/2026-05-19.md", {
+    frontmatter: { type: "daily", created: "2026-05-19" },
+    body: NEW_BODY,
+    mode: "append",
+  });
+
+  const live = fs.readFileSync(ABS, "utf8");
+  expect(live).toContain(NEW_BODY);
+  expect(r.reason).not.toBe("duplicate-skipped");
+});

--- a/tests/dedupRetryProject.test.ts
+++ b/tests/dedupRetryProject.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { serializeNote } from "../src/frontmatter";
+
+let TMP: string;
+let ABS: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-dedup-proj-"));
+  process.env.SUPERBRAIN_VAULT_DIR = TMP;
+  process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES = "8192";
+  ABS = path.join(TMP, "projects", "demo.md");
+  fs.mkdirSync(path.dirname(ABS), { recursive: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  delete process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+it("does not stick dedup-skip / drops no archive across a forced casWrite retry", async () => {
+  const NEW_BODY = "fresh activity line that is well over forty characters long indeed";
+  const FILLER = "x".repeat(9000);
+
+  const seeded = serializeNote(
+    { type: "project", status: "active", project: "demo", created: "2026-05-19", updated: "2026-05-19" },
+    `# demo\n\n## Recent activity\n\n### 2026-05-01\n\n${FILLER}\n\n### 2026-05-19\n\n${NEW_BODY}\n`,
+  );
+  fs.writeFileSync(ABS, seeded);
+
+  const peer = serializeNote(
+    { type: "project", status: "active", project: "demo", created: "2026-05-19", updated: "2026-05-19" },
+    `# demo\n\n## Recent activity\n\n### 2026-05-01\n\n${FILLER}\n`,
+  );
+
+  const realRead = fs.readFileSync.bind(fs);
+  let absReads = 0;
+  vi.spyOn(fs, "readFileSync").mockImplementation(((p: any, ...rest: any[]) => {
+    if (typeof p === "string" && path.resolve(p) === path.resolve(ABS)) {
+      absReads += 1;
+      if (absReads === 3) fs.writeFileSync(ABS, peer);
+    }
+    return (realRead as any)(p, ...rest);
+  }) as any);
+
+  const { writeNote } = await import("../src/vaultWriter");
+  const r = writeNote("projects/demo.md", {
+    frontmatter: { type: "project", status: "active", project: "demo", created: "2026-05-19" },
+    body: NEW_BODY,
+    mode: "append",
+  });
+
+  const live = fs.readFileSync(ABS, "utf8");
+  const archiveDir = path.join(TMP, "projects", "_archive");
+  const archiveFiles = fs.existsSync(archiveDir) ? fs.readdirSync(archiveDir) : [];
+
+  expect(live).toContain(NEW_BODY);
+  expect(r.reason).not.toBe("duplicate-skipped");
+  expect(archiveFiles.length).toBeGreaterThan(0);
+});
+
+it("control: genuine duplicate with no contention still dedup-skips and writes no archive", async () => {
+  const NEW_BODY = "fresh activity line that is well over forty characters long indeed";
+  const seeded = serializeNote(
+    { type: "project", status: "active", project: "demo", created: "2026-05-19", updated: "2026-05-19" },
+    `# demo\n\n## Recent activity\n\n### 2026-05-19\n\n${NEW_BODY}\n`,
+  );
+  fs.writeFileSync(ABS, seeded);
+  const before = fs.readFileSync(ABS, "utf8");
+
+  const { writeNote } = await import("../src/vaultWriter");
+  const r = writeNote("projects/demo.md", {
+    frontmatter: { type: "project", status: "active", project: "demo", created: "2026-05-19" },
+    body: NEW_BODY,
+    mode: "append",
+  });
+
+  expect(r.reason).toBe("duplicate-skipped");
+  expect(fs.readFileSync(ABS, "utf8")).toBe(before);
+  expect(fs.existsSync(path.join(TMP, "projects", "_archive"))).toBe(false);
+});

--- a/tests/distillKnownSlugs012.test.ts
+++ b/tests/distillKnownSlugs012.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readKnownProjectSlugs } from "../src/distillRun";
+import { filterToUniversal } from "../src/preferenceClassify";
+import { slug } from "../src/router";
+
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-distill012-vault-"));
+  fs.mkdirSync(path.join(TMP, "projects"), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  delete process.env.SUPERBRAIN_KNOWN_SLUGS_OVERRIDE;
+});
+
+const BODY = `## Editor
+
+- for my-app: use 2-space indent
+- always run the linter before commit
+`;
+
+describe("readKnownProjectSlugs slug normalization (012)", () => {
+  it("filename branch: a slug-collapsing project filename enumerates as its slug, not raw lowercase", () => {
+    fs.writeFileSync(path.join(TMP, "projects/My_App.md"), "---\ntype: project\n---\n");
+    const slugs = readKnownProjectSlugs(TMP);
+    expect(slugs.has("my-app")).toBe(true);
+    expect(slugs.has("my_app")).toBe(false);
+  });
+
+  it("REPRO: a `for my-app:` rule is demoted (not globalized) for projects/My_App.md", () => {
+    fs.writeFileSync(path.join(TMP, "projects/My_App.md"), "---\ntype: project\n---\n");
+    const knownSlugs = readKnownProjectSlugs(TMP);
+    const { universalBody, demoted } = filterToUniversal(BODY, knownSlugs);
+    expect(demoted).toEqual([
+      { text: "for my-app: use 2-space indent", projectSlug: "my-app" },
+    ]);
+    expect(universalBody).toContain("always run the linter before commit");
+    expect(universalBody).not.toContain("for my-app");
+  });
+
+  it("a `.`-bearing filename (my.app.md) also normalizes to my-app and demotes", () => {
+    fs.writeFileSync(path.join(TMP, "projects/my.app.md"), "---\ntype: project\n---\n");
+    const knownSlugs = readKnownProjectSlugs(TMP);
+    expect(knownSlugs.has("my-app")).toBe(true);
+    const { demoted } = filterToUniversal(BODY, knownSlugs);
+    expect(demoted.map(d => d.projectSlug)).toContain("my-app");
+  });
+
+  it("CONTROL: an already-slugified filename (data-pipeline.md) is unaffected and still demotes", () => {
+    fs.writeFileSync(path.join(TMP, "projects/data-pipeline.md"), "---\ntype: project\n---\n");
+    const knownSlugs = readKnownProjectSlugs(TMP);
+    expect(knownSlugs.has("data-pipeline")).toBe(true);
+    const body = "## Editor\n\n- for data-pipeline: use tabs\n- be nice\n";
+    const { demoted } = filterToUniversal(body, knownSlugs);
+    expect(demoted).toEqual([
+      { text: "for data-pipeline: use tabs", projectSlug: "data-pipeline" },
+    ]);
+  });
+
+  it("override branch: a non-slug override value normalizes through slug()", () => {
+    process.env.SUPERBRAIN_KNOWN_SLUGS_OVERRIDE = "My_App, Data Pipeline";
+    const slugs = readKnownProjectSlugs(TMP);
+    expect(slugs.has("my-app")).toBe(true);
+    expect(slugs.has("data-pipeline")).toBe(true);
+    expect(slugs.has("my_app")).toBe(false);
+  });
+
+  it("override branch: blank/empty segments are dropped, no \"untitled\" leaks in", () => {
+    process.env.SUPERBRAIN_KNOWN_SLUGS_OVERRIDE = "alpha,, ,beta";
+    const slugs = readKnownProjectSlugs(TMP);
+    expect([...slugs].sort()).toEqual(["alpha", "beta"]);
+    expect(slugs.has("untitled")).toBe(false);
+  });
+});

--- a/tests/distillSweep.test.ts
+++ b/tests/distillSweep.test.ts
@@ -1,0 +1,121 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-sweep-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-sweep-vault-"));
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+});
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+function substantiveNdjson(): string {
+  return JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n";
+}
+
+function writeStub(file: string) {
+  fs.writeFileSync(file, JSON.stringify([
+    { kind: "decision", title: "Pick X", project: "test",
+      body: "## Decision\nPick X.\n## Why\n- Best fit.\n## Alternatives considered\n- **Alt A** — rejected because cost.\n## Consequences\n- Trade-offs apply.",
+      date: "2026-05-19", links: [] },
+  ]));
+}
+
+function runDistillFor(sid: string, stub: string) {
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+      SUPERBRAIN_DISTILL_STUB: stub,
+      SUPERBRAIN_SESSION_ID: sid,
+      SUPERBRAIN_EMBED_STUB: "1",
+    },
+    encoding: "utf8",
+  });
+}
+
+it("next successful distill sweeps a flagged orphan session", () => {
+  const bNdjson = path.join(TMP_DATA, "sessions/B.ndjson");
+  fs.writeFileSync(bNdjson, substantiveNdjson());
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/B.needs-distill"), "1");
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/C.ndjson"), substantiveNdjson());
+
+  const stub = path.join(TMP_DATA, "stub.json");
+  writeStub(stub);
+
+  runDistillFor("C", stub);
+
+  const bSize = fs.statSync(bNdjson).size;
+  const bCursor = path.join(TMP_DATA, "sessions/B.cursor");
+  expect(fs.existsSync(bCursor)).toBe(true);
+  expect(parseInt(fs.readFileSync(bCursor, "utf8").trim(), 10)).toBe(bSize);
+  expect(fs.existsSync(path.join(TMP_DATA, "sessions/B.needs-distill"))).toBe(false);
+});
+
+it("re-distill of a swept session is a no-op (cursor unchanged, no new notes)", () => {
+  const bNdjson = path.join(TMP_DATA, "sessions/B.ndjson");
+  fs.writeFileSync(bNdjson, substantiveNdjson());
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/B.needs-distill"), "1");
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/C.ndjson"), substantiveNdjson());
+  const stub = path.join(TMP_DATA, "stub.json");
+  writeStub(stub);
+
+  runDistillFor("C", stub);
+  const cursorAfter1 = fs.readFileSync(path.join(TMP_DATA, "sessions/B.cursor"), "utf8").trim();
+  const countNotes = () => {
+    let n = 0;
+    const walk = (d: string) => {
+      for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+        const p = path.join(d, e.name);
+        if (e.isDirectory()) walk(p); else if (e.name.endsWith(".md")) n++;
+      }
+    };
+    walk(TMP_VAULT); return n;
+  };
+  const notesAfter1 = countNotes();
+
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/C2.ndjson"), substantiveNdjson());
+  runDistillFor("C2", stub);
+
+  expect(fs.readFileSync(path.join(TMP_DATA, "sessions/B.cursor"), "utf8").trim()).toBe(cursorAfter1);
+  expect(countNotes()).toBeGreaterThanOrEqual(notesAfter1);
+});
+
+it("sweep clears the flag for an empty-delta flagged session", () => {
+  const bNdjson = path.join(TMP_DATA, "sessions/B.ndjson");
+  fs.writeFileSync(bNdjson, substantiveNdjson());
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/B.cursor"), String(fs.statSync(bNdjson).size));
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/B.needs-distill"), "1");
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/C.ndjson"), substantiveNdjson());
+  const stub = path.join(TMP_DATA, "stub.json");
+  writeStub(stub);
+
+  runDistillFor("C", stub);
+  expect(fs.existsSync(path.join(TMP_DATA, "sessions/B.needs-distill"))).toBe(false);
+});
+
+import { sweepPendingDistills, flagPath } from "../src/distillSweep.js";
+
+it("a throwing flagged session is isolated; host distill and siblings unaffected", async () => {
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  fs.writeFileSync(flagPath("BAD"), "1");
+  fs.writeFileSync(flagPath("GOOD"), "1");
+  const seen: string[] = [];
+  await sweepPendingDistills("HOST", async (sid) => {
+    seen.push(sid);
+    if (sid === "BAD") throw new Error("boom");
+  });
+  expect(seen.sort()).toEqual(["BAD", "GOOD"]);
+  expect(fs.existsSync(flagPath("GOOD"))).toBe(false);
+  expect(fs.existsSync(flagPath("BAD"))).toBe(true);
+  delete process.env.SUPERBRAIN_DATA_DIR;
+});

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -58,4 +58,29 @@ describe("frontmatter", () => {
     expect(data.created).toBe("2026-05-22");
     expect(typeof data.created).toBe("string");
   });
+
+  it("accepts session_id and agent_role on every note type", () => {
+    expect(validateFrontmatter({ type: "lesson", status: "active", created: "2026-05-19", session_id: "S1", agent_role: "engineer" })).toEqual([]);
+    expect(validateFrontmatter({ type: "decision", status: "active", created: "2026-05-19", session_id: "S1", agent_role: "engineer" })).toEqual([]);
+    expect(validateFrontmatter({ type: "capture", status: "active", created: "2026-05-19", session_id: "S1", agent_role: "engineer" })).toEqual([]);
+    expect(validateFrontmatter({ type: "preference", created: "2026-05-19", session_id: "S1" })).toEqual([]);
+  });
+
+  it("still rejects a non-serializable attribution value", () => {
+    const errs = validateFrontmatter({ type: "lesson", status: "active", created: "2026-05-19", session_id: (() => 1) as any });
+    expect(errs.join(" ")).toMatch(/session_id/);
+  });
+
+  it("existing notes without attribution remain valid", () => {
+    expect(validateFrontmatter({ type: "decision", status: "active", created: "2026-05-19" })).toEqual([]);
+  });
+
+  it("serializes and round-trips session_id and agent_role unquoted", () => {
+    const out = serializeNote({ type: "lesson", status: "active", created: "2026-05-19", session_id: "S1", agent_role: "engineer" }, "body");
+    expect(out).toMatch(/^session_id: S1$/m);
+    expect(out).toMatch(/^agent_role: engineer$/m);
+    const { data } = parseNote(out);
+    expect(data.session_id).toBe("S1");
+    expect(data.agent_role).toBe("engineer");
+  });
 });

--- a/tests/indexerTypeRole.test.ts
+++ b/tests/indexerTypeRole.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openIndex } from "../src/searchIndex";
+import { indexNote } from "../src/indexer";
+
+let TMP: string; let VAULT: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-ixtr-"));
+  VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+  process.env.SUPERBRAIN_VAULT_DIR = VAULT;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+});
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR; delete process.env.SUPERBRAIN_VAULT_DIR;
+  delete process.env.SUPERBRAIN_EMBED_STUB;
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.rmSync(VAULT, { recursive: true, force: true });
+});
+
+describe("indexer populates note_type and agent_role", () => {
+  it("reads type and agent_role from frontmatter", async () => {
+    fs.mkdirSync(path.join(VAULT, "decisions"), { recursive: true });
+    fs.writeFileSync(path.join(VAULT, "decisions/d.md"),
+      "---\ntype: decision\nagent_role: planner\nproject: global\ncreated: 2026-01-01\n---\nbody text here\n");
+    await indexNote("decisions/d.md");
+    const ix = openIndex();
+    const meta = ix.getFilterMeta(["decisions/d.md"]);
+    ix.close();
+    expect(meta.get("decisions/d.md")).toMatchObject({ type: "decision", agentRole: "planner" });
+  });
+});

--- a/tests/lockfile.test.ts
+++ b/tests/lockfile.test.ts
@@ -26,4 +26,15 @@ describe("lockfile", () => {
     expect(acquireLock("distill")).toBe(true);
     expect(acquireLock("distill", { maxAgeMs: -1 })).toBe(true); // any age is stale
   });
+  it("releaseLock refuses a foreign holder", () => {
+    expect(acquireLock("distill")).toBe(true);
+    releaseLock("distill", "wrong-token");
+    expect(acquireLock("distill")).toBe(false);
+  });
+  it("a release bearing the matching token frees the lock", () => {
+    expect(acquireLock("distill")).toBe(true);
+    const token = fs.readFileSync(path.join(TMP, "locks", "distill.lock", "token"), "utf8");
+    releaseLock("distill", token);
+    expect(acquireLock("distill")).toBe(true);
+  });
 });

--- a/tests/mcpChildren.test.ts
+++ b/tests/mcpChildren.test.ts
@@ -1,0 +1,34 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let TMP: string;
+beforeEach(() => { TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-mc-")); process.env.SUPERBRAIN_DATA_DIR = TMP; });
+afterEach(() => { fs.rmSync(TMP, { recursive: true, force: true }); delete process.env.SUPERBRAIN_DATA_DIR; });
+
+it("lists children with project + open threads", async () => {
+  const { upsertDay } = await import("../src/dailyState.js");
+  const { handleChildren } = await import("../src/mcpChildren.js");
+  upsertDay("2026-06-11", "cA", { digestLine: "", routedRelPaths: [], alsoDid: [],
+    openThreads: ["wire Y"], project: "alfred", parentSessionId: "P" });
+  const out = await handleChildren({ parentSessionId: "P", date: "2026-06-11" });
+  const text = out.content[0].text;
+  expect(text).toContain("cA");
+  expect(text).toContain("alfred");
+  expect(text).toContain("wire Y");
+});
+
+it("blank parent or no children -> friendly message", async () => {
+  const { handleChildren } = await import("../src/mcpChildren.js");
+  expect((await handleChildren({ parentSessionId: "" })).content[0].text).toMatch(/no/i);
+  expect((await handleChildren({ parentSessionId: "X", date: "2026-06-11" })).content[0].text).toMatch(/no/i);
+});
+
+it("defaults date to today (UTC) when omitted", async () => {
+  const { upsertDay } = await import("../src/dailyState.js");
+  const { handleChildren } = await import("../src/mcpChildren.js");
+  const today = new Date().toISOString().slice(0, 10);
+  upsertDay(today, "cT", { digestLine: "", routedRelPaths: [], alsoDid: [], openThreads: [], parentSessionId: "P" });
+  expect((await handleChildren({ parentSessionId: "P" })).content[0].text).toContain("cT");
+});

--- a/tests/mcpSearchScoped.test.ts
+++ b/tests/mcpSearchScoped.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openIndex } from "../src/searchIndex";
+import { handleSearch } from "../src/mcpSearch";
+import { embed } from "../src/embed";
+
+let TMP: string;
+
+beforeEach(async () => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-msc-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+});
+
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_EMBED_STUB;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("handleSearch scoped", () => {
+  it("project param routes through scoped recall", async () => {
+    const [v] = await embed(["scoped recall project test note"]);
+    const ix = openIndex();
+    ix.upsertNote("projects/alpha/a.md", 1, "ha", [{ headingPath: "", anchor: "", text: "scoped recall project test note alpha" }], [v], "alpha");
+    ix.upsertNote("projects/beta/b.md", 1, "hb", [{ headingPath: "", anchor: "", text: "scoped recall project test note beta" }], [v], "beta");
+    ix.close();
+
+    const r = await handleSearch({ query: "scoped recall project test note", project: "alpha" });
+    const text = r.content[0].text;
+    expect(text).toMatch(/alpha/);
+    expect(text).not.toMatch(/beta/);
+  });
+
+  it("type param filters", async () => {
+    const [v] = await embed(["type filter mcp search note"]);
+    const ix = openIndex();
+    ix.upsertNote("decisions/d.md", 1, "hd", [{ headingPath: "", anchor: "", text: "type filter mcp search note decision" }], [v], "global", undefined, "decision");
+    ix.upsertNote("captures/c.md", 1, "hc", [{ headingPath: "", anchor: "", text: "type filter mcp search note capture" }], [v], "global", undefined, "capture");
+    ix.close();
+
+    const r = await handleSearch({ query: "type filter mcp search note", type: "decision" });
+    const text = r.content[0].text;
+    expect(text).toMatch(/decisions\/d/);
+    expect(text).not.toMatch(/captures\/c/);
+  });
+
+  it("k cap stays 20 under scoped params", async () => {
+    const [v] = await embed(["k cap test alpha note"]);
+    const ix = openIndex();
+    for (let i = 0; i < 25; i++) {
+      ix.upsertNote(`projects/alpha/n${i}.md`, 1, `h${i}`, [{ headingPath: "", anchor: "", text: `k cap test alpha note ${i}` }], [v], "alpha");
+    }
+    ix.close();
+
+    const r = await handleSearch({ query: "k cap test alpha note", k: 999, project: "alpha" });
+    const text = r.content[0].text;
+    const matches = text.match(/^\d+\. /gm) ?? [];
+    expect(matches.length).toBeLessThanOrEqual(20);
+  });
+});

--- a/tests/projectIndex.test.ts
+++ b/tests/projectIndex.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildProjectIndex, projectIndexRelPath } from "../src/projectIndex";
+import { parseNote } from "../src/frontmatter";
+
+let TMP: string;
+let TMP_DATA: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pidx-vault-"));
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pidx-data-"));
+  process.env.SUPERBRAIN_VAULT_DIR = TMP;
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+
+  fs.mkdirSync(path.join(TMP, "projects"), { recursive: true });
+  fs.mkdirSync(path.join(TMP, "decisions"), { recursive: true });
+  fs.mkdirSync(path.join(TMP, "lessons"), { recursive: true });
+  fs.mkdirSync(path.join(TMP, "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(TMP, "projects/alpha.md"),
+    "---\ntype: project\nstatus: active\nproject: alpha\n---\n# Alpha\n\n## Recent activity\n",
+  );
+  fs.writeFileSync(
+    path.join(TMP, "decisions/2026-01-01-pick-raft.md"),
+    "---\ntype: decision\nstatus: active\nproject: alpha\n---\n# 2026-01-01 — Pick raft\n\nchose raft",
+  );
+  fs.writeFileSync(
+    path.join(TMP, "lessons/2026-01-02-verify-first.md"),
+    "---\ntype: lesson\nstatus: active\nproject: alpha\n---\n# Verify first\n\n## Rule\n\nverify",
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  delete process.env.SUPERBRAIN_DATA_DIR;
+});
+
+describe("projectIndex", () => {
+  it("writes maps/<slug>-index.md", () => {
+    buildProjectIndex("alpha");
+    expect(fs.existsSync(path.join(TMP, "maps/alpha-index.md"))).toBe(true);
+  });
+
+  it("frontmatter marks ownership", () => {
+    buildProjectIndex("alpha");
+    const raw = fs.readFileSync(path.join(TMP, "maps/alpha-index.md"), "utf8");
+    const { data } = parseNote(raw);
+    expect(data.type).toBe("map");
+    expect(data.project).toBe("alpha");
+    expect(data.superbrain).toBe(true);
+    expect(data.generated).toBe(true);
+  });
+
+  it("groups by type with wikilink and hook", () => {
+    buildProjectIndex("alpha");
+    const raw = fs.readFileSync(path.join(TMP, "maps/alpha-index.md"), "utf8");
+    const { content } = parseNote(raw);
+    expect(content).toContain("## Decisions");
+    expect(content).toContain("- [[decisions/2026-01-01-pick-raft]] — 2026-01-01 — Pick raft");
+    expect(content).toContain("## Lessons");
+    expect(content).toContain("- [[lessons/2026-01-02-verify-first]] — Verify first");
+  });
+
+  it("excludes archive, self, and other projects", () => {
+    fs.mkdirSync(path.join(TMP, "projects/_archive"), { recursive: true });
+    fs.writeFileSync(
+      path.join(TMP, "projects/_archive/alpha-2026-Q1.md"),
+      "---\ntype: summary\nproject: alpha\n---\n# archive",
+    );
+    fs.writeFileSync(
+      path.join(TMP, "decisions/2026-01-03-beta-thing.md"),
+      "---\ntype: decision\nstatus: active\nproject: beta\n---\n# Beta thing",
+    );
+    fs.writeFileSync(
+      path.join(TMP, "maps/alpha-index.md"),
+      "---\ntype: map\nproject: alpha\nsuperbrain: true\ngenerated: true\n---\n# old index",
+    );
+    buildProjectIndex("alpha");
+    const raw = fs.readFileSync(path.join(TMP, "maps/alpha-index.md"), "utf8");
+    const { content } = parseNote(raw);
+    expect(content).not.toContain("projects/_archive/alpha-2026-Q1");
+    expect(content).not.toContain("2026-01-03-beta-thing");
+    expect(content).not.toContain("maps/alpha-index");
+  });
+
+  it("deterministic, no LLM", () => {
+    buildProjectIndex("alpha");
+    const body1 = parseNote(fs.readFileSync(path.join(TMP, "maps/alpha-index.md"), "utf8")).content;
+    buildProjectIndex("alpha");
+    const body2 = parseNote(fs.readFileSync(path.join(TMP, "maps/alpha-index.md"), "utf8")).content;
+    expect(body1).toBe(body2);
+  });
+
+  it("overwrites manual edits, never appends", () => {
+    fs.writeFileSync(
+      path.join(TMP, "maps/alpha-index.md"),
+      "---\ntype: map\nproject: alpha\nsuperbrain: true\ngenerated: true\n---\n# Alpha — index\n\nMANUAL EDIT MARKER\n",
+    );
+    buildProjectIndex("alpha");
+    const raw = fs.readFileSync(path.join(TMP, "maps/alpha-index.md"), "utf8");
+    const { content } = parseNote(raw);
+    expect(content).not.toContain("MANUAL EDIT MARKER");
+    expect(content).not.toMatch(/## \d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
+  });
+
+  it("single-note project does not crash", () => {
+    fs.mkdirSync(path.join(TMP, "projects"), { recursive: true });
+    fs.writeFileSync(
+      path.join(TMP, "projects/solo.md"),
+      "---\ntype: project\nstatus: active\nproject: solo\n---\n# Solo\n",
+    );
+    expect(() => buildProjectIndex("solo")).not.toThrow();
+    const raw = fs.readFileSync(path.join(TMP, "maps/solo-index.md"), "utf8");
+    const { content } = parseNote(raw);
+    expect(content).toContain("[[projects/solo]]");
+  });
+});

--- a/tests/projectIndex.test.ts
+++ b/tests/projectIndex.test.ts
@@ -66,6 +66,18 @@ describe("projectIndex", () => {
     expect(content).toContain("- [[lessons/2026-01-02-verify-first]] — Verify first");
   });
 
+  it("excludes archived decision (indexed type) at every depth", () => {
+    fs.mkdirSync(path.join(TMP, "projects/_archive"), { recursive: true });
+    fs.writeFileSync(
+      path.join(TMP, "projects/_archive/pick-raft-archived.md"),
+      "---\ntype: decision\nstatus: active\nproject: alpha\n---\n# Archived decision\n\nshould not appear",
+    );
+    buildProjectIndex("alpha");
+    const raw = fs.readFileSync(path.join(TMP, "maps/alpha-index.md"), "utf8");
+    const { content } = parseNote(raw);
+    expect(content).not.toContain("pick-raft-archived");
+  });
+
   it("excludes archive, self, and other projects", () => {
     fs.mkdirSync(path.join(TMP, "projects/_archive"), { recursive: true });
     fs.writeFileSync(

--- a/tests/projectIndexDistill.test.ts
+++ b/tests/projectIndexDistill.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { distillFromEvents } from "../src/distillRun";
+import { openIndex } from "../src/searchIndex";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pidx-distill-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pidx-distill-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+  fs.mkdirSync(path.join(TMP_VAULT, "projects"), { recursive: true });
+  fs.mkdirSync(path.join(TMP_VAULT, "maps"), { recursive: true });
+  fs.mkdirSync(path.join(TMP_DATA, "locks/distill.lock"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(TMP_VAULT, "projects/alpha.md"),
+    "---\ntype: project\nstatus: active\nproject: alpha\n---\n# Alpha\n\n## Recent activity\n",
+  );
+
+  const stub = {
+    items: [
+      {
+        kind: "project_fact",
+        title: "Alpha owns writes",
+        date: "2026-02-01",
+        project: "alpha",
+        body: "Alpha is the sole writer for X with enough words to clear dedup and then some more words here",
+      },
+    ],
+    digest: "Alpha session",
+    openThreads: [],
+    alsoDid: [],
+  };
+  const stubPath = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(stubPath, JSON.stringify(stub));
+  process.env.SUPERBRAIN_DISTILL_STUB = stubPath;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  delete process.env.SUPERBRAIN_EMBED_STUB;
+  delete process.env.SUPERBRAIN_DISTILL_STUB;
+});
+
+describe("projectIndexDistill", () => {
+  it("distill regenerates touched project index", async () => {
+    await distillFromEvents("test-sid", [
+      { type: "tool", tool: "Write", file: "src/index.ts", cwd: "/some/alpha", ts: "t1" },
+    ]);
+    expect(fs.existsSync(path.join(TMP_VAULT, "maps/alpha-index.md"))).toBe(true);
+    const content = fs.readFileSync(path.join(TMP_VAULT, "maps/alpha-index.md"), "utf8");
+    expect(content).toContain("[[projects/alpha]]");
+  });
+
+  it("index note is added to search index", async () => {
+    await distillFromEvents("test-sid", [
+      { type: "tool", tool: "Write", file: "src/index.ts", cwd: "/some/alpha", ts: "t1" },
+    ]);
+    const ix = openIndex();
+    try {
+      expect(ix.allIndexedPaths()).toContain("maps/alpha-index.md");
+    } finally {
+      ix.close();
+    }
+  });
+});

--- a/tests/projectIndexReconcile.test.ts
+++ b/tests/projectIndexReconcile.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { reconcile } from "../src/indexer";
+import { buildProjectIndex } from "../src/projectIndex";
+import { parseNote } from "../src/frontmatter";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pidx-rec-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pidx-rec-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+
+  fs.mkdirSync(path.join(TMP_VAULT, "projects"), { recursive: true });
+  fs.mkdirSync(path.join(TMP_VAULT, "decisions"), { recursive: true });
+  fs.mkdirSync(path.join(TMP_VAULT, "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(TMP_VAULT, "projects/alpha.md"),
+    "---\ntype: project\nstatus: active\nproject: alpha\n---\n# Alpha\n\n## Recent activity\n",
+  );
+  fs.writeFileSync(
+    path.join(TMP_VAULT, "decisions/2026-01-01-pick-raft.md"),
+    "---\ntype: decision\nstatus: active\nproject: alpha\n---\n# 2026-01-01 — Pick raft\n\nchose raft",
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  delete process.env.SUPERBRAIN_EMBED_STUB;
+});
+
+describe("projectIndexReconcile", () => {
+  it("reconcile heals drift", async () => {
+    fs.writeFileSync(
+      path.join(TMP_VAULT, "maps/alpha-index.md"),
+      "---\ntype: map\nproject: alpha\nsuperbrain: true\ngenerated: true\ncreated: 2026-01-01\nupdated: 2026-01-01\n---\n# alpha — index\n\n## Decisions\n\n- [[decisions/ghost]] — Ghost (stale)\n\n",
+    );
+
+    await reconcile();
+
+    const freshRaw = fs.readFileSync(path.join(TMP_VAULT, "maps/alpha-index.md"), "utf8");
+    const { content: freshContent } = parseNote(freshRaw);
+
+    const { content: expectedContent } = parseNote(
+      fs.readFileSync(path.join(TMP_VAULT, "maps/alpha-index.md"), "utf8"),
+    );
+
+    expect(freshContent).toContain("[[decisions/2026-01-01-pick-raft]]");
+    expect(freshContent).not.toContain("[[decisions/ghost]]");
+
+    fs.rmSync(path.join(TMP_VAULT, "maps/alpha-index.md"));
+    await reconcile();
+    expect(fs.existsSync(path.join(TMP_VAULT, "maps/alpha-index.md"))).toBe(true);
+  });
+
+  it("reconcile is idempotent on current index", async () => {
+    await reconcile();
+
+    expect(fs.existsSync(path.join(TMP_VAULT, "maps/alpha-index.md"))).toBe(true);
+    const mtime1 = fs.statSync(path.join(TMP_VAULT, "maps/alpha-index.md")).mtimeMs;
+    const body1 = parseNote(
+      fs.readFileSync(path.join(TMP_VAULT, "maps/alpha-index.md"), "utf8"),
+    ).content;
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    await reconcile();
+
+    const mtime2 = fs.statSync(path.join(TMP_VAULT, "maps/alpha-index.md")).mtimeMs;
+    const body2 = parseNote(
+      fs.readFileSync(path.join(TMP_VAULT, "maps/alpha-index.md"), "utf8"),
+    ).content;
+
+    expect(mtime2).toBe(mtime1);
+    expect(body2).toBe(body1);
+  });
+});

--- a/tests/projectIndexReconcile.test.ts
+++ b/tests/projectIndexReconcile.test.ts
@@ -45,17 +45,26 @@ describe("projectIndexReconcile", () => {
       "---\ntype: map\nproject: alpha\nsuperbrain: true\ngenerated: true\ncreated: 2026-01-01\nupdated: 2026-01-01\n---\n# alpha — index\n\n## Decisions\n\n- [[decisions/ghost]] — Ghost (stale)\n\n",
     );
 
+    const expectedBody = buildProjectIndex("alpha");
+    const expectedContent = parseNote(
+      fs.readFileSync(path.join(TMP_VAULT, "maps/alpha-index.md"), "utf8"),
+    ).content;
+
+    fs.writeFileSync(
+      path.join(TMP_VAULT, "maps/alpha-index.md"),
+      "---\ntype: map\nproject: alpha\nsuperbrain: true\ngenerated: true\ncreated: 2026-01-01\nupdated: 2026-01-01\n---\n# alpha — index\n\n## Decisions\n\n- [[decisions/ghost]] — Ghost (stale)\n\n",
+    );
+
     await reconcile();
 
-    const freshRaw = fs.readFileSync(path.join(TMP_VAULT, "maps/alpha-index.md"), "utf8");
-    const { content: freshContent } = parseNote(freshRaw);
-
-    const { content: expectedContent } = parseNote(
+    const { content: freshContent } = parseNote(
       fs.readFileSync(path.join(TMP_VAULT, "maps/alpha-index.md"), "utf8"),
     );
 
+    expect(freshContent).toBe(expectedContent);
     expect(freshContent).toContain("[[decisions/2026-01-01-pick-raft]]");
     expect(freshContent).not.toContain("[[decisions/ghost]]");
+    void expectedBody;
 
     fs.rmSync(path.join(TMP_VAULT, "maps/alpha-index.md"));
     await reconcile();

--- a/tests/projectIndexSlug011.test.ts
+++ b/tests/projectIndexSlug011.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  projectOfNote,
+  collectProjectNotes,
+  enumerateProjectSlugs,
+} from "../src/projectIndex";
+import { slug } from "../src/router";
+import { reconcile } from "../src/indexer";
+import { parseNote } from "../src/frontmatter";
+
+let TMP: string;
+let TMP_DATA: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pidx011-vault-"));
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-pidx011-data-"));
+  process.env.SUPERBRAIN_VAULT_DIR = TMP;
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  fs.mkdirSync(path.join(TMP, "projects"), { recursive: true });
+  fs.mkdirSync(path.join(TMP, "decisions"), { recursive: true });
+  fs.mkdirSync(path.join(TMP, "maps"), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  delete process.env.SUPERBRAIN_DATA_DIR;
+});
+
+describe("projectIndex slug normalization (011)", () => {
+  it("projectOfNote slugifies a non-conformant frontmatter project value", () => {
+    expect(projectOfNote("decisions/2026-06-11-hand.md", { project: "Foo Bar!" }))
+      .toBe(slug("Foo Bar!"));
+  });
+
+  it("collectProjectNotes finds a hand-authored note under the slugified key", () => {
+    fs.writeFileSync(
+      path.join(TMP, "decisions/2026-06-11-hand.md"),
+      "---\ntype: decision\nstatus: active\nproject: \"Foo Bar!\"\n---\n# 2026-06-11 — Hand\n\nbody",
+    );
+    const notes = collectProjectNotes(TMP, "foo-bar");
+    expect(notes.length).toBe(1);
+    expect(notes[0].relPath).toBe("decisions/2026-06-11-hand.md");
+  });
+
+  it("enumerateProjectSlugs emits only the slugified key, never the raw value", () => {
+    fs.writeFileSync(
+      path.join(TMP, "decisions/2026-06-11-hand.md"),
+      "---\ntype: decision\nstatus: active\nproject: \"Foo Bar!\"\n---\n# 2026-06-11 — Hand\n\nbody",
+    );
+    const slugs = enumerateProjectSlugs(TMP);
+    expect(slugs).toContain("foo-bar");
+    expect(slugs).not.toContain("foo bar!");
+  });
+
+  it("a non-slug-conformant project filename enumerates as its slug", () => {
+    fs.writeFileSync(
+      path.join(TMP, "projects/Foo Bar.md"),
+      "---\ntype: project\nstatus: active\n---\n# Foo Bar\n",
+    );
+    const slugs = enumerateProjectSlugs(TMP);
+    expect(slugs).toContain("foo-bar");
+    expect(slugs).not.toContain("foo bar");
+  });
+
+  it("CONTROL: a pre-slugified note is unaffected (still found)", () => {
+    fs.writeFileSync(
+      path.join(TMP, "decisions/2026-06-11-pre.md"),
+      "---\ntype: decision\nstatus: active\nproject: foo-bar\n---\n# 2026-06-11 — Pre\n\nbody",
+    );
+    expect(collectProjectNotes(TMP, "foo-bar").length).toBe(1);
+  });
+
+  it("dir-derived fallback slugifies the project filename", () => {
+    fs.writeFileSync(
+      path.join(TMP, "projects/Foo Bar.md"),
+      "---\ntype: project\nstatus: active\n---\n# Foo Bar\n",
+    );
+    expect(projectOfNote("projects/Foo Bar.md", {})).toBe("foo-bar");
+  });
+});
+
+describe("projectIndex reconcile slug normalization (011)", () => {
+  beforeEach(() => {
+    process.env.SUPERBRAIN_EMBED_STUB = "1";
+  });
+
+  afterEach(() => {
+    delete process.env.SUPERBRAIN_EMBED_STUB;
+  });
+
+  it("reconcile keys the index file on the slugified project (no wrong-slug file)", async () => {
+    fs.writeFileSync(
+      path.join(TMP, "decisions/2026-06-11-hand.md"),
+      "---\ntype: decision\nstatus: active\nproject: \"Foo Bar!\"\n---\n# 2026-06-11 — Hand\n\nbody",
+    );
+    await reconcile();
+    expect(fs.existsSync(path.join(TMP, "maps/foo-bar-index.md"))).toBe(true);
+    expect(fs.existsSync(path.join(TMP, "maps/foo bar!-index.md"))).toBe(false);
+    const { content } = parseNote(
+      fs.readFileSync(path.join(TMP, "maps/foo-bar-index.md"), "utf8"),
+    );
+    expect(content).toContain("[[decisions/2026-06-11-hand]]");
+  });
+});

--- a/tests/recallArchivePenalty.test.ts
+++ b/tests/recallArchivePenalty.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openIndex } from "../src/searchIndex.js";
+import { hybridRecall, isArchivePath } from "../src/recall.js";
+import { handleSearch } from "../src/mcpSearch.js";
+import { embed } from "../src/embed.js";
+
+let TMP: string;
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-arch-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+});
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_EMBED_STUB;
+  delete process.env.SUPERBRAIN_ARCHIVE_PENALTY;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("archive penalty — path detection", () => {
+  it("detects archive paths", () => {
+    expect(isArchivePath("projects/_archive/alfred-2026-Q2.md")).toBe(true);
+    expect(isArchivePath("knowledge/_archive/x.md")).toBe(true);
+    expect(isArchivePath("projects/alfred.md")).toBe(false);
+    expect(isArchivePath("decisions/2026-05-01-vec.md")).toBe(false);
+  });
+});
+
+describe("archive penalty — ordering", () => {
+  async function seedLiveAndArchive() {
+    const text = "alfred project recall ranking design decision notes";
+    const [vec] = await embed([text]);
+    const newer = new Date().toISOString();
+    const older = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const ix = openIndex();
+    ix.upsertNote(
+      "projects/alfred.md", 1, "h-live",
+      [{ headingPath: "", anchor: "root", text }],
+      [vec], "global", older,
+    );
+    ix.upsertNote(
+      "projects/_archive/alfred-2026-Q2.md", 1, "h-arch",
+      [{ headingPath: "", anchor: "root", text }],
+      [vec], "global", newer,
+    );
+    ix.close();
+    return text;
+  }
+
+  it("live note outranks its archive for identical content", async () => {
+    const text = await seedLiveAndArchive();
+    const results = await hybridRecall(text, 5);
+    const liveIdx = results.findIndex((r) => r.relPath === "projects/alfred.md");
+    const archIdx = results.findIndex((r) => r.relPath === "projects/_archive/alfred-2026-Q2.md");
+    expect(liveIdx).toBeGreaterThanOrEqual(0);
+    expect(archIdx).toBeGreaterThanOrEqual(0);
+    expect(liveIdx).toBeLessThan(archIdx);
+  });
+
+  it("archive still surfaces when no live note matches", async () => {
+    const [vec] = await embed(["lonely archived content only"]);
+    const ix = openIndex();
+    ix.upsertNote(
+      "projects/_archive/old-q1.md", 1, "h-only",
+      [{ headingPath: "", anchor: "root", text: "lonely archived content only" }],
+      [vec], "global",
+    );
+    ix.close();
+    const results = await hybridRecall("lonely archived content only", 5);
+    expect(results.map((r) => r.relPath)).toContain("projects/_archive/old-q1.md");
+  });
+
+  it("applies on the unscoped injection path", async () => {
+    const text = await seedLiveAndArchive();
+    const results = await hybridRecall(text, 5);
+    const liveIdx = results.findIndex((r) => r.relPath === "projects/alfred.md");
+    const archIdx = results.findIndex((r) => r.relPath === "projects/_archive/alfred-2026-Q2.md");
+    expect(liveIdx).toBeLessThan(archIdx);
+  });
+});
+
+describe("archive penalty — MCP search", () => {
+  it("applies on the MCP search path", async () => {
+    const text = "alfred mcp search ranking identical content";
+    const [vec] = await embed([text]);
+    const older = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const newer = new Date().toISOString();
+    const ix = openIndex();
+    ix.upsertNote(
+      "projects/alfred.md", 1, "h-l",
+      [{ headingPath: "", anchor: "root", text }], [vec], "global", older,
+    );
+    ix.upsertNote(
+      "projects/_archive/alfred-2026-Q2.md", 1, "h-a",
+      [{ headingPath: "", anchor: "root", text }], [vec], "global", newer,
+    );
+    ix.close();
+    const out = await handleSearch({ query: text, k: 8 });
+    const body = out.content[0].text;
+    const livePos = body.indexOf("projects/alfred");
+    const archPos = body.indexOf("projects/_archive/alfred-2026-Q2");
+    expect(livePos).toBeGreaterThanOrEqual(0);
+    expect(archPos).toBeGreaterThanOrEqual(0);
+    expect(livePos).toBeLessThan(archPos);
+  });
+});
+
+describe("archive penalty — configuration", () => {
+  async function seedLiveAndArchive() {
+    const text = "config test identical archive content ranking";
+    const [vec] = await embed([text]);
+    const older = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const newer = new Date().toISOString();
+    const ix = openIndex();
+    ix.upsertNote("projects/alfred.md", 1, "h-l",
+      [{ headingPath: "", anchor: "root", text }], [vec], "global", older);
+    ix.upsertNote("projects/_archive/alfred-2026-Q2.md", 1, "h-a",
+      [{ headingPath: "", anchor: "root", text }], [vec], "global", newer);
+    ix.close();
+    return text;
+  }
+
+  it("default penalty is 0.1", async () => {
+    delete process.env.SUPERBRAIN_ARCHIVE_PENALTY;
+    const text = await seedLiveAndArchive();
+    const results = await hybridRecall(text, 5);
+    const liveIdx = results.findIndex((r) => r.relPath === "projects/alfred.md");
+    const archIdx = results.findIndex((r) => r.relPath === "projects/_archive/alfred-2026-Q2.md");
+    expect(liveIdx).toBeLessThan(archIdx);
+  });
+
+  it("penalty is overridable via env", async () => {
+    process.env.SUPERBRAIN_ARCHIVE_PENALTY = "1";
+    const text = await seedLiveAndArchive();
+    const results = await hybridRecall(text, 5);
+    const liveIdx = results.findIndex((r) => r.relPath === "projects/alfred.md");
+    const archIdx = results.findIndex((r) => r.relPath === "projects/_archive/alfred-2026-Q2.md");
+    expect(archIdx).toBeLessThanOrEqual(liveIdx);
+  });
+});

--- a/tests/recallArchivePenalty.test.ts
+++ b/tests/recallArchivePenalty.test.ts
@@ -108,6 +108,58 @@ describe("archive penalty — MCP search", () => {
   });
 });
 
+describe("archive penalty — project-scoped path (hybridRecallWithProject)", () => {
+  it("live note outranks archive on project-scoped injection path", async () => {
+    const text = "project scoped recall fallback archive ordering test";
+    const [vec] = await embed([text]);
+    const older = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const newer = new Date().toISOString();
+    const ix = openIndex();
+    ix.upsertNote(
+      "projects/alfred.md", 1, "h-live",
+      [{ headingPath: "", anchor: "root", text }], [vec], "alfred", older,
+    );
+    ix.upsertNote(
+      "projects/_archive/alfred-2026-Q2.md", 1, "h-arch",
+      [{ headingPath: "", anchor: "root", text }], [vec], "global", newer,
+    );
+    ix.close();
+    const results = await hybridRecall(text, 5, { projectSlug: "alfred" });
+    const liveIdx = results.findIndex((r) => r.relPath === "projects/alfred.md");
+    const archIdx = results.findIndex((r) => r.relPath === "projects/_archive/alfred-2026-Q2.md");
+    expect(liveIdx).toBeGreaterThanOrEqual(0);
+    expect(archIdx).toBeGreaterThanOrEqual(0);
+    expect(liveIdx).toBeLessThan(archIdx);
+  });
+
+  it("fallback fill respects archive penalty", async () => {
+    const liveText = "alpha bravo charlie delta global live note";
+    const archText = "alpha bravo charlie delta global archive note";
+    const [liveVec] = await embed([liveText]);
+    const [archVec] = await embed([archText]);
+    const older = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const newer = new Date().toISOString();
+    const ix = openIndex();
+    ix.upsertNote(
+      "projects/global-live.md", 1, "h-live",
+      [{ headingPath: "", anchor: "root", text: liveText }], [liveVec], "global", older,
+    );
+    ix.upsertNote(
+      "projects/_archive/global-arch-q1.md", 1, "h-arch",
+      [{ headingPath: "", anchor: "root", text: archText }], [archVec], "global", newer,
+    );
+    ix.close();
+    process.env.SUPERBRAIN_EMBED_FORCE_FAIL = "1";
+    const results = await hybridRecall("xyz nomatch query zyxwv", 8, { projectSlug: "alfred" });
+    delete process.env.SUPERBRAIN_EMBED_FORCE_FAIL;
+    const liveIdx = results.findIndex((r) => r.relPath === "projects/global-live.md");
+    const archIdx = results.findIndex((r) => r.relPath === "projects/_archive/global-arch-q1.md");
+    expect(liveIdx).toBeGreaterThanOrEqual(0);
+    expect(archIdx).toBeGreaterThanOrEqual(0);
+    expect(liveIdx).toBeLessThan(archIdx);
+  });
+});
+
 describe("archive penalty — configuration", () => {
   async function seedLiveAndArchive() {
     const text = "config test identical archive content ranking";

--- a/tests/recallGeneratedExclusion.test.ts
+++ b/tests/recallGeneratedExclusion.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openIndex } from "../src/searchIndex.js";
+import { hybridRecall } from "../src/recall.js";
+import { embed } from "../src/embed.js";
+
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-gen-excl-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+});
+
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_EMBED_STUB;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("generated note exclusion from recall", () => {
+  it("generated map note does not appear in recall results while real note does", async () => {
+    const text = "pick raft consensus algorithm leader election fault tolerance";
+    const [vec] = await embed([text]);
+
+    const ix = openIndex();
+    ix.upsertNote(
+      "maps/alpha-index.md", 1, "hash-gen",
+      [{ headingPath: "", anchor: "root", text }],
+      [vec],
+      "alpha",
+      "2026-01-01",
+      "map",
+      undefined,
+      true,
+    );
+    ix.upsertNote(
+      "decisions/pick-raft.md", 1, "hash-real",
+      [{ headingPath: "", anchor: "root", text }],
+      [vec],
+      "alpha",
+      "2026-01-01",
+      "decision",
+      undefined,
+      false,
+    );
+    ix.close();
+
+    const results = await hybridRecall(text, 10);
+    const paths = results.map((r) => r.relPath);
+    expect(paths).toContain("decisions/pick-raft.md");
+    expect(paths).not.toContain("maps/alpha-index.md");
+  });
+
+  it("generated map note does not appear in project-scoped recall or fallback fill", async () => {
+    const text = "alpha project index map navigation generated content artifact";
+    const [vec] = await embed([text]);
+
+    const ix = openIndex();
+    ix.upsertNote(
+      "maps/alpha-index.md", 1, "hash-gen2",
+      [{ headingPath: "", anchor: "root", text }],
+      [vec],
+      "alpha",
+      "2026-01-01",
+      "map",
+      undefined,
+      true,
+    );
+    ix.upsertNote(
+      "decisions/real-decision.md", 1, "hash-real2",
+      [{ headingPath: "", anchor: "root", text }],
+      [vec],
+      "alpha",
+      "2026-01-01",
+      "decision",
+      undefined,
+      false,
+    );
+    ix.close();
+
+    const results = await hybridRecall(text, 10, { projectSlug: "alpha" });
+    const paths = results.map((r) => r.relPath);
+    expect(paths).toContain("decisions/real-decision.md");
+    expect(paths).not.toContain("maps/alpha-index.md");
+  });
+});

--- a/tests/recallScoped.test.ts
+++ b/tests/recallScoped.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openIndex } from "../src/searchIndex.js";
+import { hybridRecall } from "../src/recall.js";
+import { embed } from "../src/embed.js";
+
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-rs-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+});
+
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_EMBED_STUB;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+const isoDate = (daysAgo: number) => {
+  const d = new Date(Date.now() - daysAgo * 86_400_000);
+  return d.toISOString().slice(0, 10);
+};
+
+describe("recallScoped", () => {
+  it("type filter keeps only matching note type", async () => {
+    const [v] = await embed(["common query text"]);
+    const ix = openIndex();
+    ix.upsertNote("a.md", 1, "ha", [{ headingPath: "", anchor: "", text: "common query text decision" }], [v], "global", undefined, "decision", undefined);
+    ix.upsertNote("b.md", 1, "hb", [{ headingPath: "", anchor: "", text: "common query text capture" }], [v], "global", undefined, "capture", undefined);
+    ix.close();
+
+    const results = await hybridRecall("common query text", 10, { type: "decision" });
+    const paths = results.map((r) => r.relPath);
+    expect(paths).toContain("a.md");
+    expect(paths).not.toContain("b.md");
+  });
+
+  it("since filter drops notes older than the cutoff", async () => {
+    const [v] = await embed(["time filter test note"]);
+    const ix = openIndex();
+    ix.upsertNote("recent.md", 1, "hr", [{ headingPath: "", anchor: "", text: "time filter test note recent" }], [v], "global", isoDate(10), undefined, undefined);
+    ix.upsertNote("old.md", 1, "ho", [{ headingPath: "", anchor: "", text: "time filter test note old" }], [v], "global", isoDate(400), undefined, undefined);
+    ix.upsertNote("undated.md", 1, "hu", [{ headingPath: "", anchor: "", text: "time filter test note undated" }], [v], "global", undefined, undefined, undefined);
+    ix.close();
+
+    const cutoff = isoDate(30);
+    const results = await hybridRecall("time filter test note", 10, { since: cutoff });
+    const paths = results.map((r) => r.relPath);
+    expect(paths).toContain("recent.md");
+    expect(paths).not.toContain("old.md");
+    expect(paths).not.toContain("undated.md");
+  });
+
+  it("role filter keeps only matching agent_role", async () => {
+    const [v] = await embed(["role filter test query"]);
+    const ix = openIndex();
+    ix.upsertNote("p.md", 1, "hp", [{ headingPath: "", anchor: "", text: "role filter test query planner" }], [v], "global", undefined, undefined, "planner");
+    ix.upsertNote("e.md", 1, "he", [{ headingPath: "", anchor: "", text: "role filter test query engineer" }], [v], "global", undefined, undefined, "engineer");
+    ix.close();
+
+    const results = await hybridRecall("role filter test query", 10, { role: "planner" });
+    const paths = results.map((r) => r.relPath);
+    expect(paths).toContain("p.md");
+    expect(paths).not.toContain("e.md");
+  });
+
+  it("role filter is a no-op when no note carries agent_role", async () => {
+    const [v] = await embed(["role noop test query"]);
+    const ix = openIndex();
+    ix.upsertNote("x.md", 1, "hx", [{ headingPath: "", anchor: "", text: "role noop test query xray" }], [v], "global", undefined, undefined, undefined);
+    ix.upsertNote("y.md", 1, "hy", [{ headingPath: "", anchor: "", text: "role noop test query yankee" }], [v], "global", undefined, undefined, undefined);
+    ix.close();
+
+    const withRole = await hybridRecall("role noop test query", 10, { role: "planner" });
+    const withoutRole = await hybridRecall("role noop test query", 10);
+    expect(withRole.map((r) => r.relPath).sort()).toEqual(withoutRole.map((r) => r.relPath).sort());
+    expect(withRole.length).toBeGreaterThan(0);
+  });
+
+  it("project + type + since compose", async () => {
+    const [v] = await embed(["compose filter test query"]);
+    const cutoff = isoDate(30);
+    const ix = openIndex();
+    ix.upsertNote("match.md", 1, "hm", [{ headingPath: "", anchor: "", text: "compose filter test query match" }], [v], "alpha", isoDate(10), "decision", undefined);
+    ix.upsertNote("wrong-proj.md", 1, "hwp", [{ headingPath: "", anchor: "", text: "compose filter test query wrong proj" }], [v], "beta", isoDate(10), "decision", undefined);
+    ix.upsertNote("wrong-type.md", 1, "hwt", [{ headingPath: "", anchor: "", text: "compose filter test query wrong type" }], [v], "alpha", isoDate(10), "capture", undefined);
+    ix.upsertNote("wrong-date.md", 1, "hwd", [{ headingPath: "", anchor: "", text: "compose filter test query wrong date" }], [v], "alpha", isoDate(400), "decision", undefined);
+    ix.close();
+
+    const results = await hybridRecall("compose filter test query", 10, {
+      projectSlug: "alpha", type: "decision", since: cutoff,
+    });
+    const paths = results.map((r) => r.relPath);
+    expect(paths).toContain("match.md");
+    expect(paths).not.toContain("wrong-proj.md");
+    expect(paths).not.toContain("wrong-type.md");
+    expect(paths).not.toContain("wrong-date.md");
+  });
+});

--- a/tests/reindexSentinel009.test.ts
+++ b/tests/reindexSentinel009.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { forcedReindexIfNeeded, reconcile } from "../src/indexer";
+import { openIndex } from "../src/searchIndex";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-sentinel009-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-sentinel009-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+  process.env.SUPERBRAIN_EMBED_STUB = "1";
+  fs.mkdirSync(path.join(TMP_VAULT, "decisions"), { recursive: true });
+});
+
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  delete process.env.SUPERBRAIN_EMBED_STUB;
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+describe("reindex sentinel 009: note_type/agent_role backfill", () => {
+  it("forcedReindexIfNeeded 0.9.0 populates note_type and agent_role for pre-existing NULLs, no-ops on second call", async () => {
+    fs.writeFileSync(
+      path.join(TMP_VAULT, "decisions/g.md"),
+      "---\ntype: decision\nagent_role: engineer\nproject: global\ncreated: 2026-01-01\n---\nbody content here\n",
+    );
+    await reconcile();
+
+    const db1 = new Database(path.join(TMP_DATA, "index.db"));
+    db1.prepare("UPDATE notes SET note_type=NULL, agent_role=NULL WHERE rel_path=?").run("decisions/g.md");
+    db1.close();
+
+    const ix0 = openIndex();
+    const metaBefore = ix0.getFilterMeta(["decisions/g.md"]);
+    ix0.close();
+    expect(metaBefore.get("decisions/g.md")?.type).toBeNull();
+    expect(metaBefore.get("decisions/g.md")?.agentRole).toBeNull();
+
+    const ran = await forcedReindexIfNeeded("0.9.0", TMP_DATA);
+    expect(ran).toBe(true);
+    expect(fs.existsSync(path.join(TMP_DATA, "reindexed-0.9.0.txt"))).toBe(true);
+
+    const ix1 = openIndex();
+    const metaAfter = ix1.getFilterMeta(["decisions/g.md"]);
+    ix1.close();
+    expect(metaAfter.get("decisions/g.md")?.type).toBe("decision");
+    expect(metaAfter.get("decisions/g.md")?.agentRole).toBe("engineer");
+
+    const db2 = new Database(path.join(TMP_DATA, "index.db"));
+    db2.prepare("UPDATE notes SET note_type=NULL, agent_role=NULL WHERE rel_path=?").run("decisions/g.md");
+    db2.close();
+
+    const ran2 = await forcedReindexIfNeeded("0.9.0", TMP_DATA);
+    expect(ran2).toBe(false);
+
+    const ix2 = openIndex();
+    const metaNoChange = ix2.getFilterMeta(["decisions/g.md"]);
+    ix2.close();
+    expect(metaNoChange.get("decisions/g.md")?.type).toBeNull();
+    expect(metaNoChange.get("decisions/g.md")?.agentRole).toBeNull();
+  });
+});

--- a/tests/searchIndex.test.ts
+++ b/tests/searchIndex.test.ts
@@ -78,6 +78,18 @@ describe("searchIndex", () => {
     ix.close();
   });
 
+  it("persists note_type and agent_role and exposes them via getFilterMeta", () => {
+    const ix = openIndex();
+    ix.upsertNote("decisions/d.md", 1, "h", [
+      { headingPath: "", anchor: "", text: "alpha" },
+    ], [vec(0.3)], "global", "2026-01-01", "decision", "planner");
+    const meta = ix.getFilterMeta(["decisions/d.md"]);
+    expect(meta.get("decisions/d.md")).toEqual({
+      project: "global", created: "2026-01-01", type: "decision", agentRole: "planner",
+    });
+    ix.close();
+  });
+
   it("re-upsert/delete purges FTS heading terms (no stale contentless rows)", () => {
     const ix = openIndex();
     ix.upsertNote("p/h.md", 1, "h1",

--- a/tests/searchIndex.test.ts
+++ b/tests/searchIndex.test.ts
@@ -85,7 +85,7 @@ describe("searchIndex", () => {
     ], [vec(0.3)], "global", "2026-01-01", "decision", "planner");
     const meta = ix.getFilterMeta(["decisions/d.md"]);
     expect(meta.get("decisions/d.md")).toEqual({
-      project: "global", created: "2026-01-01", type: "decision", agentRole: "planner",
+      project: "global", created: "2026-01-01", type: "decision", agentRole: "planner", generated: false,
     });
     ix.close();
   });

--- a/tests/sessionAttribution.test.ts
+++ b/tests/sessionAttribution.test.ts
@@ -1,0 +1,16 @@
+import { it, expect } from "vitest";
+import { parentSessionId, attributionFields } from "../src/sessionAttribution.js";
+
+it("parentSessionId returns trimmed value when set", () => {
+  expect(parentSessionId({ SUPERBRAIN_PARENT_SESSION_ID: "  P  " })).toBe("P");
+});
+it("parentSessionId returns undefined when unset/blank", () => {
+  expect(parentSessionId({})).toBeUndefined();
+  expect(parentSessionId({ SUPERBRAIN_PARENT_SESSION_ID: "" })).toBeUndefined();
+  expect(parentSessionId({ SUPERBRAIN_PARENT_SESSION_ID: "   " })).toBeUndefined();
+});
+it("attributionFields is additive and a no-op when absent", () => {
+  expect(attributionFields({ SUPERBRAIN_PARENT_SESSION_ID: "P" })).toEqual({ parent_session_id: "P" });
+  expect(attributionFields({})).toEqual({});
+  expect({ a: 1, ...attributionFields({}) }).toEqual({ a: 1 });
+});

--- a/tests/sessionGc.test.ts
+++ b/tests/sessionGc.test.ts
@@ -115,6 +115,18 @@ describe("pruneSessionFiles", () => {
     expect(result.errors).toEqual([]);
   });
 
+  it("a fresh needs-distill flag keeps the session group from being pruned", () => {
+    const sd = sessDir(TMP);
+    const old = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+    fs.writeFileSync(path.join(sd, "B.ndjson"), "x\n");
+    fs.utimesSync(path.join(sd, "B.ndjson"), old, old);
+    fs.writeFileSync(path.join(sd, "B.needs-distill"), "1");
+    const res = pruneSessionFiles(TMP, { maxAgeDays: 30 });
+    expect(res.deleted).toHaveLength(0);
+    expect(fs.existsSync(path.join(sd, "B.ndjson"))).toBe(true);
+    expect(fs.existsSync(path.join(sd, "B.needs-distill"))).toBe(true);
+  });
+
   it("handles all known session extensions: .ndjson .cursor .pending .salience.json .injected.json .turns.json", () => {
     const old = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
     const sid = "session-exts-001";

--- a/tests/sessionGcRun.test.ts
+++ b/tests/sessionGcRun.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runSessionGcOncePerDay } from "../src/sessionGcRun.js";
+
+let TMP: string;
+const STAMP = "session-gc.stamp";
+
+function sessDir(base: string): string {
+  return path.join(base, "sessions");
+}
+function makeSessionFile(dir: string, name: string, mtime: Date): void {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, "");
+  fs.utimesSync(p, mtime, mtime);
+}
+function daysAgo(n: number): Date {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+}
+
+const GC_ENV = [
+  "SUPERBRAIN_GC_MAX_AGE_DAYS",
+  "SUPERBRAIN_GC_MIN_INTERVAL_HOURS",
+  "SUPERBRAIN_GC_DRY_RUN",
+  "SUPERBRAIN_GC_DISABLE",
+];
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sbgcrun-"));
+  fs.mkdirSync(sessDir(TMP), { recursive: true });
+  for (const k of GC_ENV) delete process.env[k];
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  for (const k of GC_ENV) delete process.env[k];
+});
+
+describe("runSessionGcOncePerDay", () => {
+  it("runs and writes stamp on first invocation", () => {
+    const sid = "s-first";
+    makeSessionFile(sessDir(TMP), `${sid}.ndjson`, daysAgo(40));
+    const r = runSessionGcOncePerDay(TMP);
+    expect(r.ran).toBe(true);
+    expect(r.skippedByCadence).toBe(false);
+    expect(fs.existsSync(path.join(TMP, STAMP))).toBe(true);
+    expect(fs.existsSync(path.join(sessDir(TMP), `${sid}.ndjson`))).toBe(false);
+  });
+
+  it("skips when stamp is fresh (cadence guard)", () => {
+    const sid = "s-fresh-stamp";
+    makeSessionFile(sessDir(TMP), `${sid}.ndjson`, daysAgo(40));
+    fs.writeFileSync(path.join(TMP, STAMP), "x");
+    const r = runSessionGcOncePerDay(TMP);
+    expect(r.ran).toBe(false);
+    expect(r.skippedByCadence).toBe(true);
+    expect(fs.existsSync(path.join(sessDir(TMP), `${sid}.ndjson`))).toBe(true);
+  });
+
+  it("runs again once the stamp is older than the interval", () => {
+    const sid = "s-stale-stamp";
+    makeSessionFile(sessDir(TMP), `${sid}.ndjson`, daysAgo(40));
+    const stampPath = path.join(TMP, STAMP);
+    fs.writeFileSync(stampPath, "x");
+    const old = daysAgo(2);
+    fs.utimesSync(stampPath, old, old);
+    const r = runSessionGcOncePerDay(TMP);
+    expect(r.ran).toBe(true);
+    expect(fs.existsSync(path.join(sessDir(TMP), `${sid}.ndjson`))).toBe(false);
+  });
+
+  it("deletes 31-day-old group and keeps 5-day-old group with default age", () => {
+    const oldSid = "s-old";
+    const freshSid = "s-recent";
+    makeSessionFile(sessDir(TMP), `${oldSid}.ndjson`, daysAgo(31));
+    makeSessionFile(sessDir(TMP), `${oldSid}.cursor`, daysAgo(31));
+    makeSessionFile(sessDir(TMP), `${freshSid}.ndjson`, daysAgo(5));
+    runSessionGcOncePerDay(TMP);
+    expect(fs.existsSync(path.join(sessDir(TMP), `${oldSid}.ndjson`))).toBe(false);
+    expect(fs.existsSync(path.join(sessDir(TMP), `${freshSid}.ndjson`))).toBe(true);
+  });
+
+  it("honors SUPERBRAIN_GC_MAX_AGE_DAYS override", () => {
+    process.env.SUPERBRAIN_GC_MAX_AGE_DAYS = "7";
+    const sid = "s-10d";
+    makeSessionFile(sessDir(TMP), `${sid}.ndjson`, daysAgo(10));
+    runSessionGcOncePerDay(TMP);
+    expect(fs.existsSync(path.join(sessDir(TMP), `${sid}.ndjson`))).toBe(false);
+  });
+
+  it("honors SUPERBRAIN_GC_MIN_INTERVAL_HOURS override", () => {
+    process.env.SUPERBRAIN_GC_MIN_INTERVAL_HOURS = "0";
+    const sid = "s-interval0";
+    makeSessionFile(sessDir(TMP), `${sid}.ndjson`, daysAgo(40));
+    const first = runSessionGcOncePerDay(TMP);
+    expect(first.ran).toBe(true);
+    makeSessionFile(sessDir(TMP), `${sid}-b.ndjson`, daysAgo(40));
+    const second = runSessionGcOncePerDay(TMP);
+    expect(second.ran).toBe(true);
+    expect(second.skippedByCadence).toBe(false);
+  });
+
+  it("dry-run reports deletions without removing files", () => {
+    process.env.SUPERBRAIN_GC_DRY_RUN = "1";
+    const sid = "s-dry";
+    makeSessionFile(sessDir(TMP), `${sid}.ndjson`, daysAgo(40));
+    const r = runSessionGcOncePerDay(TMP);
+    expect(r.ran).toBe(true);
+    expect(r.result!.deleted.length).toBeGreaterThan(0);
+    expect(fs.existsSync(path.join(sessDir(TMP), `${sid}.ndjson`))).toBe(true);
+    expect(fs.existsSync(path.join(TMP, STAMP))).toBe(true);
+  });
+
+  it("SUPERBRAIN_GC_DISABLE=1 disables GC entirely", () => {
+    process.env.SUPERBRAIN_GC_DISABLE = "1";
+    const sid = "s-disabled";
+    makeSessionFile(sessDir(TMP), `${sid}.ndjson`, daysAgo(40));
+    const r = runSessionGcOncePerDay(TMP);
+    expect(r.ran).toBe(false);
+    expect(r.skippedByCadence).toBe(false);
+    expect(fs.existsSync(path.join(sessDir(TMP), `${sid}.ndjson`))).toBe(true);
+    expect(fs.existsSync(path.join(TMP, STAMP))).toBe(false);
+  });
+
+  it("never deletes or modifies any .md note", () => {
+    const vault = path.join(TMP, "vault");
+    fs.mkdirSync(vault, { recursive: true });
+    const note = path.join(vault, "My Note.md");
+    fs.writeFileSync(note, "# Hand-authored\nimportant\n");
+    const strayMd = path.join(TMP, "README.md");
+    fs.writeFileSync(strayMd, "stray\n");
+
+    const old = daysAgo(40);
+    fs.utimesSync(note, old, old);
+    fs.utimesSync(strayMd, old, old);
+
+    makeSessionFile(sessDir(TMP), "s-vaultsafe.ndjson", old);
+
+    const before = {
+      note: { body: fs.readFileSync(note, "utf8"), mtime: fs.statSync(note).mtimeMs },
+      stray: { body: fs.readFileSync(strayMd, "utf8"), mtime: fs.statSync(strayMd).mtimeMs },
+    };
+
+    runSessionGcOncePerDay(TMP);
+
+    expect(fs.existsSync(note)).toBe(true);
+    expect(fs.existsSync(strayMd)).toBe(true);
+    expect(fs.readFileSync(note, "utf8")).toBe(before.note.body);
+    expect(fs.readFileSync(strayMd, "utf8")).toBe(before.stray.body);
+    expect(fs.statSync(note).mtimeMs).toBe(before.note.mtime);
+    expect(fs.statSync(strayMd).mtimeMs).toBe(before.stray.mtime);
+    expect(fs.existsSync(path.join(sessDir(TMP), "s-vaultsafe.ndjson"))).toBe(false);
+  });
+});

--- a/tests/sessionHierarchy.test.ts
+++ b/tests/sessionHierarchy.test.ts
@@ -1,0 +1,74 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { upsertDay, childrenOf } from "../src/dailyState.js";
+
+let TMP_DATA: string;
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-hier-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+});
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  delete process.env.SUPERBRAIN_DATA_DIR;
+});
+
+it("childrenOf filters by parent, ordered, empty + missing-file safe", () => {
+  upsertDay("2026-06-11", "cZ", { digestLine: "", routedRelPaths: [], alsoDid: [], openThreads: ["t1"], parentSessionId: "P" });
+  upsertDay("2026-06-11", "cA", { digestLine: "", routedRelPaths: [], alsoDid: [], openThreads: ["t2"], parentSessionId: "P" });
+  upsertDay("2026-06-11", "other", { digestLine: "", routedRelPaths: [], alsoDid: [], openThreads: [], parentSessionId: "Q" });
+  const kids = childrenOf("2026-06-11", "P");
+  expect(kids.map(k => k.sessionId)).toEqual(["cA", "cZ"]);
+  expect(kids[0].entry.openThreads).toEqual(["t2"]);
+  expect(childrenOf("2026-06-11", "ZZZ")).toEqual([]);
+  expect(childrenOf("1999-01-01", "P")).toEqual([]);
+});
+
+function runDistill(env: Record<string, string>, data: string, vault: string, stub: string) {
+  fs.mkdirSync(path.join(data, "sessions"), { recursive: true });
+  fs.writeFileSync(path.join(data, "sessions/S.ndjson"),
+    JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n");
+  fs.mkdirSync(path.join(data, "locks/distill.lock"), { recursive: true });
+  const merged = { ...process.env, SUPERBRAIN_DATA_DIR: data, SUPERBRAIN_VAULT_DIR: vault,
+    SUPERBRAIN_DISTILL_STUB: stub, SUPERBRAIN_SESSION_ID: "S", SUPERBRAIN_EMBED_STUB: "1", ...env };
+  if (!("SUPERBRAIN_PARENT_SESSION_ID" in env)) delete merged.SUPERBRAIN_PARENT_SESSION_ID;
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], { env: merged, encoding: "utf8" });
+}
+
+const STUB_ITEM = {
+  items: [{ kind: "decision", title: "Pick X", project: "test",
+    body: "## Decision\nPick X.\n## Why\n- Best fit.", date: "2026-05-19", links: [] }],
+  digest: "Chose X", openThreads: ["wire Y"], alsoDid: [],
+};
+
+it("records parent in daily state and stamps notes when env set", () => {
+  const data = fs.mkdtempSync(path.join(os.tmpdir(), "sb-h-d-"));
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), "sb-h-v-"));
+  const stub = path.join(data, "stub.json");
+  fs.mkdirSync(data, { recursive: true });
+  fs.writeFileSync(stub, JSON.stringify(STUB_ITEM));
+  runDistill({ SUPERBRAIN_PARENT_SESSION_ID: "P" }, data, vault, stub);
+  const day = JSON.parse(fs.readFileSync(path.join(data, "daily/2026-05-19.json"), "utf8"));
+  expect(day.S.parentSessionId).toBe("P");
+  const note = fs.readFileSync(path.join(vault, "decisions/2026-05-19-pick-x.md"), "utf8");
+  expect(note).toMatch(/^parent_session_id: P$/m);
+  fs.rmSync(data, { recursive: true, force: true });
+  fs.rmSync(vault, { recursive: true, force: true });
+});
+
+it("omits parentage entirely when env unset", () => {
+  const data = fs.mkdtempSync(path.join(os.tmpdir(), "sb-h-d2-"));
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), "sb-h-v2-"));
+  const stub = path.join(data, "stub.json");
+  fs.mkdirSync(data, { recursive: true });
+  fs.writeFileSync(stub, JSON.stringify(STUB_ITEM));
+  runDistill({}, data, vault, stub);
+  const day = JSON.parse(fs.readFileSync(path.join(data, "daily/2026-05-19.json"), "utf8"));
+  expect("parentSessionId" in day.S).toBe(false);
+  const note = fs.readFileSync(path.join(vault, "decisions/2026-05-19-pick-x.md"), "utf8");
+  expect(note).not.toMatch(/parent_session_id/);
+  fs.rmSync(data, { recursive: true, force: true });
+  fs.rmSync(vault, { recursive: true, force: true });
+});

--- a/tests/sessionHierarchy.test.ts
+++ b/tests/sessionHierarchy.test.ts
@@ -39,7 +39,8 @@ function runDistill(env: Record<string, string>, data: string, vault: string, st
 
 const STUB_ITEM = {
   items: [{ kind: "decision", title: "Pick X", project: "test",
-    body: "## Decision\nPick X.\n## Why\n- Best fit.", date: "2026-05-19", links: [] }],
+    body: "## Decision\nPick X.\n## Why\n- Best fit.\n## Alternatives considered\n- **Alt A** — rejected because cost.\n## Consequences\n- Trade-offs apply.",
+    date: "2026-05-19", links: [] }],
   digest: "Chose X", openThreads: ["wire Y"], alsoDid: [],
 };
 

--- a/tests/vaultWriter.test.ts
+++ b/tests/vaultWriter.test.ts
@@ -173,4 +173,23 @@ describe("vaultWriter", () => {
 
     delete process.env.SUPERBRAIN_PROJECT_NOTE_CAP_BYTES;
   });
+
+  it("project-note append survives a concurrent peer write (CAS)", () => {
+    const fm = { type: "project", status: "active", project: "demo" };
+    writeNote("projects/demo.md", { frontmatter: fm, body: "# demo\n\n## Recent activity\n", mode: "create" });
+    writeNote("projects/demo.md", { frontmatter: fm, body: "BBBB fact bravo this is distiller B unique content line one two three", mode: "append" });
+    writeNote("projects/demo.md", { frontmatter: fm, body: "AAAA fact alpha this is distiller A unique content line one two three", mode: "append" });
+    const t = fs.readFileSync(path.join(TMP, "projects/demo.md"), "utf8");
+    expect(t).toContain("BBBB fact bravo");
+    expect(t).toContain("AAAA fact alpha");
+  });
+
+  it("general append survives a concurrent peer write (CAS)", () => {
+    writeNote("daily/2026-05-19.md", { frontmatter: { type: "daily" }, body: "first body alpha unique content line one two three four", mode: "create" });
+    writeNote("daily/2026-05-19.md", { frontmatter: { type: "daily" }, body: "BBBB peer body bravo unique content line one two three four", mode: "append" });
+    writeNote("daily/2026-05-19.md", { frontmatter: { type: "daily" }, body: "AAAA later body alpha unique content line one two three four", mode: "append" });
+    const t = fs.readFileSync(path.join(TMP, "daily/2026-05-19.md"), "utf8");
+    expect(t).toContain("BBBB peer body bravo");
+    expect(t).toContain("AAAA later body alpha");
+  });
 });


### PR DESCRIPTION
Makes SuperBrain's memory safe and useful when many assistants work at once. Fixes two ways memories could silently disappear (simultaneous writes overwriting each other; short-lived sessions never getting saved), records who wrote each memory and which session it came from, lets searches be narrowed by project, kind, date, or author instead of returning everything blended, stops old archived material from drowning out current notes, gives each project an auto-maintained table of contents, and tidies old session logs once a day.

Nothing is removed. The version moves to 0.9.0 so existing installs re-index once.

876 tests green. Twelve board tasks total, each through independent review and QA; a post-hoc adversarial code review found three additional defects (a retry-state carry that could drop archived sections, and two slug-normalization gaps that mis-filed hand-authored notes and mis-scoped preferences) — all three fixed and verified on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
