### PR TITLE
chore: release 0.10.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -14,7 +14,7 @@ async function main() {
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
   const { handleChildren } = await import("../src/mcpChildren.js");
-  const server = new McpServer({ name: "superbrain", version: "0.10.0" });
+  const server = new McpServer({ name: "superbrain", version: "0.10.1" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas). Optional scope: project (slug), type (note type e.g. decision/capture/lesson), since (ISO date, only newer notes), role (agent_role).",

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -13,7 +13,7 @@ async function main() {
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
     const { handleChildren } = await import("../src/mcpChildren.js");
-    const server = new McpServer({ name: "superbrain", version: "0.10.0" });
+    const server = new McpServer({ name: "superbrain", version: "0.10.1" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas). Optional scope: project (slug), type (note type e.g. decision/capture/lesson), since (ISO date, only newer notes), role (agent_role).", {
         query: z.string(),
         k: z.number().optional(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version lockstep bump to 0.10.1 across package.json, plugin.json, marketplace.json, sb-mcp (src+dist). Ships #78 — the reconcile-runaway fix (singleton daemon, bounded orphan retries, stdin prompts, spawn debounce) — to plugin users. Suite: 911/911 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)