### PR TITLE
chore: release 0.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -14,7 +14,7 @@ async function main() {
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
   const { handleChildren } = await import("../src/mcpChildren.js");
-  const server = new McpServer({ name: "superbrain", version: "0.8.1" });
+  const server = new McpServer({ name: "superbrain", version: "0.10.0" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas). Optional scope: project (slug), type (note type e.g. decision/capture/lesson), since (ISO date, only newer notes), role (agent_role).",

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -13,7 +13,7 @@ async function main() {
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
     const { handleChildren } = await import("../src/mcpChildren.js");
-    const server = new McpServer({ name: "superbrain", version: "0.8.1" });
+    const server = new McpServer({ name: "superbrain", version: "0.10.0" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas). Optional scope: project (slug), type (note type e.g. decision/capture/lesson), since (ISO date, only newer notes), role (agent_role).", {
         query: z.string(),
         k: z.number().optional(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",

--- a/tests/versionLockstep.test.ts
+++ b/tests/versionLockstep.test.ts
@@ -1,0 +1,8 @@
+import { it, expect } from "vitest";
+import fs from "node:fs";
+
+it("the MCP server version tracks package.json", () => {
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")).version;
+  const mcp = fs.readFileSync("bin/sb-mcp.ts", "utf8").match(/version: "([^"]+)"/)?.[1];
+  expect(mcp).toBe(pkg);
+});


### PR DESCRIPTION
## Summary
- Bump version to 0.10.0 — ships the session flight recorder (#75): per-session vault notes (raw turn log + checkpoint digest), orphan-delta sweep at SessionStart, GC integration, recall gap-sensing rule.
- Fix a pre-existing lockstep violation: `bin/sb-mcp.ts` still declared `0.8.1` after the 0.9.0 release. All four version locations (package.json, plugin.json, marketplace.json, MCP server) now agree, and a new test pins the MCP server string to package.json so it cannot drift again.

## Verification
- `npm run typecheck`: 0 errors
- `npm test`: 905 passed (146 files)
- `git diff --exit-code dist` after build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
