### PR TITLE
fix: reconcile runaway — singleton daemon, bounded orphan retries, stdin prompts, spawn debounce

### DIFF
--- a/bin/sb-reconcile.ts
+++ b/bin/sb-reconcile.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { writeFailure } from "../src/sentinel.js";
 import { depsPresent } from "../src/bootstrap.js";
 import { pluginRoot } from "../src/paths.js";
+import { acquireLock, releaseLock } from "../src/lockfile.js";
 
 function resolveVersion(): string {
   try {
@@ -19,28 +20,37 @@ async function main() {
   if (!depsPresent(pluginRoot())) {
     process.exit(0);
   }
-  const version = process.env.npm_package_version || resolveVersion();
-  const { reconcile, forcedReindexIfNeeded } = await import("../src/indexer.js");
-  await forcedReindexIfNeeded(version).catch(
-    (e: any) => writeFailure(`forced reindex failed: ${e?.message || e}`)
-  );
-  const { runCheapUpgradeSteps } = await import("../src/autoUpgrade.js");
-  const { dataDir } = await import("../src/paths.js");
-  await runCheapUpgradeSteps(dataDir(), version).catch(
-    (e: any) => writeFailure(`auto-upgrade failed: ${e?.message || e}`)
-  );
-  await reconcile().catch((e: any) => writeFailure(`reconcile failed: ${e?.message || e}`));
-  try {
-    const { sweepOrphanedSessions } = await import("../src/distillRun.js");
-    await sweepOrphanedSessions(process.env.SUPERBRAIN_SESSION_ID || "");
-  } catch (e: any) {
-    writeFailure(`orphan sweep failed: ${e?.message || e}`);
+  // Singleton: every SessionStart spawns this daemon; concurrent copies
+  // multiply RAM and re-sweep the same orphans. Second copy yields silently.
+  if (!acquireLock("reconcile", { maxAgeMs: 30 * 60 * 1000 })) {
+    process.exit(0);
   }
   try {
-    const { runSessionGcOncePerDay } = await import("../src/sessionGcRun.js");
-    runSessionGcOncePerDay(dataDir());
-  } catch (e: any) {
-    writeFailure(`session gc failed: ${e?.message || e}`);
+    const version = process.env.npm_package_version || resolveVersion();
+    const { reconcile, forcedReindexIfNeeded } = await import("../src/indexer.js");
+    await forcedReindexIfNeeded(version).catch(
+      (e: any) => writeFailure(`forced reindex failed: ${e?.message || e}`)
+    );
+    const { runCheapUpgradeSteps } = await import("../src/autoUpgrade.js");
+    const { dataDir } = await import("../src/paths.js");
+    await runCheapUpgradeSteps(dataDir(), version).catch(
+      (e: any) => writeFailure(`auto-upgrade failed: ${e?.message || e}`)
+    );
+    await reconcile().catch((e: any) => writeFailure(`reconcile failed: ${e?.message || e}`));
+    try {
+      const { sweepOrphanedSessions } = await import("../src/distillRun.js");
+      await sweepOrphanedSessions(process.env.SUPERBRAIN_SESSION_ID || "");
+    } catch (e: any) {
+      writeFailure(`orphan sweep failed: ${e?.message || e}`);
+    }
+    try {
+      const { runSessionGcOncePerDay } = await import("../src/sessionGcRun.js");
+      runSessionGcOncePerDay(dataDir());
+    } catch (e: any) {
+      writeFailure(`session gc failed: ${e?.message || e}`);
+    }
+  } finally {
+    releaseLock("reconcile");
   }
   process.exit(0);
 }

--- a/bin/sb-session-start.ts
+++ b/bin/sb-session-start.ts
@@ -47,13 +47,19 @@ async function main() {
 
     // Detached, recursion-guarded index reconcile so Obsidian/git drift self-heals
     // without blocking startup. Uses the same node-spawn pattern as the distiller.
+    // Debounced: SessionStart also fires for every claude -p one-shot, and a
+    // burst of those must not stack daemons (sb-reconcile itself also holds a
+    // singleton lock as the second line of defence).
     if (process.env.SUPERBRAIN_FAKE_DISTILLER !== "1" && depsPresent(root)) {
       try {
-        const reconciler = fileURLToPath(new URL("./sb-reconcile.js", import.meta.url));
-        spawn(process.execPath, [reconciler], {
-          detached: true, stdio: "ignore",
-          env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || "") }, cwd: vaultPath(),
-        }).unref();
+        const { shouldSpawnReconcile } = await import("../src/reconcileGate.js");
+        if (shouldSpawnReconcile(dataDir())) {
+          const reconciler = fileURLToPath(new URL("./sb-reconcile.js", import.meta.url));
+          spawn(process.execPath, [reconciler], {
+            detached: true, stdio: "ignore",
+            env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || "") }, cwd: vaultPath(),
+          }).unref();
+        }
       } catch { /* non-fatal */ }
     }
 

--- a/dist/bin/sb-reconcile.js
+++ b/dist/bin/sb-reconcile.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { writeFailure } from "../src/sentinel.js";
 import { depsPresent } from "../src/bootstrap.js";
 import { pluginRoot } from "../src/paths.js";
+import { acquireLock, releaseLock } from "../src/lockfile.js";
 function resolveVersion() {
     try {
         const pkg = JSON.parse(fs.readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "package.json"), "utf8"));
@@ -18,26 +19,36 @@ async function main() {
     if (!depsPresent(pluginRoot())) {
         process.exit(0);
     }
-    const version = process.env.npm_package_version || resolveVersion();
-    const { reconcile, forcedReindexIfNeeded } = await import("../src/indexer.js");
-    await forcedReindexIfNeeded(version).catch((e) => writeFailure(`forced reindex failed: ${e?.message || e}`));
-    const { runCheapUpgradeSteps } = await import("../src/autoUpgrade.js");
-    const { dataDir } = await import("../src/paths.js");
-    await runCheapUpgradeSteps(dataDir(), version).catch((e) => writeFailure(`auto-upgrade failed: ${e?.message || e}`));
-    await reconcile().catch((e) => writeFailure(`reconcile failed: ${e?.message || e}`));
-    try {
-        const { sweepOrphanedSessions } = await import("../src/distillRun.js");
-        await sweepOrphanedSessions(process.env.SUPERBRAIN_SESSION_ID || "");
-    }
-    catch (e) {
-        writeFailure(`orphan sweep failed: ${e?.message || e}`);
+    // Singleton: every SessionStart spawns this daemon; concurrent copies
+    // multiply RAM and re-sweep the same orphans. Second copy yields silently.
+    if (!acquireLock("reconcile", { maxAgeMs: 30 * 60 * 1000 })) {
+        process.exit(0);
     }
     try {
-        const { runSessionGcOncePerDay } = await import("../src/sessionGcRun.js");
-        runSessionGcOncePerDay(dataDir());
+        const version = process.env.npm_package_version || resolveVersion();
+        const { reconcile, forcedReindexIfNeeded } = await import("../src/indexer.js");
+        await forcedReindexIfNeeded(version).catch((e) => writeFailure(`forced reindex failed: ${e?.message || e}`));
+        const { runCheapUpgradeSteps } = await import("../src/autoUpgrade.js");
+        const { dataDir } = await import("../src/paths.js");
+        await runCheapUpgradeSteps(dataDir(), version).catch((e) => writeFailure(`auto-upgrade failed: ${e?.message || e}`));
+        await reconcile().catch((e) => writeFailure(`reconcile failed: ${e?.message || e}`));
+        try {
+            const { sweepOrphanedSessions } = await import("../src/distillRun.js");
+            await sweepOrphanedSessions(process.env.SUPERBRAIN_SESSION_ID || "");
+        }
+        catch (e) {
+            writeFailure(`orphan sweep failed: ${e?.message || e}`);
+        }
+        try {
+            const { runSessionGcOncePerDay } = await import("../src/sessionGcRun.js");
+            runSessionGcOncePerDay(dataDir());
+        }
+        catch (e) {
+            writeFailure(`session gc failed: ${e?.message || e}`);
+        }
     }
-    catch (e) {
-        writeFailure(`session gc failed: ${e?.message || e}`);
+    finally {
+        releaseLock("reconcile");
     }
     process.exit(0);
 }

--- a/dist/bin/sb-session-start.js
+++ b/dist/bin/sb-session-start.js
@@ -60,13 +60,19 @@ async function main() {
         catch { /* courtesy notice is best-effort */ }
         // Detached, recursion-guarded index reconcile so Obsidian/git drift self-heals
         // without blocking startup. Uses the same node-spawn pattern as the distiller.
+        // Debounced: SessionStart also fires for every claude -p one-shot, and a
+        // burst of those must not stack daemons (sb-reconcile itself also holds a
+        // singleton lock as the second line of defence).
         if (process.env.SUPERBRAIN_FAKE_DISTILLER !== "1" && depsPresent(root)) {
             try {
-                const reconciler = fileURLToPath(new URL("./sb-reconcile.js", import.meta.url));
-                spawn(process.execPath, [reconciler], {
-                    detached: true, stdio: "ignore",
-                    env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || "") }, cwd: vaultPath(),
-                }).unref();
+                const { shouldSpawnReconcile } = await import("../src/reconcileGate.js");
+                if (shouldSpawnReconcile(dataDir())) {
+                    const reconciler = fileURLToPath(new URL("./sb-reconcile.js", import.meta.url));
+                    spawn(process.execPath, [reconciler], {
+                        detached: true, stdio: "ignore",
+                        env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || "") }, cwd: vaultPath(),
+                    }).unref();
+                }
             }
             catch { /* non-fatal */ }
         }

--- a/dist/src/claudeCli.js
+++ b/dist/src/claudeCli.js
@@ -10,7 +10,15 @@ export function buildClaudeSpawnOptions(platform) {
         opts.shell = true;
     return opts;
 }
+// The prompt travels on stdin, never argv: a session delta above ARG_MAX
+// (~1MB on macOS) makes an argv prompt fail with E2BIG before claude even
+// spawns, permanently stranding that session's distill.
+export function buildClaudePInvocation(prompt, platform = process.platform) {
+    const options = buildClaudeSpawnOptions(platform);
+    options.input = prompt;
+    return { args: ["--model", distillModel(), "-p"], options };
+}
 export function claudeP(prompt) {
-    const args = ["--model", distillModel(), "-p", prompt];
-    return execFileSync("claude", args, buildClaudeSpawnOptions(process.platform));
+    const { args, options } = buildClaudePInvocation(prompt);
+    return execFileSync("claude", args, options);
 }

--- a/dist/src/distillRun.js
+++ b/dist/src/distillRun.js
@@ -12,7 +12,7 @@ import { route } from "./router.js";
 import { writeNote } from "./vaultWriter.js";
 import { acquireLock, releaseLock } from "./lockfile.js";
 import { writeFailure } from "./sentinel.js";
-import { vaultPath, dataDir } from "./paths.js";
+import { vaultPath, dataDir, sessionsDir } from "./paths.js";
 import { indexNote } from "./indexer.js";
 import { upsertDay } from "./dailyState.js";
 import { buildDailyNote } from "./dailyNote.js";
@@ -22,7 +22,7 @@ import { resolveLinks } from "./wikilink.js";
 import { gcTranscript } from "./transcriptStore.js";
 import { pruneSessionFiles } from "./sessionGc.js";
 import { updateSessionNoteDigest } from "./sessionNote.js";
-import { sweepPendingDistills, clearFlag, listOrphanedSessions } from "./distillSweep.js";
+import { sweepPendingDistills, clearFlag, listOrphanedSessions, bumpAttempts, clearAttempts, MAX_DISTILL_ATTEMPTS } from "./distillSweep.js";
 import { classify } from "./classification.js";
 import { recordRejection } from "./rejectQueue.js";
 import { serializeNote } from "./frontmatter.js";
@@ -526,7 +526,7 @@ export async function runDistill() {
         releaseLock("distill", process.env.SUPERBRAIN_LOCK_TOKEN);
     }
 }
-export async function sweepOrphanedSessions(excludeSid) {
+export async function sweepOrphanedSessions(excludeSid, distillOne = distillSession) {
     const orphans = listOrphanedSessions(excludeSid);
     if (!orphans.length)
         return 0;
@@ -541,12 +541,24 @@ export async function sweepOrphanedSessions(excludeSid) {
     try {
         for (const sid of orphans) {
             try {
-                await distillSession(sid);
+                await distillOne(sid);
                 clearFlag(sid);
+                clearAttempts(sid);
                 swept++;
             }
             catch (e) {
-                writeFailure(`orphan distill failed for ${sid}: ${e?.message || e}`);
+                const n = bumpAttempts(sid);
+                if (n >= MAX_DISTILL_ATTEMPTS) {
+                    try {
+                        writeCursor(sid, fs.statSync(path.join(sessionsDir(), `${sid}.ndjson`)).size);
+                    }
+                    catch { /* best-effort */ }
+                    clearFlag(sid);
+                    writeFailure(`orphan distill failed for ${sid} (attempt ${n}/${MAX_DISTILL_ATTEMPTS}) — giving up, session marked processed: ${e?.message || e}`);
+                }
+                else {
+                    writeFailure(`orphan distill failed for ${sid} (attempt ${n}/${MAX_DISTILL_ATTEMPTS}): ${e?.message || e}`);
+                }
             }
         }
     }

--- a/dist/src/distillSweep.js
+++ b/dist/src/distillSweep.js
@@ -24,6 +24,36 @@ export function clearFlag(sid) {
     catch { /* best-effort */ }
 }
 const NDJSON_EXT = ".ndjson";
+const ATTEMPTS_EXT = ".distill-attempts";
+// A distill that fails MAX_DISTILL_ATTEMPTS times will fail the next 100 too;
+// unbounded retries across reconcile sweeps were the 2026-06-11 runaway burn.
+export const MAX_DISTILL_ATTEMPTS = 3;
+function attemptsPath(sid) {
+    return path.join(sessionsDir(), `${sid}${ATTEMPTS_EXT}`);
+}
+export function readAttempts(sid) {
+    try {
+        const n = parseInt(fs.readFileSync(attemptsPath(sid), "utf8").trim(), 10);
+        return Number.isFinite(n) && n >= 0 ? n : 0;
+    }
+    catch {
+        return 0;
+    }
+}
+export function bumpAttempts(sid) {
+    const n = readAttempts(sid) + 1;
+    try {
+        fs.writeFileSync(attemptsPath(sid), String(n));
+    }
+    catch { /* best-effort */ }
+    return n;
+}
+export function clearAttempts(sid) {
+    try {
+        fs.rmSync(attemptsPath(sid), { force: true });
+    }
+    catch { /* best-effort */ }
+}
 export function listOrphanedSessions(excludeSid, opts) {
     const rawEnv = process.env.SUPERBRAIN_ORPHAN_IDLE_HOURS;
     const envHours = rawEnv && rawEnv.trim() ? Number(rawEnv) : NaN;
@@ -47,6 +77,8 @@ export function listOrphanedSessions(excludeSid, opts) {
         try {
             const st = fs.statSync(path.join(sessionsDir(), f));
             if (now - st.mtimeMs < maxIdleMs)
+                continue;
+            if (readAttempts(sid) >= MAX_DISTILL_ATTEMPTS)
                 continue;
             if (st.size > readCursor(sid))
                 out.push(sid);

--- a/dist/src/reconcileGate.js
+++ b/dist/src/reconcileGate.js
@@ -1,0 +1,21 @@
+import fs from "node:fs";
+import path from "node:path";
+// SessionStart fires for every claude invocation on the machine, including
+// claude -p one-shots; without a debounce, bursty spawners (watchers, scripts,
+// CI) stack reconcile daemons faster than they finish.
+export const RECONCILE_DEBOUNCE_MS = 10 * 60 * 1000;
+export function shouldSpawnReconcile(dataDirPath, now = Date.now()) {
+    const stamp = path.join(dataDirPath, "reconcile-stamp");
+    try {
+        if (now - fs.statSync(stamp).mtimeMs < RECONCILE_DEBOUNCE_MS)
+            return false;
+    }
+    catch { /* no stamp yet */ }
+    try {
+        fs.mkdirSync(dataDirPath, { recursive: true });
+        fs.writeFileSync(stamp, String(now));
+        fs.utimesSync(stamp, now / 1000, now / 1000);
+    }
+    catch { /* best-effort */ }
+    return true;
+}

--- a/src/claudeCli.ts
+++ b/src/claudeCli.ts
@@ -11,7 +11,19 @@ export function buildClaudeSpawnOptions(platform: NodeJS.Platform): ExecFileSync
   return opts;
 }
 
+// The prompt travels on stdin, never argv: a session delta above ARG_MAX
+// (~1MB on macOS) makes an argv prompt fail with E2BIG before claude even
+// spawns, permanently stranding that session's distill.
+export function buildClaudePInvocation(
+  prompt: string,
+  platform: NodeJS.Platform = process.platform,
+): { args: string[]; options: ExecFileSyncOptionsWithStringEncoding } {
+  const options = buildClaudeSpawnOptions(platform);
+  options.input = prompt;
+  return { args: ["--model", distillModel(), "-p"], options };
+}
+
 export function claudeP(prompt: string): string {
-  const args = ["--model", distillModel(), "-p", prompt];
-  return execFileSync("claude", args, buildClaudeSpawnOptions(process.platform));
+  const { args, options } = buildClaudePInvocation(prompt);
+  return execFileSync("claude", args, options);
 }

--- a/src/distillRun.ts
+++ b/src/distillRun.ts
@@ -14,7 +14,7 @@ import { route, type DistilledItem } from "./router.js";
 import { writeNote } from "./vaultWriter.js";
 import { acquireLock, releaseLock } from "./lockfile.js";
 import { writeFailure } from "./sentinel.js";
-import { vaultPath, dataDir } from "./paths.js";
+import { vaultPath, dataDir, sessionsDir } from "./paths.js";
 import { indexNote } from "./indexer.js";
 import { upsertDay } from "./dailyState.js";
 import { buildDailyNote } from "./dailyNote.js";
@@ -24,7 +24,7 @@ import { resolveLinks } from "./wikilink.js";
 import { gcTranscript } from "./transcriptStore.js";
 import { pruneSessionFiles } from "./sessionGc.js";
 import { updateSessionNoteDigest } from "./sessionNote.js";
-import { sweepPendingDistills, clearFlag, listOrphanedSessions } from "./distillSweep.js";
+import { sweepPendingDistills, clearFlag, listOrphanedSessions, bumpAttempts, clearAttempts, MAX_DISTILL_ATTEMPTS } from "./distillSweep.js";
 import { classify } from "./classification.js";
 import { recordRejection } from "./rejectQueue.js";
 import { type NoteType } from "./templates.js";
@@ -481,7 +481,10 @@ export async function runDistill(): Promise<void> {
   }
 }
 
-export async function sweepOrphanedSessions(excludeSid: string): Promise<number> {
+export async function sweepOrphanedSessions(
+  excludeSid: string,
+  distillOne: (sid: string) => Promise<void> = distillSession,
+): Promise<number> {
   const orphans = listOrphanedSessions(excludeSid);
   if (!orphans.length) return 0;
   if (!acquireLock("distill")) return 0;
@@ -491,11 +494,21 @@ export async function sweepOrphanedSessions(excludeSid: string): Promise<number>
   try {
     for (const sid of orphans) {
       try {
-        await distillSession(sid);
+        await distillOne(sid);
         clearFlag(sid);
+        clearAttempts(sid);
         swept++;
       } catch (e: any) {
-        writeFailure(`orphan distill failed for ${sid}: ${e?.message || e}`);
+        const n = bumpAttempts(sid);
+        if (n >= MAX_DISTILL_ATTEMPTS) {
+          try {
+            writeCursor(sid, fs.statSync(path.join(sessionsDir(), `${sid}.ndjson`)).size);
+          } catch { /* best-effort */ }
+          clearFlag(sid);
+          writeFailure(`orphan distill failed for ${sid} (attempt ${n}/${MAX_DISTILL_ATTEMPTS}) — giving up, session marked processed: ${e?.message || e}`);
+        } else {
+          writeFailure(`orphan distill failed for ${sid} (attempt ${n}/${MAX_DISTILL_ATTEMPTS}): ${e?.message || e}`);
+        }
       }
     }
   } finally {

--- a/src/distillSweep.ts
+++ b/src/distillSweep.ts
@@ -23,6 +23,32 @@ export function clearFlag(sid: string): void {
 }
 
 const NDJSON_EXT = ".ndjson";
+const ATTEMPTS_EXT = ".distill-attempts";
+
+// A distill that fails MAX_DISTILL_ATTEMPTS times will fail the next 100 too;
+// unbounded retries across reconcile sweeps were the 2026-06-11 runaway burn.
+export const MAX_DISTILL_ATTEMPTS = 3;
+
+function attemptsPath(sid: string): string {
+  return path.join(sessionsDir(), `${sid}${ATTEMPTS_EXT}`);
+}
+
+export function readAttempts(sid: string): number {
+  try {
+    const n = parseInt(fs.readFileSync(attemptsPath(sid), "utf8").trim(), 10);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  } catch { return 0; }
+}
+
+export function bumpAttempts(sid: string): number {
+  const n = readAttempts(sid) + 1;
+  try { fs.writeFileSync(attemptsPath(sid), String(n)); } catch { /* best-effort */ }
+  return n;
+}
+
+export function clearAttempts(sid: string): void {
+  try { fs.rmSync(attemptsPath(sid), { force: true }); } catch { /* best-effort */ }
+}
 
 export interface OrphanScanOptions { maxIdleMs?: number; now?: number }
 
@@ -42,6 +68,7 @@ export function listOrphanedSessions(excludeSid: string, opts?: OrphanScanOption
     try {
       const st = fs.statSync(path.join(sessionsDir(), f));
       if (now - st.mtimeMs < maxIdleMs) continue;
+      if (readAttempts(sid) >= MAX_DISTILL_ATTEMPTS) continue;
       if (st.size > readCursor(sid)) out.push(sid);
     } catch { /* unreadable entry — skip */ }
   }

--- a/src/reconcileGate.ts
+++ b/src/reconcileGate.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import path from "node:path";
+
+// SessionStart fires for every claude invocation on the machine, including
+// claude -p one-shots; without a debounce, bursty spawners (watchers, scripts,
+// CI) stack reconcile daemons faster than they finish.
+export const RECONCILE_DEBOUNCE_MS = 10 * 60 * 1000;
+
+export function shouldSpawnReconcile(dataDirPath: string, now: number = Date.now()): boolean {
+  const stamp = path.join(dataDirPath, "reconcile-stamp");
+  try {
+    if (now - fs.statSync(stamp).mtimeMs < RECONCILE_DEBOUNCE_MS) return false;
+  } catch { /* no stamp yet */ }
+  try {
+    fs.mkdirSync(dataDirPath, { recursive: true });
+    fs.writeFileSync(stamp, String(now));
+    fs.utimesSync(stamp, now / 1000, now / 1000);
+  } catch { /* best-effort */ }
+  return true;
+}

--- a/tests/reconcileRunaway.test.ts
+++ b/tests/reconcileRunaway.test.ts
@@ -1,0 +1,119 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { buildClaudePInvocation } from "../src/claudeCli.js";
+import { listOrphanedSessions, readAttempts, MAX_DISTILL_ATTEMPTS } from "../src/distillSweep.js";
+import { sweepOrphanedSessions } from "../src/distillRun.js";
+import { shouldSpawnReconcile, RECONCILE_DEBOUNCE_MS } from "../src/reconcileGate.js";
+
+let TMP_DATA: string;
+let TMP_VAULT: string;
+
+beforeEach(() => {
+  TMP_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "sb-runaway-data-"));
+  TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), "sb-runaway-vault-"));
+  fs.mkdirSync(path.join(TMP_DATA, "sessions"), { recursive: true });
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  process.env.SUPERBRAIN_VAULT_DIR = TMP_VAULT;
+});
+afterEach(() => {
+  delete process.env.SUPERBRAIN_DATA_DIR;
+  delete process.env.SUPERBRAIN_VAULT_DIR;
+  fs.rmSync(TMP_DATA, { recursive: true, force: true });
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+function makeOrphan(sid: string): string {
+  const p = path.join(TMP_DATA, "sessions", `${sid}.ndjson`);
+  fs.writeFileSync(p, JSON.stringify({ type: "tool", tool: "Write", file: "a.ts", cwd: "/p", ts: "t" }) + "\n");
+  const t = (Date.now() - 4 * 3_600_000) / 1000;
+  fs.utimesSync(p, t, t);
+  return p;
+}
+
+it("distill prompt travels via stdin, never argv (E2BIG)", () => {
+  const huge = "x".repeat(2_000_000);
+  const { args, options } = buildClaudePInvocation(huge, "darwin");
+  expect(options.input).toBe(huge);
+  for (const a of args) expect(a.length).toBeLessThan(1000);
+  expect(args[args.length - 1]).toBe("-p");
+});
+
+it("a permanently failing orphan is retried at most MAX_DISTILL_ATTEMPTS times, then marked processed", async () => {
+  const ndjson = makeOrphan("POISON");
+  let calls = 0;
+  const failing = async (_sid: string) => { calls++; throw new Error("E2BIG"); };
+
+  for (let i = 0; i < MAX_DISTILL_ATTEMPTS; i++) {
+    await sweepOrphanedSessions("HOST", failing);
+  }
+  expect(calls).toBe(MAX_DISTILL_ATTEMPTS);
+
+  const cursor = path.join(TMP_DATA, "sessions", "POISON.cursor");
+  expect(parseInt(fs.readFileSync(cursor, "utf8").trim(), 10)).toBe(fs.statSync(ndjson).size);
+
+  await sweepOrphanedSessions("HOST", failing);
+  expect(calls).toBe(MAX_DISTILL_ATTEMPTS);
+});
+
+it("attempt counter survives across sweeps and is cleared on success", async () => {
+  makeOrphan("FLAKY");
+  let calls = 0;
+  const flaky = async (_sid: string) => { calls++; if (calls === 1) throw new Error("transient"); };
+
+  await sweepOrphanedSessions("HOST", flaky);
+  expect(readAttempts("FLAKY")).toBe(1);
+
+  await sweepOrphanedSessions("HOST", flaky);
+  expect(calls).toBe(2);
+  expect(readAttempts("FLAKY")).toBe(0);
+  expect(fs.existsSync(path.join(TMP_DATA, "sessions", "FLAKY.distill-attempts"))).toBe(false);
+});
+
+it("orphans at the attempt ceiling are not even listed", () => {
+  makeOrphan("CAPPED");
+  fs.writeFileSync(path.join(TMP_DATA, "sessions", "CAPPED.distill-attempts"), String(MAX_DISTILL_ATTEMPTS));
+  expect(listOrphanedSessions("HOST")).toEqual([]);
+});
+
+it("reconcile spawn is debounced within the window", () => {
+  const now = Date.now();
+  expect(shouldSpawnReconcile(TMP_DATA, now)).toBe(true);
+  expect(shouldSpawnReconcile(TMP_DATA, now + 1000)).toBe(false);
+  expect(shouldSpawnReconcile(TMP_DATA, now + RECONCILE_DEBOUNCE_MS + 1000)).toBe(true);
+});
+
+it("a second sb-reconcile is a no-op while the first holds the reconcile lock", () => {
+  makeOrphan("ORPH");
+  const stub = path.join(TMP_DATA, "stub.json");
+  fs.writeFileSync(stub, JSON.stringify({
+    items: [], digest: "orphan digest",
+  }));
+  const env = {
+    ...process.env,
+    SUPERBRAIN_DATA_DIR: TMP_DATA,
+    SUPERBRAIN_VAULT_DIR: TMP_VAULT,
+    SUPERBRAIN_DISTILL_STUB: stub,
+    SUPERBRAIN_EMBED_STUB: "1",
+    SUPERBRAIN_SESSION_ID: "HOST",
+    SUPERBRAIN_ORPHAN_IDLE_HOURS: "0",
+    SUPERBRAIN_GC_DISABLE: "1",
+  };
+
+  const lockDir = path.join(TMP_DATA, "locks", "reconcile.lock");
+  fs.mkdirSync(lockDir, { recursive: true });
+  fs.writeFileSync(path.join(lockDir, "pid"), "99999");
+  fs.writeFileSync(path.join(lockDir, "token"), "held-elsewhere");
+
+  execFileSync("npx", ["tsx", "bin/sb-reconcile.ts"], { env, encoding: "utf8" });
+  expect(fs.existsSync(path.join(TMP_DATA, "sessions", "ORPH.cursor"))).toBe(false);
+
+  fs.rmSync(lockDir, { recursive: true, force: true });
+  execFileSync("npx", ["tsx", "bin/sb-reconcile.ts"], { env, encoding: "utf8" });
+  const ndjson = path.join(TMP_DATA, "sessions", "ORPH.ndjson");
+  const cursor = path.join(TMP_DATA, "sessions", "ORPH.cursor");
+  expect(parseInt(fs.readFileSync(cursor, "utf8").trim(), 10)).toBe(fs.statSync(ndjson).size);
+  expect(fs.existsSync(path.join(TMP_DATA, "locks", "reconcile.lock"))).toBe(false);
+});


### PR DESCRIPTION
## Incident

2026-06-11, single machine, ~5 hours: double-digit subscription-quota burn, duplicate 200MB+ background daemons, and at peak ~8 sonnet distill calls per minute — none of them asked for by the user.

## Root cause (compound)

1. **Unguarded daemon spawn.** `sb-session-start` spawns a detached `sb-reconcile` on *every* SessionStart — and SessionStart fires for every `claude -p` one-shot on the machine, not just interactive sessions. A repo watcher ticking `claude -p` every 3 minutes spawned daemons faster than they exited; nothing enforced a singleton.
2. **Unbounded orphan retries.** `sweepOrphanedSessions` retries any orphan whose distill throws, without advancing its cursor — so a *permanently* failing orphan is re-distilled by every subsequent sweep, forever. With sweeps arriving every few minutes (see 1), this is an infinite token loop. The sentinel message "fixed automatically next checkpoint" is false for orphans, which never get another checkpoint.
3. **E2BIG as a permanent-failure mode.** The distill prompt is passed as an argv argument; sessions whose delta exceeds ARG_MAX (~1MB on macOS) fail at spawn forever — feeding defect 2.
4. The killed `claude -p` one-shots from (1) also produced capture NDJSONs that became *new* orphans three hours later — the two systems fed each other.

## Fix (each at a root)

- `bin/sb-reconcile.ts`: takes `acquireLock("reconcile", { maxAgeMs: 30min })` at entry; a second copy exits silently; released in `finally`.
- `src/distillSweep.ts` / `src/distillRun.ts`: per-session `.distill-attempts` counter. After `MAX_DISTILL_ATTEMPTS` (3) failures the orphan's cursor is advanced to EOF, its flag cleared, and the sentinel records "giving up, session marked processed" — loud, honest, terminal. Counter clears on success. Capped orphans are excluded from listing as a second line of defence.
- `src/claudeCli.ts`: `claudeP` sends the prompt via stdin (`execFileSync` `input`), argv carries only flags — E2BIG eliminated at the source. `buildClaudePInvocation` exported for testability.
- `bin/sb-session-start.ts`: reconcile spawn debounced to once per 10 minutes via a stamp file (`src/reconcileGate.ts`); the singleton lock backstops races.

## Tests

`tests/reconcileRunaway.test.ts` — six tests pinning all four defects, following the existing orphanSweep e2e conventions (tsx + env stubs). Verified failing against pre-fix code. Full suite: **147 files / 911 tests green.**

## Notes for reviewer

- The watcher-side amplifier (hung `claude -p` from a `--json-schema` misuse) is fixed separately in its own repo; this PR makes SuperBrain safe against any such burst source.
- Existing orphan backlogs on affected machines will still get up to 3 attempts each after upgrade; operators who want to skip a known-junk backlog can advance cursors manually before re-enabling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
