### PR TITLE
feat: session flight recorder (turn log, checkpoint digest, orphan sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Safety rails: inject never creates new project notes (use `/superbrain:discover`
 ├── daily/         auto-written daily activity
 ├── lessons/       durable, generalizable rules learned from your pushback
 ├── capture/       raw inbound; triage tag for `/superbrain:inject` items
+├── sessions/      per-session flight recorder — raw turn log + checkpoint digest (pruned after 30 days)
 ├── meta/          preferences.md — deduplicated profile auto-injected at SessionStart
 ├── maps/          auto-generated Maps-of-Content   (planned)
 └── index.md       catalog — the primary navigation surface

--- a/bin/sb-checkpoint.ts
+++ b/bin/sb-checkpoint.ts
@@ -7,6 +7,8 @@ import { acquireLock, releaseLock } from "../src/lockfile.js";
 import { writeFailure } from "../src/sentinel.js";
 import { isChild, buildDistillCommand } from "../src/distillerEngine.js";
 import { snapshotTranscript } from "../src/transcriptStore.js";
+import { appendAssistantTail } from "../src/sessionNote.js";
+import { readLastAssistantText } from "../src/transcriptTail.js";
 
 function readStdin(): string { try { return fs.readFileSync(0, "utf8"); } catch { return ""; } }
 
@@ -17,6 +19,11 @@ function main() {
     const sid = h.session_id || "unknown";
     const event = h.hook_event_name;
     const pendingFile = path.join(dataDir(), "sessions", `${sid}.pending`);
+
+    try {
+      const tail = readLastAssistantText(h.transcript_path);
+      if (tail) appendAssistantTail(sid, h.cwd || process.cwd(), tail);
+    } catch { /* turn log is best-effort */ }
 
     // Stop only acts when a salience marker is pending. PreCompact/SessionEnd always act.
     if (event === "Stop" && !fs.existsSync(pendingFile)) process.exit(0);

--- a/bin/sb-recall.ts
+++ b/bin/sb-recall.ts
@@ -3,15 +3,19 @@ import fs from "node:fs";
 import { isChild } from "../src/distillerEngine.js";
 import { depsPresent } from "../src/bootstrap.js";
 import { pluginRoot } from "../src/paths.js";
+import { appendPromptLine } from "../src/sessionNote.js";
 
 function readStdin(): string { try { return fs.readFileSync(0, "utf8"); } catch { return ""; } }
 
 async function main() {
   if (isChild()) process.exit(0);
   try {
-    if (!depsPresent(pluginRoot())) process.exit(0);
     let h: any; try { h = JSON.parse(readStdin()); } catch { process.exit(0); }
     const prompt = (h?.prompt || "").trim();
+    try {
+      if (h?.session_id && prompt) appendPromptLine(h.session_id, h?.cwd || process.cwd(), prompt);
+    } catch { /* turn log is best-effort */ }
+    if (!depsPresent(pluginRoot())) process.exit(0);
     if (!prompt) process.exit(0);
 
     const { getInjectedSlugs, appendInjectedSlugs } = await import("../src/sessionInjected.js");

--- a/bin/sb-reconcile.ts
+++ b/bin/sb-reconcile.ts
@@ -31,6 +31,12 @@ async function main() {
   );
   await reconcile().catch((e: any) => writeFailure(`reconcile failed: ${e?.message || e}`));
   try {
+    const { sweepOrphanedSessions } = await import("../src/distillRun.js");
+    await sweepOrphanedSessions(process.env.SUPERBRAIN_SESSION_ID || "");
+  } catch (e: any) {
+    writeFailure(`orphan sweep failed: ${e?.message || e}`);
+  }
+  try {
     const { runSessionGcOncePerDay } = await import("../src/sessionGcRun.js");
     runSessionGcOncePerDay(dataDir());
   } catch (e: any) {

--- a/bin/sb-session-start.ts
+++ b/bin/sb-session-start.ts
@@ -52,7 +52,7 @@ async function main() {
         const reconciler = fileURLToPath(new URL("./sb-reconcile.js", import.meta.url));
         spawn(process.execPath, [reconciler], {
           detached: true, stdio: "ignore",
-          env: { ...process.env, SUPERBRAIN_CHILD: "1" }, cwd: vaultPath(),
+          env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || "") }, cwd: vaultPath(),
         }).unref();
       } catch { /* non-fatal */ }
     }

--- a/dist/bin/sb-checkpoint.js
+++ b/dist/bin/sb-checkpoint.js
@@ -7,6 +7,8 @@ import { acquireLock, releaseLock } from "../src/lockfile.js";
 import { writeFailure } from "../src/sentinel.js";
 import { isChild, buildDistillCommand } from "../src/distillerEngine.js";
 import { snapshotTranscript } from "../src/transcriptStore.js";
+import { appendAssistantTail } from "../src/sessionNote.js";
+import { readLastAssistantText } from "../src/transcriptTail.js";
 function readStdin() { try {
     return fs.readFileSync(0, "utf8");
 }
@@ -27,6 +29,12 @@ function main() {
         const sid = h.session_id || "unknown";
         const event = h.hook_event_name;
         const pendingFile = path.join(dataDir(), "sessions", `${sid}.pending`);
+        try {
+            const tail = readLastAssistantText(h.transcript_path);
+            if (tail)
+                appendAssistantTail(sid, h.cwd || process.cwd(), tail);
+        }
+        catch { /* turn log is best-effort */ }
         // Stop only acts when a salience marker is pending. PreCompact/SessionEnd always act.
         if (event === "Stop" && !fs.existsSync(pendingFile))
             process.exit(0);

--- a/dist/bin/sb-recall.js
+++ b/dist/bin/sb-recall.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { isChild } from "../src/distillerEngine.js";
 import { depsPresent } from "../src/bootstrap.js";
 import { pluginRoot } from "../src/paths.js";
+import { appendPromptLine } from "../src/sessionNote.js";
 function readStdin() { try {
     return fs.readFileSync(0, "utf8");
 }
@@ -13,8 +14,6 @@ async function main() {
     if (isChild())
         process.exit(0);
     try {
-        if (!depsPresent(pluginRoot()))
-            process.exit(0);
         let h;
         try {
             h = JSON.parse(readStdin());
@@ -23,6 +22,13 @@ async function main() {
             process.exit(0);
         }
         const prompt = (h?.prompt || "").trim();
+        try {
+            if (h?.session_id && prompt)
+                appendPromptLine(h.session_id, h?.cwd || process.cwd(), prompt);
+        }
+        catch { /* turn log is best-effort */ }
+        if (!depsPresent(pluginRoot()))
+            process.exit(0);
         if (!prompt)
             process.exit(0);
         const { getInjectedSlugs, appendInjectedSlugs } = await import("../src/sessionInjected.js");

--- a/dist/bin/sb-reconcile.js
+++ b/dist/bin/sb-reconcile.js
@@ -26,6 +26,13 @@ async function main() {
     await runCheapUpgradeSteps(dataDir(), version).catch((e) => writeFailure(`auto-upgrade failed: ${e?.message || e}`));
     await reconcile().catch((e) => writeFailure(`reconcile failed: ${e?.message || e}`));
     try {
+        const { sweepOrphanedSessions } = await import("../src/distillRun.js");
+        await sweepOrphanedSessions(process.env.SUPERBRAIN_SESSION_ID || "");
+    }
+    catch (e) {
+        writeFailure(`orphan sweep failed: ${e?.message || e}`);
+    }
+    try {
         const { runSessionGcOncePerDay } = await import("../src/sessionGcRun.js");
         runSessionGcOncePerDay(dataDir());
     }

--- a/dist/bin/sb-session-start.js
+++ b/dist/bin/sb-session-start.js
@@ -65,7 +65,7 @@ async function main() {
                 const reconciler = fileURLToPath(new URL("./sb-reconcile.js", import.meta.url));
                 spawn(process.execPath, [reconciler], {
                     detached: true, stdio: "ignore",
-                    env: { ...process.env, SUPERBRAIN_CHILD: "1" }, cwd: vaultPath(),
+                    env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || "") }, cwd: vaultPath(),
                 }).unref();
             }
             catch { /* non-fatal */ }

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -10,7 +10,7 @@ import { readDelta } from "./ndjson.js";
 import { readCursor, writeCursor } from "./cursor.js";
 import { route } from "./router.js";
 import { writeNote } from "./vaultWriter.js";
-import { releaseLock } from "./lockfile.js";
+import { acquireLock, releaseLock } from "./lockfile.js";
 import { writeFailure } from "./sentinel.js";
 import { vaultPath, dataDir } from "./paths.js";
 import { indexNote } from "./indexer.js";
@@ -21,7 +21,8 @@ import { filterToUniversal } from "./preferenceClassify.js";
 import { resolveLinks } from "./wikilink.js";
 import { gcTranscript } from "./transcriptStore.js";
 import { pruneSessionFiles } from "./sessionGc.js";
-import { sweepPendingDistills, clearFlag } from "./distillSweep.js";
+import { updateSessionNoteDigest } from "./sessionNote.js";
+import { sweepPendingDistills, clearFlag, listOrphanedSessions } from "./distillSweep.js";
 import { classify } from "./classification.js";
 import { recordRejection } from "./rejectQueue.js";
 import { serializeNote } from "./frontmatter.js";
@@ -466,6 +467,12 @@ export async function distillFromEvents(sid, events) {
     catch (e) {
         writeFailure(`daily note failed: ${e?.message || e}`);
     }
+    try {
+        updateSessionNoteDigest(sid, env.digest || "", Object.values(routedByDate).flat());
+    }
+    catch (e) {
+        writeFailure(`session note digest failed: ${e?.message || e}`);
+    }
     return { notesWritten };
 }
 async function distillSession(sid) {
@@ -518,4 +525,33 @@ export async function runDistill() {
     finally {
         releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN);
     }
+}
+export async function sweepOrphanedSessions(excludeSid) {
+    const orphans = listOrphanedSessions(excludeSid);
+    if (!orphans.length)
+        return 0;
+    if (!acquireLock("distill"))
+        return 0;
+    let token;
+    try {
+        token = fs.readFileSync(path.join(dataDir(), "locks", "distill.lock", "token"), "utf8");
+    }
+    catch { /* best-effort */ }
+    let swept = 0;
+    try {
+        for (const sid of orphans) {
+            try {
+                await distillSession(sid);
+                clearFlag(sid);
+                swept++;
+            }
+            catch (e) {
+                writeFailure(`orphan distill failed for ${sid}: ${e?.message || e}`);
+            }
+        }
+    }
+    finally {
+        releaseLock("distill", token);
+    }
+    return swept;
 }

--- a/dist/src/distillSweep.js
+++ b/dist/src/distillSweep.js
@@ -25,7 +25,8 @@ export function clearFlag(sid) {
 }
 const NDJSON_EXT = ".ndjson";
 export function listOrphanedSessions(excludeSid, opts) {
-    const envHours = Number(process.env.SUPERBRAIN_ORPHAN_IDLE_HOURS);
+    const rawEnv = process.env.SUPERBRAIN_ORPHAN_IDLE_HOURS;
+    const envHours = rawEnv && rawEnv.trim() ? Number(rawEnv) : NaN;
     const maxIdleMs = opts?.maxIdleMs
         ?? (Number.isFinite(envHours) && envHours >= 0 ? envHours : 3) * 3_600_000;
     const now = opts?.now ?? Date.now();

--- a/dist/src/distillSweep.js
+++ b/dist/src/distillSweep.js
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { sessionsDir } from "./paths.js";
 import { writeFailure } from "./sentinel.js";
+import { readCursor } from "./cursor.js";
 const FLAG_EXT = ".needs-distill";
 export function flagPath(sid) {
     return path.join(sessionsDir(), `${sid}${FLAG_EXT}`);
@@ -21,6 +22,37 @@ export function clearFlag(sid) {
         fs.rmSync(flagPath(sid), { force: true });
     }
     catch { /* best-effort */ }
+}
+const NDJSON_EXT = ".ndjson";
+export function listOrphanedSessions(excludeSid, opts) {
+    const envHours = Number(process.env.SUPERBRAIN_ORPHAN_IDLE_HOURS);
+    const maxIdleMs = opts?.maxIdleMs
+        ?? (Number.isFinite(envHours) && envHours >= 0 ? envHours : 3) * 3_600_000;
+    const now = opts?.now ?? Date.now();
+    let entries;
+    try {
+        entries = fs.readdirSync(sessionsDir());
+    }
+    catch {
+        return [];
+    }
+    const out = [];
+    for (const f of entries) {
+        if (!f.endsWith(NDJSON_EXT))
+            continue;
+        const sid = f.slice(0, -NDJSON_EXT.length);
+        if (sid === excludeSid)
+            continue;
+        try {
+            const st = fs.statSync(path.join(sessionsDir(), f));
+            if (now - st.mtimeMs < maxIdleMs)
+                continue;
+            if (st.size > readCursor(sid))
+                out.push(sid);
+        }
+        catch { /* unreadable entry — skip */ }
+    }
+    return out;
 }
 export async function sweepPendingDistills(excludeSid, distillOne) {
     for (const sid of listFlaggedSessions()) {

--- a/dist/src/indexer.js
+++ b/dist/src/indexer.js
@@ -9,7 +9,7 @@ import { parseNote } from "./frontmatter.js";
 import { deriveEdges, deleteEdgesFrom, upsertEdges } from "./edges.js";
 import { slug as routerSlug } from "./router.js";
 import { buildProjectIndex, enumerateProjectSlugs } from "./projectIndex.js";
-const EXCLUDED = new Set([".trash", ".obsidian", ".git", "node_modules"]);
+const EXCLUDED = new Set([".trash", ".obsidian", ".git", "node_modules", "sessions"]);
 function walk(dir, root, acc) {
     for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
         if (e.isDirectory()) {

--- a/dist/src/sessionGc.js
+++ b/dist/src/sessionGc.js
@@ -1,10 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
+import { softDelete } from "./vaultWriter.js";
+import { vaultPath } from "./paths.js";
 const KNOWN_EXTENSIONS = new Set([
     ".ndjson",
     ".cursor",
     ".pending",
     ".needs-distill",
+    ".note",
     ".salience.json",
     ".injected.json",
     ".turns.json",
@@ -80,6 +83,46 @@ export function pruneSessionFiles(dataDirPath, opts) {
                     result.errors.push(`${fp}: ${e?.message ?? String(e)}`);
                 }
             }
+        }
+    }
+    return result;
+}
+export function pruneSessionNotes(opts) {
+    const maxAgeDays = opts?.maxAgeDays ?? 30;
+    const dryRun = opts?.dryRun ?? false;
+    const result = { deleted: [], skipped: 0, errors: [] };
+    const dir = path.join(vaultPath(), "sessions");
+    let entries;
+    try {
+        entries = fs.readdirSync(dir);
+    }
+    catch {
+        return result;
+    }
+    const nowMs = Date.now();
+    const thresholdMs = maxAgeDays * 24 * 60 * 60 * 1000;
+    for (const f of entries) {
+        if (!f.endsWith(".md"))
+            continue;
+        const fp = path.join(dir, f);
+        try {
+            const stat = fs.statSync(fp);
+            if (nowMs - stat.mtimeMs < thresholdMs) {
+                result.skipped++;
+                continue;
+            }
+            if (dryRun) {
+                result.deleted.push(fp);
+                continue;
+            }
+            const res = softDelete(path.join("sessions", f));
+            if (res.ok)
+                result.deleted.push(fp);
+            else
+                result.errors.push(`${fp}: ${res.reason}`);
+        }
+        catch (e) {
+            result.errors.push(`${fp}: ${e?.message ?? String(e)}`);
         }
     }
     return result;

--- a/dist/src/sessionGcRun.js
+++ b/dist/src/sessionGcRun.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { pruneSessionFiles } from "./sessionGc.js";
+import { pruneSessionFiles, pruneSessionNotes } from "./sessionGc.js";
 const STAMP_FILE = "session-gc.stamp";
 const DEFAULT_MIN_INTERVAL_HOURS = 24;
 function envNumber(name, fallback) {
@@ -32,6 +32,10 @@ export function runSessionGcOncePerDay(dataDirPath, opts) {
     const maxAgeDays = envNumber("SUPERBRAIN_GC_MAX_AGE_DAYS", 30);
     const dryRun = process.env.SUPERBRAIN_GC_DRY_RUN === "1";
     const result = pruneSessionFiles(dataDirPath, { maxAgeDays, dryRun });
+    try {
+        pruneSessionNotes({ maxAgeDays, dryRun });
+    }
+    catch { /* best-effort */ }
     try {
         fs.mkdirSync(dataDirPath, { recursive: true });
         fs.writeFileSync(stampPath, new Date(now).toISOString());

--- a/dist/src/sessionNote.js
+++ b/dist/src/sessionNote.js
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+import path from "node:path";
+import { sessionsDir, vaultPath } from "./paths.js";
+import { resolveProjectSlug } from "./sessionProject.js";
+const TURN_LOG_CAP_BYTES = 64 * 1024;
+const LINE_MAX = 200;
+const TURN_LOG_MARKER = "## Turn log\n";
+export function notePointerPath(sid) {
+    return path.join(sessionsDir(), `${sid}.note`);
+}
+function today() { return new Date().toISOString().slice(0, 10); }
+function hhmm() { return new Date().toTimeString().slice(0, 5); }
+function oneLine(text, max = LINE_MAX) {
+    const t = text.replace(/\s+/g, " ").trim();
+    return t.length > max ? t.slice(0, max - 1) + "…" : t;
+}
+function safeSlug(cwd) {
+    try {
+        return resolveProjectSlug(cwd);
+    }
+    catch {
+        return undefined;
+    }
+}
+function skeleton(sid, slug) {
+    const head = slug
+        ? `# Session ${sid.slice(0, 8)} — [[projects/${slug}]]`
+        : `# Session ${sid.slice(0, 8)}`;
+    const fm = [
+        "---",
+        "type: session",
+        `session: ${sid}`,
+        ...(slug ? [`project: ${slug}`] : []),
+        `created: ${today()}`,
+        `updated: ${today()}`,
+        "superbrain: true",
+        "---",
+    ].join("\n");
+    return `${fm}\n\n${head}\n\n## Digest\n\n(no checkpoint yet)\n\n## Notes routed\n\n${TURN_LOG_MARKER}`;
+}
+function ensureNote(sid, cwd) {
+    const ptr = notePointerPath(sid);
+    let rel = "";
+    try {
+        rel = fs.readFileSync(ptr, "utf8").trim();
+    }
+    catch { /* no pointer yet */ }
+    let slug;
+    if (!rel) {
+        slug = safeSlug(cwd);
+        rel = path.join("sessions", `${slug || "unscoped"}-${Math.floor(Date.now() / 1000)}.md`);
+        fs.mkdirSync(path.dirname(ptr), { recursive: true });
+        fs.writeFileSync(ptr, rel);
+    }
+    const abs = path.join(vaultPath(), rel);
+    if (!fs.existsSync(abs)) {
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, skeleton(sid, slug ?? safeSlug(cwd)));
+    }
+    return abs;
+}
+function trimTurnLog(abs) {
+    let raw;
+    try {
+        raw = fs.readFileSync(abs, "utf8");
+    }
+    catch {
+        return;
+    }
+    if (Buffer.byteLength(raw, "utf8") <= TURN_LOG_CAP_BYTES)
+        return;
+    const i = raw.indexOf(TURN_LOG_MARKER);
+    if (i < 0)
+        return;
+    const head = raw.slice(0, i + TURN_LOG_MARKER.length);
+    const lines = raw.slice(i + TURN_LOG_MARKER.length).split("\n");
+    while (lines.length > 1 && Buffer.byteLength(head + lines.join("\n"), "utf8") > TURN_LOG_CAP_BYTES) {
+        lines.shift();
+    }
+    fs.writeFileSync(abs, head + lines.join("\n"));
+}
+export function appendPromptLine(sid, cwd, prompt) {
+    if (!sid || !prompt.trim())
+        return;
+    const abs = ensureNote(sid, cwd);
+    fs.appendFileSync(abs, `- ${hhmm()} ▸ ${oneLine(prompt)}\n`);
+    trimTurnLog(abs);
+}
+export function appendAssistantTail(sid, cwd, text) {
+    if (!sid || !text.trim())
+        return;
+    const abs = ensureNote(sid, cwd);
+    fs.appendFileSync(abs, `  ↳ ${oneLine(text)}\n`);
+    trimTurnLog(abs);
+}
+export function updateSessionNoteDigest(sid, digest, routedRelPaths) {
+    let rel;
+    try {
+        rel = fs.readFileSync(notePointerPath(sid), "utf8").trim();
+    }
+    catch {
+        return;
+    }
+    if (!rel)
+        return;
+    const abs = path.join(vaultPath(), rel);
+    let raw;
+    try {
+        raw = fs.readFileSync(abs, "utf8");
+    }
+    catch {
+        return;
+    }
+    if (digest.trim()) {
+        const dMarker = "## Digest\n";
+        const di = raw.indexOf(dMarker);
+        if (di >= 0) {
+            const start = di + dMarker.length;
+            const end = raw.indexOf("\n## ", start);
+            const tail = end < 0 ? "" : raw.slice(end);
+            raw = raw.slice(0, start) + `\n${oneLine(digest, 400)}\n` + tail;
+        }
+    }
+    const marker = "## Notes routed\n";
+    const i = raw.indexOf(marker);
+    if (i >= 0 && routedRelPaths.length) {
+        const insertAt = i + marker.length;
+        const end = raw.indexOf("\n## ", insertAt);
+        const existing = end < 0 ? raw.slice(insertAt) : raw.slice(insertAt, end);
+        const fresh = routedRelPaths
+            .map((p) => `- [[${p.replace(/\.md$/, "")}]]`)
+            .filter((l) => !existing.includes(l));
+        if (fresh.length)
+            raw = raw.slice(0, insertAt) + fresh.join("\n") + "\n" + raw.slice(insertAt);
+    }
+    raw = raw.replace(/^updated: .*$/m, `updated: ${today()}`);
+    fs.writeFileSync(abs, raw);
+}

--- a/dist/src/transcriptTail.js
+++ b/dist/src/transcriptTail.js
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+const TAIL_BYTES = 256 * 1024;
+export function readLastAssistantText(transcriptPath) {
+    if (!transcriptPath)
+        return "";
+    let fd;
+    try {
+        fd = fs.openSync(transcriptPath, "r");
+    }
+    catch {
+        return "";
+    }
+    try {
+        const size = fs.fstatSync(fd).size;
+        const start = Math.max(0, size - TAIL_BYTES);
+        const buf = Buffer.alloc(size - start);
+        fs.readSync(fd, buf, 0, buf.length, start);
+        let lines = buf.toString("utf8").split("\n");
+        if (start > 0)
+            lines = lines.slice(1);
+        for (let i = lines.length - 1; i >= 0; i--) {
+            const line = lines[i].trim();
+            if (!line)
+                continue;
+            let j;
+            try {
+                j = JSON.parse(line);
+            }
+            catch {
+                continue;
+            }
+            if (j?.type !== "assistant")
+                continue;
+            const content = j?.message?.content;
+            if (typeof content === "string" && content.trim())
+                return content.trim();
+            if (Array.isArray(content)) {
+                const t = content
+                    .filter((c) => c?.type === "text" && typeof c.text === "string")
+                    .map((c) => c.text)
+                    .join(" ")
+                    .trim();
+                if (t)
+                    return t;
+            }
+        }
+        return "";
+    }
+    catch {
+        return "";
+    }
+    finally {
+        try {
+            fs.closeSync(fd);
+        }
+        catch { /* already closed */ }
+    }
+}

--- a/skills/superbrain-recall/SKILL.md
+++ b/skills/superbrain-recall/SKILL.md
@@ -13,3 +13,27 @@ When the user's question may already be answered by their accumulated notes, cal
 - If results are empty or irrelevant, say so plainly and answer normally — never
   fabricate a citation or invent a note.
 - Prefer one well-formed query over many noisy ones.
+
+## Gap sensing — when memory looks stale
+
+Recalled memory can lag reality: a session may have crashed before its last
+checkpoint distilled, or the machine slept mid-conversation. Before answering
+questions about recent work, check for staleness signals:
+
+- git history shows commits NEWER than the latest memory for this project
+- the user references recent work you have no recall of
+
+When you suspect a gap:
+
+1. List `sessions/` in the vault, filtered to this project's slug, newest
+   first (the filename embeds a unix timestamp: `{project}-{ts}.md`).
+2. Read the newest note that is not the current session: the `## Digest`
+   line summarizes the session as of its last checkpoint; the `## Turn log`
+   carries the raw prompt/reply trail beyond it.
+3. If finer detail is needed and the session is recent (~30 days), the raw
+   Claude transcript can be derived — `~/.claude/projects/<cwd with "/" and
+   "." replaced by "-">/`, newest `.jsonl` by mtime. Read its tail rather
+   than the whole file. Where resuming would genuinely help, offer
+   `claude --resume <session-id>` to the user; never resume on your own.
+4. State plainly which parts of your answer come from the flight recorder
+   versus distilled memory.

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -23,6 +23,7 @@ import { filterToUniversal } from "./preferenceClassify.js";
 import { resolveLinks } from "./wikilink.js";
 import { gcTranscript } from "./transcriptStore.js";
 import { pruneSessionFiles } from "./sessionGc.js";
+import { updateSessionNoteDigest } from "./sessionNote.js";
 import { sweepPendingDistills, clearFlag } from "./distillSweep.js";
 import { classify } from "./classification.js";
 import { recordRejection } from "./rejectQueue.js";
@@ -446,6 +447,9 @@ export async function distillFromEvents(sid: string, events: any[]): Promise<Dis
       try { await indexNote(dn.relPath); } catch (e: any) { writeFailure(`index failed: ${e?.message || e}`); }
     }
   } catch (e: any) { writeFailure(`daily note failed: ${e?.message || e}`); }
+  try {
+    updateSessionNoteDigest(sid, env.digest || "", Object.values(routedByDate).flat());
+  } catch (e: any) { writeFailure(`session note digest failed: ${e?.message || e}`); }
   return { notesWritten };
 }
 

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -12,7 +12,7 @@ import { readDelta } from "./ndjson.js";
 import { readCursor, writeCursor } from "./cursor.js";
 import { route, type DistilledItem } from "./router.js";
 import { writeNote } from "./vaultWriter.js";
-import { releaseLock } from "./lockfile.js";
+import { acquireLock, releaseLock } from "./lockfile.js";
 import { writeFailure } from "./sentinel.js";
 import { vaultPath, dataDir } from "./paths.js";
 import { indexNote } from "./indexer.js";
@@ -24,7 +24,7 @@ import { resolveLinks } from "./wikilink.js";
 import { gcTranscript } from "./transcriptStore.js";
 import { pruneSessionFiles } from "./sessionGc.js";
 import { updateSessionNoteDigest } from "./sessionNote.js";
-import { sweepPendingDistills, clearFlag } from "./distillSweep.js";
+import { sweepPendingDistills, clearFlag, listOrphanedSessions } from "./distillSweep.js";
 import { classify } from "./classification.js";
 import { recordRejection } from "./rejectQueue.js";
 import { type NoteType } from "./templates.js";
@@ -479,4 +479,27 @@ export async function runDistill(): Promise<void> {
   } finally {
     releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN);
   }
+}
+
+export async function sweepOrphanedSessions(excludeSid: string): Promise<number> {
+  const orphans = listOrphanedSessions(excludeSid);
+  if (!orphans.length) return 0;
+  if (!acquireLock("distill")) return 0;
+  let token: string | undefined;
+  try { token = fs.readFileSync(path.join(dataDir(), "locks", "distill.lock", "token"), "utf8"); } catch { /* best-effort */ }
+  let swept = 0;
+  try {
+    for (const sid of orphans) {
+      try {
+        await distillSession(sid);
+        clearFlag(sid);
+        swept++;
+      } catch (e: any) {
+        writeFailure(`orphan distill failed for ${sid}: ${e?.message || e}`);
+      }
+    }
+  } finally {
+    releaseLock("distill", token);
+  }
+  return swept;
 }

--- a/src/distillSweep.ts
+++ b/src/distillSweep.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { sessionsDir } from "./paths.js";
 import { writeFailure } from "./sentinel.js";
+import { readCursor } from "./cursor.js";
 
 const FLAG_EXT = ".needs-distill";
 
@@ -19,6 +20,31 @@ export function listFlaggedSessions(): string[] {
 
 export function clearFlag(sid: string): void {
   try { fs.rmSync(flagPath(sid), { force: true }); } catch { /* best-effort */ }
+}
+
+const NDJSON_EXT = ".ndjson";
+
+export interface OrphanScanOptions { maxIdleMs?: number; now?: number }
+
+export function listOrphanedSessions(excludeSid: string, opts?: OrphanScanOptions): string[] {
+  const envHours = Number(process.env.SUPERBRAIN_ORPHAN_IDLE_HOURS);
+  const maxIdleMs = opts?.maxIdleMs
+    ?? (Number.isFinite(envHours) && envHours >= 0 ? envHours : 3) * 3_600_000;
+  const now = opts?.now ?? Date.now();
+  let entries: string[];
+  try { entries = fs.readdirSync(sessionsDir()); } catch { return []; }
+  const out: string[] = [];
+  for (const f of entries) {
+    if (!f.endsWith(NDJSON_EXT)) continue;
+    const sid = f.slice(0, -NDJSON_EXT.length);
+    if (sid === excludeSid) continue;
+    try {
+      const st = fs.statSync(path.join(sessionsDir(), f));
+      if (now - st.mtimeMs < maxIdleMs) continue;
+      if (st.size > readCursor(sid)) out.push(sid);
+    } catch { /* unreadable entry — skip */ }
+  }
+  return out;
 }
 
 export async function sweepPendingDistills(

--- a/src/distillSweep.ts
+++ b/src/distillSweep.ts
@@ -27,7 +27,8 @@ const NDJSON_EXT = ".ndjson";
 export interface OrphanScanOptions { maxIdleMs?: number; now?: number }
 
 export function listOrphanedSessions(excludeSid: string, opts?: OrphanScanOptions): string[] {
-  const envHours = Number(process.env.SUPERBRAIN_ORPHAN_IDLE_HOURS);
+  const rawEnv = process.env.SUPERBRAIN_ORPHAN_IDLE_HOURS;
+  const envHours = rawEnv && rawEnv.trim() ? Number(rawEnv) : NaN;
   const maxIdleMs = opts?.maxIdleMs
     ?? (Number.isFinite(envHours) && envHours >= 0 ? envHours : 3) * 3_600_000;
   const now = opts?.now ?? Date.now();

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -10,7 +10,7 @@ import { deriveEdges, deleteEdgesFrom, upsertEdges } from "./edges.js";
 import { slug as routerSlug } from "./router.js";
 import { buildProjectIndex, enumerateProjectSlugs } from "./projectIndex.js";
 
-const EXCLUDED = new Set([".trash", ".obsidian", ".git", "node_modules"]);
+const EXCLUDED = new Set([".trash", ".obsidian", ".git", "node_modules", "sessions"]);
 
 function walk(dir: string, root: string, acc: string[]) {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/src/sessionGc.ts
+++ b/src/sessionGc.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { softDelete } from "./vaultWriter.js";
+import { vaultPath } from "./paths.js";
 
 export interface SessionGcOptions {
   maxAgeDays?: number;
@@ -104,14 +105,11 @@ export function pruneSessionFiles(
   return result;
 }
 
-export function pruneSessionNotes(
-  vault: string,
-  opts?: SessionGcOptions,
-): SessionGcResult {
+export function pruneSessionNotes(opts?: SessionGcOptions): SessionGcResult {
   const maxAgeDays = opts?.maxAgeDays ?? 30;
   const dryRun = opts?.dryRun ?? false;
   const result: SessionGcResult = { deleted: [], skipped: 0, errors: [] };
-  const dir = path.join(vault, "sessions");
+  const dir = path.join(vaultPath(), "sessions");
   let entries: string[];
   try { entries = fs.readdirSync(dir); } catch { return result; }
   const nowMs = Date.now();

--- a/src/sessionGc.ts
+++ b/src/sessionGc.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { softDelete } from "./vaultWriter.js";
 
 export interface SessionGcOptions {
   maxAgeDays?: number;
@@ -17,6 +18,7 @@ const KNOWN_EXTENSIONS = new Set([
   ".cursor",
   ".pending",
   ".needs-distill",
+  ".note",
   ".salience.json",
   ".injected.json",
   ".turns.json",
@@ -99,5 +101,34 @@ export function pruneSessionFiles(
     }
   }
 
+  return result;
+}
+
+export function pruneSessionNotes(
+  vault: string,
+  opts?: SessionGcOptions,
+): SessionGcResult {
+  const maxAgeDays = opts?.maxAgeDays ?? 30;
+  const dryRun = opts?.dryRun ?? false;
+  const result: SessionGcResult = { deleted: [], skipped: 0, errors: [] };
+  const dir = path.join(vault, "sessions");
+  let entries: string[];
+  try { entries = fs.readdirSync(dir); } catch { return result; }
+  const nowMs = Date.now();
+  const thresholdMs = maxAgeDays * 24 * 60 * 60 * 1000;
+  for (const f of entries) {
+    if (!f.endsWith(".md")) continue;
+    const fp = path.join(dir, f);
+    try {
+      const stat = fs.statSync(fp);
+      if (nowMs - stat.mtimeMs < thresholdMs) { result.skipped++; continue; }
+      if (dryRun) { result.deleted.push(fp); continue; }
+      const res = softDelete(path.join("sessions", f));
+      if (res.ok) result.deleted.push(fp);
+      else result.errors.push(`${fp}: ${res.reason}`);
+    } catch (e: any) {
+      result.errors.push(`${fp}: ${e?.message ?? String(e)}`);
+    }
+  }
   return result;
 }

--- a/src/sessionGcRun.ts
+++ b/src/sessionGcRun.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { pruneSessionFiles, type SessionGcResult } from "./sessionGc.js";
+import { pruneSessionFiles, pruneSessionNotes, type SessionGcResult } from "./sessionGc.js";
+import { vaultPath } from "./paths.js";
 
 const STAMP_FILE = "session-gc.stamp";
 const DEFAULT_MIN_INTERVAL_HOURS = 24;
@@ -46,6 +47,7 @@ export function runSessionGcOncePerDay(
   const dryRun = process.env.SUPERBRAIN_GC_DRY_RUN === "1";
 
   const result = pruneSessionFiles(dataDirPath, { maxAgeDays, dryRun });
+  try { pruneSessionNotes(vaultPath(), { maxAgeDays, dryRun }); } catch { /* best-effort */ }
 
   try {
     fs.mkdirSync(dataDirPath, { recursive: true });

--- a/src/sessionGcRun.ts
+++ b/src/sessionGcRun.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pruneSessionFiles, pruneSessionNotes, type SessionGcResult } from "./sessionGc.js";
-import { vaultPath } from "./paths.js";
 
 const STAMP_FILE = "session-gc.stamp";
 const DEFAULT_MIN_INTERVAL_HOURS = 24;
@@ -47,7 +46,7 @@ export function runSessionGcOncePerDay(
   const dryRun = process.env.SUPERBRAIN_GC_DRY_RUN === "1";
 
   const result = pruneSessionFiles(dataDirPath, { maxAgeDays, dryRun });
-  try { pruneSessionNotes(vaultPath(), { maxAgeDays, dryRun }); } catch { /* best-effort */ }
+  try { pruneSessionNotes({ maxAgeDays, dryRun }); } catch { /* best-effort */ }
 
   try {
     fs.mkdirSync(dataDirPath, { recursive: true });

--- a/src/sessionNote.ts
+++ b/src/sessionNote.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+import { sessionsDir, vaultPath } from "./paths.js";
+import { resolveProjectSlug } from "./sessionProject.js";
+
+const TURN_LOG_CAP_BYTES = 64 * 1024;
+const LINE_MAX = 200;
+const TURN_LOG_MARKER = "## Turn log\n";
+
+export function notePointerPath(sid: string): string {
+  return path.join(sessionsDir(), `${sid}.note`);
+}
+
+function today(): string { return new Date().toISOString().slice(0, 10); }
+function hhmm(): string { return new Date().toTimeString().slice(0, 5); }
+
+function oneLine(text: string, max = LINE_MAX): string {
+  const t = text.replace(/\s+/g, " ").trim();
+  return t.length > max ? t.slice(0, max - 1) + "…" : t;
+}
+
+function safeSlug(cwd: string): string | undefined {
+  try { return resolveProjectSlug(cwd); } catch { return undefined; }
+}
+
+function skeleton(sid: string, slug: string | undefined): string {
+  const head = slug
+    ? `# Session ${sid.slice(0, 8)} — [[projects/${slug}]]`
+    : `# Session ${sid.slice(0, 8)}`;
+  const fm = [
+    "---",
+    "type: session",
+    `session: ${sid}`,
+    ...(slug ? [`project: ${slug}`] : []),
+    `created: ${today()}`,
+    `updated: ${today()}`,
+    "superbrain: true",
+    "---",
+  ].join("\n");
+  return `${fm}\n\n${head}\n\n## Digest\n\n(no checkpoint yet)\n\n## Notes routed\n\n${TURN_LOG_MARKER}`;
+}
+
+function noteAbsPath(sid: string, cwd: string): string {
+  const ptr = notePointerPath(sid);
+  try {
+    const rel = fs.readFileSync(ptr, "utf8").trim();
+    if (rel) return path.join(vaultPath(), rel);
+  } catch { /* no pointer yet */ }
+  const slug = safeSlug(cwd);
+  const rel = path.join("sessions", `${slug || "unscoped"}-${Math.floor(Date.now() / 1000)}.md`);
+  fs.mkdirSync(path.dirname(ptr), { recursive: true });
+  fs.writeFileSync(ptr, rel);
+  return path.join(vaultPath(), rel);
+}
+
+function ensureNote(sid: string, cwd: string): string {
+  const abs = noteAbsPath(sid, cwd);
+  if (!fs.existsSync(abs)) {
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, skeleton(sid, safeSlug(cwd)));
+  }
+  return abs;
+}
+
+function trimTurnLog(abs: string): void {
+  let raw: string;
+  try { raw = fs.readFileSync(abs, "utf8"); } catch { return; }
+  if (Buffer.byteLength(raw, "utf8") <= TURN_LOG_CAP_BYTES) return;
+  const i = raw.indexOf(TURN_LOG_MARKER);
+  if (i < 0) return;
+  const head = raw.slice(0, i + TURN_LOG_MARKER.length);
+  const lines = raw.slice(i + TURN_LOG_MARKER.length).split("\n");
+  while (lines.length > 1 && Buffer.byteLength(head + lines.join("\n"), "utf8") > TURN_LOG_CAP_BYTES) {
+    lines.shift();
+  }
+  fs.writeFileSync(abs, head + lines.join("\n"));
+}
+
+export function appendPromptLine(sid: string, cwd: string, prompt: string): void {
+  if (!sid || !prompt.trim()) return;
+  const abs = ensureNote(sid, cwd);
+  fs.appendFileSync(abs, `- ${hhmm()} ▸ ${oneLine(prompt)}\n`);
+  trimTurnLog(abs);
+}
+
+export function appendAssistantTail(sid: string, cwd: string, text: string): void {
+  if (!sid || !text.trim()) return;
+  const abs = ensureNote(sid, cwd);
+  fs.appendFileSync(abs, `  ↳ ${oneLine(text)}\n`);
+  trimTurnLog(abs);
+}
+
+export function updateSessionNoteDigest(sid: string, digest: string, routedRelPaths: string[]): void {
+  let rel: string;
+  try { rel = fs.readFileSync(notePointerPath(sid), "utf8").trim(); } catch { return; }
+  if (!rel) return;
+  const abs = path.join(vaultPath(), rel);
+  let raw: string;
+  try { raw = fs.readFileSync(abs, "utf8"); } catch { return; }
+  if (digest.trim()) {
+    raw = raw.replace(/## Digest\n\n[^\n]*\n/, `## Digest\n\n${oneLine(digest, 400)}\n`);
+  }
+  const marker = "## Notes routed\n";
+  const i = raw.indexOf(marker);
+  if (i >= 0 && routedRelPaths.length) {
+    const insertAt = i + marker.length;
+    const end = raw.indexOf("\n## ", insertAt);
+    const existing = end < 0 ? raw.slice(insertAt) : raw.slice(insertAt, end);
+    const fresh = routedRelPaths
+      .map((p) => `- [[${p.replace(/\.md$/, "")}]]`)
+      .filter((l) => !existing.includes(l));
+    if (fresh.length) raw = raw.slice(0, insertAt) + fresh.join("\n") + "\n" + raw.slice(insertAt);
+  }
+  raw = raw.replace(/^updated: .*$/m, `updated: ${today()}`);
+  fs.writeFileSync(abs, raw);
+}

--- a/src/sessionNote.ts
+++ b/src/sessionNote.ts
@@ -40,24 +40,21 @@ function skeleton(sid: string, slug: string | undefined): string {
   return `${fm}\n\n${head}\n\n## Digest\n\n(no checkpoint yet)\n\n## Notes routed\n\n${TURN_LOG_MARKER}`;
 }
 
-function noteAbsPath(sid: string, cwd: string): string {
-  const ptr = notePointerPath(sid);
-  try {
-    const rel = fs.readFileSync(ptr, "utf8").trim();
-    if (rel) return path.join(vaultPath(), rel);
-  } catch { /* no pointer yet */ }
-  const slug = safeSlug(cwd);
-  const rel = path.join("sessions", `${slug || "unscoped"}-${Math.floor(Date.now() / 1000)}.md`);
-  fs.mkdirSync(path.dirname(ptr), { recursive: true });
-  fs.writeFileSync(ptr, rel);
-  return path.join(vaultPath(), rel);
-}
-
 function ensureNote(sid: string, cwd: string): string {
-  const abs = noteAbsPath(sid, cwd);
+  const ptr = notePointerPath(sid);
+  let rel = "";
+  try { rel = fs.readFileSync(ptr, "utf8").trim(); } catch { /* no pointer yet */ }
+  let slug: string | undefined;
+  if (!rel) {
+    slug = safeSlug(cwd);
+    rel = path.join("sessions", `${slug || "unscoped"}-${Math.floor(Date.now() / 1000)}.md`);
+    fs.mkdirSync(path.dirname(ptr), { recursive: true });
+    fs.writeFileSync(ptr, rel);
+  }
+  const abs = path.join(vaultPath(), rel);
   if (!fs.existsSync(abs)) {
     fs.mkdirSync(path.dirname(abs), { recursive: true });
-    fs.writeFileSync(abs, skeleton(sid, safeSlug(cwd)));
+    fs.writeFileSync(abs, skeleton(sid, slug ?? safeSlug(cwd)));
   }
   return abs;
 }
@@ -98,7 +95,14 @@ export function updateSessionNoteDigest(sid: string, digest: string, routedRelPa
   let raw: string;
   try { raw = fs.readFileSync(abs, "utf8"); } catch { return; }
   if (digest.trim()) {
-    raw = raw.replace(/## Digest\n\n[^\n]*\n/, `## Digest\n\n${oneLine(digest, 400)}\n`);
+    const dMarker = "## Digest\n";
+    const di = raw.indexOf(dMarker);
+    if (di >= 0) {
+      const start = di + dMarker.length;
+      const end = raw.indexOf("\n## ", start);
+      const tail = end < 0 ? "" : raw.slice(end);
+      raw = raw.slice(0, start) + `\n${oneLine(digest, 400)}\n` + tail;
+    }
   }
   const marker = "## Notes routed\n";
   const i = raw.indexOf(marker);

--- a/src/transcriptTail.ts
+++ b/src/transcriptTail.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+
+const TAIL_BYTES = 256 * 1024;
+
+export function readLastAssistantText(transcriptPath: string | undefined): string {
+  if (!transcriptPath) return "";
+  let fd: number;
+  try { fd = fs.openSync(transcriptPath, "r"); } catch { return ""; }
+  try {
+    const size = fs.fstatSync(fd).size;
+    const start = Math.max(0, size - TAIL_BYTES);
+    const buf = Buffer.alloc(size - start);
+    fs.readSync(fd, buf, 0, buf.length, start);
+    let lines = buf.toString("utf8").split("\n");
+    if (start > 0) lines = lines.slice(1);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      let j: any;
+      try { j = JSON.parse(line); } catch { continue; }
+      if (j?.type !== "assistant") continue;
+      const content = j?.message?.content;
+      if (typeof content === "string" && content.trim()) return content.trim();
+      if (Array.isArray(content)) {
+        const t = content
+          .filter((c: any) => c?.type === "text" && typeof c.text === "string")
+          .map((c: any) => c.text)
+          .join(" ")
+          .trim();
+        if (t) return t;
+      }
+    }
+    return "";
+  } catch {
+    return "";
+  } finally {
+    try { fs.closeSync(fd); } catch { /* already closed */ }
+  }
+}

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -132,6 +132,24 @@ describe("indexer", () => {
     expect(rows.every((r) => r.to_path !== "projects/alpha.md")).toBe(true);
   });
 
+  it("reconcile does not index notes inside the sessions/ folder", async () => {
+    fs.mkdirSync(path.join(TMP_VAULT, "sessions"), { recursive: true });
+    fs.writeFileSync(
+      path.join(TMP_VAULT, "sessions/unscoped-1700000000.md"),
+      "---\ntype: session\n---\n## Session\nraw turn log data"
+    );
+    fs.writeFileSync(
+      path.join(TMP_VAULT, "decisions/normal.md"),
+      "---\ntype: decision\nstatus: active\n---\n## Normal\nindexable content"
+    );
+    await reconcile();
+    const ix = openIndex();
+    const allPaths = ix.allIndexedPaths();
+    expect(allPaths).not.toContain("sessions/unscoped-1700000000.md");
+    expect(allPaths).toContain("decisions/normal.md");
+    ix.close();
+  });
+
   it("forcedReindexIfNeeded runs once for a version then is a no-op on second call", async () => {
     const f = path.join(TMP_VAULT, "decisions/f.md");
     fs.writeFileSync(f, "---\ntype: decision\nproject: bar\n---\n## F\ncontent for sentinel test");

--- a/tests/orphanSweep.test.ts
+++ b/tests/orphanSweep.test.ts
@@ -1,0 +1,85 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { listOrphanedSessions } from "../src/distillSweep.js";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-orph-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-orph-vault-"));
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+});
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+function eventLine(): string {
+  return JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n";
+}
+
+function makeSession(sid: string, opts?: { cursorAtTip?: boolean; ageMs?: number }): void {
+  const p = path.join(TMP_DATA, "sessions", `${sid}.ndjson`);
+  fs.writeFileSync(p, eventLine());
+  if (opts?.cursorAtTip) {
+    fs.writeFileSync(path.join(TMP_DATA, "sessions", `${sid}.cursor`), String(fs.statSync(p).size));
+  }
+  if (opts?.ageMs) {
+    const t = (Date.now() - opts.ageMs) / 1000;
+    fs.utimesSync(p, t, t);
+  }
+}
+
+it("stale session with undistilled bytes is an orphan", () => {
+  makeSession("A", { ageMs: 4 * 3_600_000 });
+  expect(listOrphanedSessions("HOST")).toEqual(["A"]);
+});
+
+it("fresh sessions, fully-distilled sessions, and the current session are not orphans", () => {
+  makeSession("FRESH");
+  makeSession("DONE", { cursorAtTip: true, ageMs: 4 * 3_600_000 });
+  makeSession("ME", { ageMs: 4 * 3_600_000 });
+  expect(listOrphanedSessions("ME")).toEqual([]);
+});
+
+it("idle threshold is configurable via opts", () => {
+  makeSession("B", { ageMs: 60_000 });
+  expect(listOrphanedSessions("HOST", { maxIdleMs: 0 })).toEqual(["B"]);
+  expect(listOrphanedSessions("HOST", { maxIdleMs: 3_600_000 })).toEqual([]);
+});
+
+it("sb-reconcile distills an orphaned session end to end", () => {
+  makeSession("ORPH");
+  const stub = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(stub, JSON.stringify({
+    items: [
+      { kind: "decision", title: "Pick X", project: "test",
+        body: "## Decision\nPick X.\n## Why\n- Best fit.\n## Alternatives considered\n- **Alt A** — rejected because cost.\n## Consequences\n- Trade-offs apply.",
+        date: "2026-06-11", links: [] },
+    ],
+    digest: "orphan digest",
+  }));
+  execFileSync("npx", ["tsx", "bin/sb-reconcile.ts"], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+      SUPERBRAIN_DISTILL_STUB: stub,
+      SUPERBRAIN_EMBED_STUB: "1",
+      SUPERBRAIN_SESSION_ID: "HOST",
+      SUPERBRAIN_ORPHAN_IDLE_HOURS: "0",
+      SUPERBRAIN_GC_DISABLE: "1",
+    },
+    encoding: "utf8",
+  });
+  const ndjson = path.join(TMP_DATA, "sessions/ORPH.ndjson");
+  const cursor = path.join(TMP_DATA, "sessions/ORPH.cursor");
+  expect(fs.existsSync(cursor)).toBe(true);
+  expect(parseInt(fs.readFileSync(cursor, "utf8").trim(), 10)).toBe(fs.statSync(ndjson).size);
+});

--- a/tests/sessionGc.test.ts
+++ b/tests/sessionGc.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { pruneSessionFiles } from "../src/sessionGc.js";
+import { pruneSessionFiles, pruneSessionNotes } from "../src/sessionGc.js";
 
 let TMP: string;
 
@@ -142,4 +142,39 @@ describe("pruneSessionFiles", () => {
       expect(fs.existsSync(path.join(sd, `${sid}${ext}`))).toBe(false);
     }
   });
+
+  it("a .note pointer is pruned with its session group", () => {
+    const sd = path.join(TMP, "sessions");
+    const old = (Date.now() - 40 * 24 * 3_600_000) / 1000;
+    for (const f of ["N.ndjson", "N.cursor", "N.note"]) {
+      const p = path.join(sd, f);
+      fs.writeFileSync(p, "x");
+      fs.utimesSync(p, old, old);
+    }
+    const res = pruneSessionFiles(TMP);
+    expect(res.deleted.some((d) => d.endsWith("N.note"))).toBe(true);
+  });
+});
+
+it("old session notes are soft-deleted to .trash; fresh ones kept", () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), "sb-gc-vault-"));
+  process.env.SUPERBRAIN_VAULT_DIR = vault;
+  try {
+    const dir = path.join(vault, "sessions");
+    fs.mkdirSync(dir, { recursive: true });
+    const oldNote = path.join(dir, "proj-1700000000.md");
+    const freshNote = path.join(dir, "proj-1800000000.md");
+    fs.writeFileSync(oldNote, "old");
+    fs.writeFileSync(freshNote, "fresh");
+    const old = (Date.now() - 40 * 24 * 3_600_000) / 1000;
+    fs.utimesSync(oldNote, old, old);
+    const res = pruneSessionNotes(vault);
+    expect(res.deleted.length).toBe(1);
+    expect(fs.existsSync(oldNote)).toBe(false);
+    expect(fs.existsSync(freshNote)).toBe(true);
+    expect(fs.readdirSync(path.join(vault, ".trash")).some((f) => f.includes("proj-1700000000"))).toBe(true);
+  } finally {
+    delete process.env.SUPERBRAIN_VAULT_DIR;
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
 });

--- a/tests/sessionGc.test.ts
+++ b/tests/sessionGc.test.ts
@@ -168,7 +168,7 @@ it("old session notes are soft-deleted to .trash; fresh ones kept", () => {
     fs.writeFileSync(freshNote, "fresh");
     const old = (Date.now() - 40 * 24 * 3_600_000) / 1000;
     fs.utimesSync(oldNote, old, old);
-    const res = pruneSessionNotes(vault);
+    const res = pruneSessionNotes();
     expect(res.deleted.length).toBe(1);
     expect(fs.existsSync(oldNote)).toBe(false);
     expect(fs.existsSync(freshNote)).toBe(true);

--- a/tests/sessionNote.test.ts
+++ b/tests/sessionNote.test.ts
@@ -1,0 +1,100 @@
+// tests/sessionNote.test.ts
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  appendPromptLine,
+  appendAssistantTail,
+  updateSessionNoteDigest,
+  notePointerPath,
+} from "../src/sessionNote.js";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-sn-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-sn-vault-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+});
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+function noteAbs(sid: string): string {
+  const rel = fs.readFileSync(notePointerPath(sid), "utf8").trim();
+  return path.join(TMP_VAULT, rel);
+}
+
+it("first prompt line creates the note with frontmatter and pointer", () => {
+  appendPromptLine("S1234567890", "/tmp/nowhere", "hello world");
+  const abs = noteAbs("S1234567890");
+  const raw = fs.readFileSync(abs, "utf8");
+  expect(path.basename(abs)).toMatch(/^unscoped-\d+\.md$/);
+  expect(raw).toContain("type: session");
+  expect(raw).toContain("session: S1234567890");
+  expect(raw).toContain("## Digest");
+  expect(raw).toContain("(no checkpoint yet)");
+  expect(raw).toContain("## Turn log");
+  expect(raw).toMatch(/- \d{2}:\d{2} ▸ hello world\n$/);
+});
+
+it("assistant tail appends an indented continuation line", () => {
+  appendPromptLine("S2", "/tmp/nowhere", "question");
+  appendAssistantTail("S2", "/tmp/nowhere", "the  answer\nwith newlines");
+  const raw = fs.readFileSync(noteAbs("S2"), "utf8");
+  expect(raw).toContain("  ↳ the answer with newlines");
+});
+
+it("long lines are truncated to a single ~200-char line", () => {
+  appendPromptLine("S3", "/tmp/nowhere", "x".repeat(500));
+  const raw = fs.readFileSync(noteAbs("S3"), "utf8");
+  const line = raw.split("\n").find((l) => l.includes("▸"))!;
+  expect(line.length).toBeLessThan(220);
+  expect(line).toContain("…");
+});
+
+it("digest update replaces placeholder and appends deduped routed links", () => {
+  appendPromptLine("S4", "/tmp/nowhere", "work");
+  updateSessionNoteDigest("S4", "Fixed the frobnicator", ["decisions/2026-06-11-a.md", "lessons/b.md"]);
+  let raw = fs.readFileSync(noteAbs("S4"), "utf8");
+  expect(raw).toContain("## Digest\n\nFixed the frobnicator");
+  expect(raw).not.toContain("(no checkpoint yet)");
+  expect(raw).toContain("- [[decisions/2026-06-11-a]]");
+  expect(raw).toContain("- [[lessons/b]]");
+  updateSessionNoteDigest("S4", "Fixed and tested the frobnicator", ["decisions/2026-06-11-a.md"]);
+  raw = fs.readFileSync(noteAbs("S4"), "utf8");
+  expect(raw).toContain("## Digest\n\nFixed and tested the frobnicator");
+  expect(raw.match(/2026-06-11-a/g)!.length).toBe(1);
+});
+
+it("digest update for a session with no note is a no-op", () => {
+  expect(() => updateSessionNoteDigest("GHOST", "digest", [])).not.toThrow();
+});
+
+it("turn log trims oldest lines past the size cap, digest survives", () => {
+  appendPromptLine("S5", "/tmp/nowhere", "first-marker");
+  updateSessionNoteDigest("S5", "the digest", []);
+  for (let i = 0; i < 400; i++) {
+    appendPromptLine("S5", "/tmp/nowhere", `prompt ${i} ${"y".repeat(180)}`);
+  }
+  const raw = fs.readFileSync(noteAbs("S5"), "utf8");
+  expect(Buffer.byteLength(raw, "utf8")).toBeLessThanOrEqual(64 * 1024 + 512);
+  expect(raw).toContain("the digest");
+  expect(raw).not.toContain("first-marker");
+  expect(raw).toContain("prompt 399");
+});
+
+it("recreates the note if pointer exists but file was removed", () => {
+  appendPromptLine("S6", "/tmp/nowhere", "before");
+  fs.rmSync(noteAbs("S6"));
+  appendPromptLine("S6", "/tmp/nowhere", "after");
+  const raw = fs.readFileSync(noteAbs("S6"), "utf8");
+  expect(raw).toContain("type: session");
+  expect(raw).toContain("after");
+});

--- a/tests/sessionNoteDigest.test.ts
+++ b/tests/sessionNoteDigest.test.ts
@@ -1,0 +1,56 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-snd-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-snd-vault-"));
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+});
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+it("a distill rewrites the session note digest and routed links", () => {
+  fs.writeFileSync(
+    path.join(TMP_DATA, "sessions/D1.ndjson"),
+    JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n",
+  );
+  fs.writeFileSync(path.join(TMP_DATA, "sessions/D1.note"), "sessions/unscoped-1700000000.md");
+  fs.mkdirSync(path.join(TMP_VAULT, "sessions"), { recursive: true });
+  fs.writeFileSync(
+    path.join(TMP_VAULT, "sessions/unscoped-1700000000.md"),
+    "---\ntype: session\nsession: D1\ncreated: 2026-06-11\nupdated: 2026-06-11\nsuperbrain: true\n---\n\n# Session D1\n\n## Digest\n\n(no checkpoint yet)\n\n## Notes routed\n\n## Turn log\n- 10:00 ▸ work\n",
+  );
+  const stub = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(stub, JSON.stringify({
+    items: [
+      { kind: "decision", title: "Pick X", project: "test",
+        body: "## Decision\nPick X.\n## Why\n- Best fit.\n## Alternatives considered\n- **Alt A** — rejected because cost.\n## Consequences\n- Trade-offs apply.",
+        date: "2026-06-11", links: [] },
+    ],
+    digest: "Chose X over Alt A for the frobnicator",
+  }));
+  execFileSync("npx", ["tsx", "bin/sb-distill.ts"], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+      SUPERBRAIN_DISTILL_STUB: stub,
+      SUPERBRAIN_SESSION_ID: "D1",
+      SUPERBRAIN_EMBED_STUB: "1",
+    },
+    encoding: "utf8",
+  });
+  const raw = fs.readFileSync(path.join(TMP_VAULT, "sessions/unscoped-1700000000.md"), "utf8");
+  expect(raw).toContain("## Digest\n\nChose X over Alt A for the frobnicator");
+  expect(raw).not.toContain("(no checkpoint yet)");
+  expect(raw).toMatch(/## Notes routed\n- \[\[decisions\//);
+  expect(raw).toContain("## Turn log\n- 10:00 ▸ work");
+});

--- a/tests/sessionNoteHooks.test.ts
+++ b/tests/sessionNoteHooks.test.ts
@@ -1,0 +1,66 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-snh-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-snh-vault-"));
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+});
+afterEach(() => {
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+function runHook(bin: string, payload: any): void {
+  execFileSync("npx", ["tsx", bin], {
+    env: {
+      ...process.env,
+      SUPERBRAIN_DATA_DIR: TMP_DATA,
+      SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+      SUPERBRAIN_FAKE_DISTILLER: "1",
+      SUPERBRAIN_EMBED_STUB: "1",
+    },
+    input: JSON.stringify(payload),
+    encoding: "utf8",
+  });
+}
+
+function readSessionNote(sid: string): string {
+  const rel = fs.readFileSync(path.join(TMP_DATA, "sessions", `${sid}.note`), "utf8").trim();
+  return fs.readFileSync(path.join(TMP_VAULT, rel), "utf8");
+}
+
+it("UserPromptSubmit appends a prompt line to the session note", () => {
+  runHook("bin/sb-recall.ts", { session_id: "SR1", cwd: "/tmp/nowhere", prompt: "fix the login bug" });
+  expect(readSessionNote("SR1")).toContain("▸ fix the login bug");
+});
+
+it("Stop appends the assistant tail from the transcript", () => {
+  const transcript = path.join(TMP_DATA, "t.jsonl");
+  fs.writeFileSync(
+    transcript,
+    JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "done, tests green" }] } }) + "\n",
+  );
+  runHook("bin/sb-checkpoint.ts", {
+    session_id: "SC1",
+    cwd: "/tmp/nowhere",
+    hook_event_name: "Stop",
+    transcript_path: transcript,
+  });
+  expect(readSessionNote("SC1")).toContain("↳ done, tests green");
+});
+
+it("hooks exit 0 on malformed payloads and write nothing", () => {
+  execFileSync("npx", ["tsx", "bin/sb-recall.ts"], {
+    env: { ...process.env, SUPERBRAIN_DATA_DIR: TMP_DATA, SUPERBRAIN_VAULT_DIR: TMP_VAULT },
+    input: "not json",
+    encoding: "utf8",
+  });
+  expect(fs.existsSync(path.join(TMP_VAULT, "sessions"))).toBe(false);
+});

--- a/tests/transcriptTail.test.ts
+++ b/tests/transcriptTail.test.ts
@@ -1,0 +1,43 @@
+// tests/transcriptTail.test.ts
+import { it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readLastAssistantText } from "../src/transcriptTail.js";
+
+function tmpTranscript(lines: any[]): string {
+  const p = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "sb-tt-")), "t.jsonl");
+  fs.writeFileSync(p, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  return p;
+}
+
+it("returns the last assistant text block", () => {
+  const p = tmpTranscript([
+    { type: "user", message: { content: "hi" } },
+    { type: "assistant", message: { content: [{ type: "text", text: "first" }] } },
+    { type: "user", message: { content: "more" } },
+    { type: "assistant", message: { content: [{ type: "text", text: "final answer" }] } },
+  ]);
+  expect(readLastAssistantText(p)).toBe("final answer");
+});
+
+it("skips assistant entries with no text content", () => {
+  const p = tmpTranscript([
+    { type: "assistant", message: { content: [{ type: "text", text: "kept" }] } },
+    { type: "assistant", message: { content: [{ type: "tool_use", name: "Bash" }] } },
+  ]);
+  expect(readLastAssistantText(p)).toBe("kept");
+});
+
+it("tolerates junk lines and string content", () => {
+  const p = tmpTranscript([
+    { type: "assistant", message: { content: "plain string reply" } },
+  ]);
+  fs.appendFileSync(p, "not json at all\n");
+  expect(readLastAssistantText(p)).toBe("plain string reply");
+});
+
+it("returns empty string for missing or undefined path", () => {
+  expect(readLastAssistantText("/nonexistent/nowhere.jsonl")).toBe("");
+  expect(readLastAssistantText(undefined)).toBe("");
+});


### PR DESCRIPTION
## Summary
- Every session now writes a flight-recorder note in vault `sessions/`: raw per-turn prompt/reply lines (no LLM in the hot path) plus a digest the distiller refreshes at each checkpoint, backlinked to the project note.
- Orphaned undistilled session deltas (crash, sleep, kill) are detected by cursor-vs-size plus stale mtime (default 3h, `SUPERBRAIN_ORPHAN_IDLE_HOURS`) and distilled by the detached reconcile pass at SessionStart, under the distill lock.
- GC prunes `.note` pointers with their session file group and soft-deletes vault session notes older than 30 days to `.trash`.
- Vault `sessions/` is excluded from the search-index walk so raw turn logs never echo back through recall.
- The recall skill gains a gap-sensing rule: when memory looks stale against git evidence, read the newest session note (digest, then turn log), optionally the raw transcript tail, and offer `claude --resume`.

## Verification
- `npm run typecheck`: 0 errors
- `npm test`: 904 passed (145 files), including freshCloneE2E import-safety
- `git diff --exit-code dist` after build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
