### PR TITLE
fix: stabilisation remediation, lock liveness, claude-p timeout, safe-spawn, data-path durability (Phases 0-3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "superbrain",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "source": "./",
       "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
       "homepage": "https://github.com/m3talux/superbrain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superbrain",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "author": {
     "name": "m3talux"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,39 @@ jobs:
 
       - name: Verify shipped dist is reproducible
         run: git diff --exit-code dist
+
+  # Broader coverage matrix. Kept as a SEPARATE job so the required status check
+  # named "typecheck • build • test" above is unchanged — turning that job into a
+  # matrix would rename its checks and stall branch protection. macOS is included
+  # because the lock/spawn paths these tests cover are exercised most on darwin.
+  compat:
+    name: compat
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: [20, 22]
+        exclude:
+          - os: ubuntu-latest
+            node: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/bin/sb-bootstrap.ts
+++ b/bin/sb-bootstrap.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-import { execFileSync, spawn } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { acquireLock, releaseLock } from "../src/lockfile.js";
 import { bootstrapDone, markBootstrapDone, depsPresent } from "../src/bootstrap.js";
+import { spawnDetachedCommand } from "../src/spawnChild.js";
 import { writeFailure } from "../src/sentinel.js";
 import { dataDir, vaultPath } from "../src/paths.js";
 
@@ -82,12 +83,13 @@ async function main() {
         console.log(
           `SuperBrain: backfilling frontmatter on ${state.frontmatterMissing} legacy notes (detached, ~30s)`
         );
-        const child = spawn(
+        spawnDetachedCommand(
+          "backfill",
           "npx",
           ["tsx", "scripts/backfill-frontmatter.ts", vault, "--apply"],
-          { cwd: root, detached: true, stdio: "ignore" }
+          process.env,
+          { cwd: root },
         );
-        child.unref();
       }
     } catch (e: any) {
       writeFailure(`bootstrap migration check failed (non-fatal): ${e?.message || e}`);

--- a/bin/sb-checkpoint.ts
+++ b/bin/sb-checkpoint.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { dataDir } from "../src/paths.js";
 import { acquireLock, releaseLock } from "../src/lockfile.js";
 import { writeFailure } from "../src/sentinel.js";
 import { isChild, buildDistillCommand } from "../src/distillerEngine.js";
+import { spawnDetachedChild } from "../src/spawnChild.js";
 import { snapshotTranscript } from "../src/transcriptStore.js";
 import { appendAssistantTail } from "../src/sessionNote.js";
 import { readLastAssistantText } from "../src/transcriptTail.js";
@@ -57,9 +57,12 @@ function main() {
         let lockToken: string | undefined;
         try { lockToken = fs.readFileSync(path.join(dataDir(), "locks", "distill.lock", "token"), "utf8"); } catch { /* best-effort */ }
         const spec = buildDistillCommand({ sessionId: sid, cwd: safeCwd, lockToken });
-        const child = spawn(spec.cmd, spec.args, spec.options);
-        child.on("error", (e) => { writeFailure(`distiller spawn failed: ${e.message}`); releaseLock("distill"); });
-        child.unref(); // detached; sb-distill releases the lock when done
+        // detached; sb-distill releases the lock when done. On spawn failure the
+        // child never gets there, so release the lock here.
+        spawnDetachedChild("distill", spec.args[0], spec.options.env, {
+          cwd: spec.options.cwd,
+          onError: () => releaseLock("distill"),
+        });
       }
       if (fs.existsSync(pendingFile)) fs.rmSync(pendingFile, { force: true });
     } catch (e: any) {

--- a/bin/sb-mcp.ts
+++ b/bin/sb-mcp.ts
@@ -14,7 +14,7 @@ async function main() {
   const { z } = await import("zod");
   const { handleSearch } = await import("../src/mcpSearch.js");
   const { handleChildren } = await import("../src/mcpChildren.js");
-  const server = new McpServer({ name: "superbrain", version: "0.10.1" });
+  const server = new McpServer({ name: "superbrain", version: "0.11.0" });
   server.tool(
     "superbrain_search",
     "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas). Optional scope: project (slug), type (note type e.g. decision/capture/lesson), since (ISO date, only newer notes), role (agent_role).",

--- a/bin/sb-session-start.ts
+++ b/bin/sb-session-start.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { readAndClearFailure } from "../src/sentinel.js";
 import { dataDir, vaultPath, pluginRoot } from "../src/paths.js";
@@ -9,6 +8,7 @@ import { isChild } from "../src/distillerEngine.js";
 import { depsPresent, runBootstrap } from "../src/bootstrap.js";
 import { recordedVaultPath } from "../src/vaultMarker.js";
 import { isUnknownProject, looksLikeCodeProject } from "../src/discoverer.js";
+import { spawnDetachedChild } from "../src/spawnChild.js";
 
 function readStdin(): string { try { return fs.readFileSync(0, "utf8"); } catch { return ""; } }
 
@@ -55,10 +55,9 @@ async function main() {
         const { shouldSpawnReconcile } = await import("../src/reconcileGate.js");
         if (shouldSpawnReconcile(dataDir())) {
           const reconciler = fileURLToPath(new URL("./sb-reconcile.js", import.meta.url));
-          spawn(process.execPath, [reconciler], {
-            detached: true, stdio: "ignore",
-            env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || "") }, cwd: vaultPath(),
-          }).unref();
+          spawnDetachedChild("reconcile", reconciler, {
+            ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || ""),
+          }, { cwd: vaultPath() });
         }
       } catch { /* non-fatal */ }
     }
@@ -72,10 +71,9 @@ async function main() {
         const projectDir = h.cwd || process.env.CLAUDE_PROJECT_DIR;
         if (projectDir && looksLikeCodeProject(projectDir) && isUnknownProject(projectDir)) {
           const discoverer = fileURLToPath(new URL("./sb-discover.js", import.meta.url));
-          spawn(process.execPath, [discoverer], {
-            detached: true, stdio: "ignore",
-            env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PROJECT_DIR: projectDir },
-          }).unref();
+          spawnDetachedChild("discover", discoverer, {
+            ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PROJECT_DIR: projectDir,
+          });
           parts.push(`SuperBrain is mapping this project for the first time — a project note will appear in the vault shortly.`);
         }
       } catch { /* non-fatal */ }

--- a/dist/bin/sb-bootstrap.js
+++ b/dist/bin/sb-bootstrap.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-import { execFileSync, spawn } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { acquireLock, releaseLock } from "../src/lockfile.js";
 import { bootstrapDone, markBootstrapDone, depsPresent } from "../src/bootstrap.js";
+import { spawnDetachedCommand } from "../src/spawnChild.js";
 import { writeFailure } from "../src/sentinel.js";
 import { dataDir, vaultPath } from "../src/paths.js";
 const PLATFORM_HINTS = {
@@ -82,8 +83,7 @@ async function main() {
             const state = await detectLegacyState(vault, db);
             if (state.frontmatterMissing > 0) {
                 console.log(`SuperBrain: backfilling frontmatter on ${state.frontmatterMissing} legacy notes (detached, ~30s)`);
-                const child = spawn("npx", ["tsx", "scripts/backfill-frontmatter.ts", vault, "--apply"], { cwd: root, detached: true, stdio: "ignore" });
-                child.unref();
+                spawnDetachedCommand("backfill", "npx", ["tsx", "scripts/backfill-frontmatter.ts", vault, "--apply"], process.env, { cwd: root });
             }
         }
         catch (e) {

--- a/dist/bin/sb-checkpoint.js
+++ b/dist/bin/sb-checkpoint.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { dataDir } from "../src/paths.js";
 import { acquireLock, releaseLock } from "../src/lockfile.js";
 import { writeFailure } from "../src/sentinel.js";
 import { isChild, buildDistillCommand } from "../src/distillerEngine.js";
+import { spawnDetachedChild } from "../src/spawnChild.js";
 import { snapshotTranscript } from "../src/transcriptStore.js";
 import { appendAssistantTail } from "../src/sessionNote.js";
 import { readLastAssistantText } from "../src/transcriptTail.js";
@@ -71,9 +71,12 @@ function main() {
                 }
                 catch { /* best-effort */ }
                 const spec = buildDistillCommand({ sessionId: sid, cwd: safeCwd, lockToken });
-                const child = spawn(spec.cmd, spec.args, spec.options);
-                child.on("error", (e) => { writeFailure(`distiller spawn failed: ${e.message}`); releaseLock("distill"); });
-                child.unref(); // detached; sb-distill releases the lock when done
+                // detached; sb-distill releases the lock when done. On spawn failure the
+                // child never gets there, so release the lock here.
+                spawnDetachedChild("distill", spec.args[0], spec.options.env, {
+                    cwd: spec.options.cwd,
+                    onError: () => releaseLock("distill"),
+                });
             }
             if (fs.existsSync(pendingFile))
                 fs.rmSync(pendingFile, { force: true });

--- a/dist/bin/sb-mcp.js
+++ b/dist/bin/sb-mcp.js
@@ -13,7 +13,7 @@ async function main() {
     const { z } = await import("zod");
     const { handleSearch } = await import("../src/mcpSearch.js");
     const { handleChildren } = await import("../src/mcpChildren.js");
-    const server = new McpServer({ name: "superbrain", version: "0.10.1" });
+    const server = new McpServer({ name: "superbrain", version: "0.11.0" });
     server.tool("superbrain_search", "Search the user's SuperBrain Obsidian vault (past decisions, projects, people, gotchas). Optional scope: project (slug), type (note type e.g. decision/capture/lesson), since (ISO date, only newer notes), role (agent_role).", {
         query: z.string(),
         k: z.number().optional(),

--- a/dist/bin/sb-session-start.js
+++ b/dist/bin/sb-session-start.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { readAndClearFailure } from "../src/sentinel.js";
 import { dataDir, vaultPath, pluginRoot } from "../src/paths.js";
@@ -9,6 +8,7 @@ import { isChild } from "../src/distillerEngine.js";
 import { depsPresent, runBootstrap } from "../src/bootstrap.js";
 import { recordedVaultPath } from "../src/vaultMarker.js";
 import { isUnknownProject, looksLikeCodeProject } from "../src/discoverer.js";
+import { spawnDetachedChild } from "../src/spawnChild.js";
 function readStdin() { try {
     return fs.readFileSync(0, "utf8");
 }
@@ -68,10 +68,9 @@ async function main() {
                 const { shouldSpawnReconcile } = await import("../src/reconcileGate.js");
                 if (shouldSpawnReconcile(dataDir())) {
                     const reconciler = fileURLToPath(new URL("./sb-reconcile.js", import.meta.url));
-                    spawn(process.execPath, [reconciler], {
-                        detached: true, stdio: "ignore",
-                        env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || "") }, cwd: vaultPath(),
-                    }).unref();
+                    spawnDetachedChild("reconcile", reconciler, {
+                        ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_SESSION_ID: String(h.session_id || ""),
+                    }, { cwd: vaultPath() });
                 }
             }
             catch { /* non-fatal */ }
@@ -85,10 +84,9 @@ async function main() {
                 const projectDir = h.cwd || process.env.CLAUDE_PROJECT_DIR;
                 if (projectDir && looksLikeCodeProject(projectDir) && isUnknownProject(projectDir)) {
                     const discoverer = fileURLToPath(new URL("./sb-discover.js", import.meta.url));
-                    spawn(process.execPath, [discoverer], {
-                        detached: true, stdio: "ignore",
-                        env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PROJECT_DIR: projectDir },
-                    }).unref();
+                    spawnDetachedChild("discover", discoverer, {
+                        ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PROJECT_DIR: projectDir,
+                    });
                     parts.push(`SuperBrain is mapping this project for the first time — a project note will appear in the vault shortly.`);
                 }
             }

--- a/dist/src/atomicWrite.js
+++ b/dist/src/atomicWrite.js
@@ -40,7 +40,9 @@ export function casWrite(file, produce, opts = {}) {
             return { ok: true, attempts: attempt };
         }
     }
-    const last = readWithChecksum(file);
-    atomicWrite(file, produce(last ? last.content : null));
-    return { ok: true, attempts: maxAttempts };
+    // Contention never settled. The old fallback blindly overwrote here, clobbering
+    // whichever concurrent writer last touched the file (and through a TOCTOU
+    // window at that). Decline instead: leave the peer's data intact and report
+    // failure so the caller can retry rather than silently lose the other write.
+    return { ok: false, attempts: maxAttempts };
 }

--- a/dist/src/bootstrap.js
+++ b/dist/src/bootstrap.js
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { pluginRoot as defaultPluginRoot } from "./paths.js";
+import { spawnDetachedChild } from "./spawnChild.js";
 // Bounded search for a compiled native addon (*.node) within a directory.
 function hasDotNode(dir) {
     let entries;
@@ -64,13 +64,8 @@ export function markBootstrapDone(root = defaultPluginRoot()) {
 export function runBootstrap(pluginRoot) {
     if (bootstrapDone(pluginRoot) && depsPresent(pluginRoot))
         return;
-    try {
-        const runner = fileURLToPath(new URL("../bin/sb-bootstrap.js", import.meta.url));
-        spawn(process.execPath, [runner], {
-            detached: true, stdio: "ignore",
-            env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PLUGIN_ROOT: pluginRoot },
-            cwd: pluginRoot,
-        }).unref();
-    }
-    catch { /* non-fatal; retried next SessionStart */ }
+    const runner = fileURLToPath(new URL("../bin/sb-bootstrap.js", import.meta.url));
+    spawnDetachedChild("bootstrap", runner, {
+        ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PLUGIN_ROOT: pluginRoot,
+    }, { cwd: pluginRoot });
 }

--- a/dist/src/claudeCli.js
+++ b/dist/src/claudeCli.js
@@ -4,8 +4,21 @@ import { distillModel } from "./model.js";
 // Windows installer ships as `claude.cmd`, so a direct execFile returns ENOENT.
 // shell: true routes through cmd.exe which DOES resolve the extension. Non-
 // Windows: shell: false keeps argument escaping simple and safe.
+const DEFAULT_TIMEOUT_MS = 180_000;
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 export function buildClaudeSpawnOptions(platform) {
-    const opts = { encoding: "utf8" };
+    // Without a timeout a wedged `claude -p` blocks execFileSync indefinitely,
+    // stranding the distill (and its lock) until the process is killed by hand.
+    // A bounded timeout makes the hang throw, which the caller's catch routes to
+    // the sentinel + lock release. maxBuffer is raised well above Node's 1MB
+    // default so a large distill payload is not itself mistaken for a failure.
+    const envTimeout = Number(process.env.SUPERBRAIN_DISTILL_TIMEOUT_MS);
+    const timeout = Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : DEFAULT_TIMEOUT_MS;
+    const opts = {
+        encoding: "utf8",
+        timeout,
+        maxBuffer: MAX_BUFFER_BYTES,
+    };
     if (platform === "win32")
         opts.shell = true;
     return opts;

--- a/dist/src/cursor.js
+++ b/dist/src/cursor.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
-import path from "node:path";
 import { cursorPath } from "./paths.js";
+import { atomicWrite } from "./atomicWrite.js";
 export function readCursor(sessionId) {
     try {
         const n = parseInt(fs.readFileSync(cursorPath(sessionId), "utf8").trim(), 10);
@@ -11,7 +11,7 @@ export function readCursor(sessionId) {
     }
 }
 export function writeCursor(sessionId, offset) {
-    const p = cursorPath(sessionId);
-    fs.mkdirSync(path.dirname(p), { recursive: true });
-    fs.writeFileSync(p, String(offset));
+    // atomic: a kill mid-write must never truncate the cursor to a value that
+    // readCursor coerces to 0 (which would reprocess the entire session).
+    atomicWrite(cursorPath(sessionId), String(offset));
 }

--- a/dist/src/dailyState.js
+++ b/dist/src/dailyState.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { dataDir } from "./paths.js";
+import { atomicWrite } from "./atomicWrite.js";
 function fileFor(date) {
     return path.join(dataDir(), "daily", `${date}.json`);
 }
@@ -13,11 +14,11 @@ export function readDay(date) {
     }
 }
 export function upsertDay(date, sessionId, entry) {
-    const f = fileFor(date);
-    fs.mkdirSync(path.dirname(f), { recursive: true });
     const cur = readDay(date);
     cur[sessionId] = entry;
-    fs.writeFileSync(f, JSON.stringify(cur));
+    // atomic: a kill mid-write must never leave truncated JSON that readDay
+    // silently swallows as {} (losing the whole day's session entries).
+    atomicWrite(fileFor(date), JSON.stringify(cur));
 }
 export function childrenOf(date, parentId) {
     if (!parentId)

--- a/dist/src/distillSweep.js
+++ b/dist/src/distillSweep.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { sessionsDir } from "./paths.js";
 import { writeFailure } from "./sentinel.js";
 import { readCursor } from "./cursor.js";
+import { atomicWrite } from "./atomicWrite.js";
 const FLAG_EXT = ".needs-distill";
 export function flagPath(sid) {
     return path.join(sessionsDir(), `${sid}${FLAG_EXT}`);
@@ -42,8 +43,10 @@ export function readAttempts(sid) {
 }
 export function bumpAttempts(sid) {
     const n = readAttempts(sid) + 1;
+    // atomic so an interrupted bump never truncates the counter to 0, which would
+    // reset the retry budget and re-open the runaway it exists to bound.
     try {
-        fs.writeFileSync(attemptsPath(sid), String(n));
+        atomicWrite(attemptsPath(sid), String(n));
     }
     catch { /* best-effort */ }
     return n;

--- a/dist/src/lockfile.js
+++ b/dist/src/lockfile.js
@@ -11,6 +11,28 @@ function readToken(dir) {
         return null;
     }
 }
+// A lock whose recorded holder is gone should be reclaimed at once rather than
+// waiting out the mtime TTL — a crashed distill otherwise wedges every acquirer
+// for 15 minutes. Returns true only when the pid is readable AND provably dead;
+// an unreadable pid or a PID-reuse ambiguity falls through to the mtime TTL.
+function holderIsDead(dir) {
+    let pid;
+    try {
+        pid = Number(fs.readFileSync(path.join(dir, "pid"), "utf8").trim());
+    }
+    catch {
+        return false;
+    }
+    if (!Number.isInteger(pid) || pid <= 0)
+        return false;
+    try {
+        process.kill(pid, 0);
+        return false; // signal delivered (or EPERM) -> process exists
+    }
+    catch (e) {
+        return e.code === "ESRCH";
+    }
+}
 export function acquireLock(name, opts = {}) {
     const dir = lockDir(name);
     fs.mkdirSync(path.dirname(dir), { recursive: true });
@@ -26,7 +48,7 @@ export function acquireLock(name, opts = {}) {
         const maxAgeMs = opts.maxAgeMs ?? 15 * 60 * 1000;
         try {
             const age = Date.now() - fs.statSync(dir).mtimeMs;
-            if (age > maxAgeMs) {
+            if (holderIsDead(dir) || age > maxAgeMs) {
                 forceRelease(name);
                 fs.mkdirSync(dir);
                 fs.writeFileSync(path.join(dir, "pid"), String(process.pid));

--- a/dist/src/searchIndex.js
+++ b/dist/src/searchIndex.js
@@ -72,6 +72,11 @@ export function openIndex() {
     const db = new Database(dbPath);
     sqliteVec.load(db);
     db.pragma("journal_mode = WAL");
+    // distill and reconcile hold different locks, so both can write index.db at
+    // once. WAL + an explicit busy_timeout makes the second writer wait for the
+    // first instead of throwing SQLITE_BUSY. Pinned rather than relying on
+    // better-sqlite3's 5000ms default.
+    db.pragma("busy_timeout = 10000");
     ensureVecTable(db);
     // Migrate: add columns if they don't exist (idempotent)
     const cols = db.pragma("table_info(notes)").map((c) => c.name);

--- a/dist/src/spawnChild.js
+++ b/dist/src/spawnChild.js
@@ -1,0 +1,40 @@
+import { spawn } from "node:child_process";
+import { writeFailure } from "./sentinel.js";
+// The single detached-spawn primitive. Every fire-and-forget child in
+// SuperBrain (distill, reconcile, discover, bootstrap, backfill) goes through
+// here so the spawn mechanics and — critically — the failure path are
+// identical: a spawn that throws synchronously or emits an async 'error' must
+// always reach the sentinel, never vanish silently. Singleton/debounce gating
+// stays at the call sites because it is genuinely site-specific (a lock for
+// distill, a time-stamp for reconcile, note-existence for discover, a deps
+// check for bootstrap) and a one-size gate here would be wrong for most of them.
+export function spawnDetachedCommand(name, command, args, env, opts = {}) {
+    const handleError = (e) => {
+        writeFailure(`${name} spawn failed: ${e.message}`);
+        try {
+            opts.onError?.(e);
+        }
+        catch { /* onError is best-effort */ }
+    };
+    try {
+        const child = spawn(command, args, {
+            detached: true,
+            stdio: "ignore",
+            env,
+            cwd: opts.cwd,
+        });
+        child.on("error", handleError);
+        child.unref();
+        return child;
+    }
+    catch (e) {
+        handleError(e instanceof Error ? e : new Error(String(e)));
+        return null;
+    }
+}
+// Convenience wrapper for the common case: a detached Node child running one
+// script (the four node-spawned daemons). Backfill, which shells out to
+// `npx tsx`, calls spawnDetachedCommand directly.
+export function spawnDetachedChild(name, scriptPath, env, opts = {}) {
+    return spawnDetachedCommand(name, process.execPath, [scriptPath], env, opts);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superbrain",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superbrain",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbrain",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Automatic Claude Code -> Obsidian second brain: zero-config session capture, hybrid search, autonomous recall, daily/lessons/preferences.",
   "type": "module",
   "license": "MIT",

--- a/src/atomicWrite.ts
+++ b/src/atomicWrite.ts
@@ -39,7 +39,9 @@ export function casWrite(
       return { ok: true, attempts: attempt };
     }
   }
-  const last = readWithChecksum(file);
-  atomicWrite(file, produce(last ? last.content : null));
-  return { ok: true, attempts: maxAttempts };
+  // Contention never settled. The old fallback blindly overwrote here, clobbering
+  // whichever concurrent writer last touched the file (and through a TOCTOU
+  // window at that). Decline instead: leave the peer's data intact and report
+  // failure so the caller can retry rather than silently lose the other write.
+  return { ok: false, attempts: maxAttempts };
 }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { pluginRoot as defaultPluginRoot } from "./paths.js";
+import { spawnDetachedChild } from "./spawnChild.js";
 
 // Bounded search for a compiled native addon (*.node) within a directory.
 function hasDotNode(dir: string): boolean {
@@ -55,12 +55,8 @@ export function markBootstrapDone(root: string = defaultPluginRoot()): void {
 // under a lock and writes bootstrap-done / the sentinel itself.
 export function runBootstrap(pluginRoot: string): void {
   if (bootstrapDone(pluginRoot) && depsPresent(pluginRoot)) return;
-  try {
-    const runner = fileURLToPath(new URL("../bin/sb-bootstrap.js", import.meta.url));
-    spawn(process.execPath, [runner], {
-      detached: true, stdio: "ignore",
-      env: { ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PLUGIN_ROOT: pluginRoot },
-      cwd: pluginRoot,
-    }).unref();
-  } catch { /* non-fatal; retried next SessionStart */ }
+  const runner = fileURLToPath(new URL("../bin/sb-bootstrap.js", import.meta.url));
+  spawnDetachedChild("bootstrap", runner, {
+    ...process.env, SUPERBRAIN_CHILD: "1", SUPERBRAIN_PLUGIN_ROOT: pluginRoot,
+  }, { cwd: pluginRoot });
 }

--- a/src/claudeCli.ts
+++ b/src/claudeCli.ts
@@ -5,8 +5,22 @@ import { distillModel } from "./model.js";
 // Windows installer ships as `claude.cmd`, so a direct execFile returns ENOENT.
 // shell: true routes through cmd.exe which DOES resolve the extension. Non-
 // Windows: shell: false keeps argument escaping simple and safe.
+const DEFAULT_TIMEOUT_MS = 180_000;
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
 export function buildClaudeSpawnOptions(platform: NodeJS.Platform): ExecFileSyncOptionsWithStringEncoding {
-  const opts: ExecFileSyncOptionsWithStringEncoding = { encoding: "utf8" };
+  // Without a timeout a wedged `claude -p` blocks execFileSync indefinitely,
+  // stranding the distill (and its lock) until the process is killed by hand.
+  // A bounded timeout makes the hang throw, which the caller's catch routes to
+  // the sentinel + lock release. maxBuffer is raised well above Node's 1MB
+  // default so a large distill payload is not itself mistaken for a failure.
+  const envTimeout = Number(process.env.SUPERBRAIN_DISTILL_TIMEOUT_MS);
+  const timeout = Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : DEFAULT_TIMEOUT_MS;
+  const opts: ExecFileSyncOptionsWithStringEncoding = {
+    encoding: "utf8",
+    timeout,
+    maxBuffer: MAX_BUFFER_BYTES,
+  };
   if (platform === "win32") opts.shell = true;
   return opts;
 }

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
-import path from "node:path";
 import { cursorPath } from "./paths.js";
+import { atomicWrite } from "./atomicWrite.js";
 
 export function readCursor(sessionId: string): number {
   try {
@@ -9,7 +9,7 @@ export function readCursor(sessionId: string): number {
   } catch { return 0; }
 }
 export function writeCursor(sessionId: string, offset: number): void {
-  const p = cursorPath(sessionId);
-  fs.mkdirSync(path.dirname(p), { recursive: true });
-  fs.writeFileSync(p, String(offset));
+  // atomic: a kill mid-write must never truncate the cursor to a value that
+  // readCursor coerces to 0 (which would reprocess the entire session).
+  atomicWrite(cursorPath(sessionId), String(offset));
 }

--- a/src/dailyState.ts
+++ b/src/dailyState.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { dataDir } from "./paths.js";
+import { atomicWrite } from "./atomicWrite.js";
 
 export interface DaySessionEntry {
   digestLine: string;
@@ -23,11 +24,11 @@ export function readDay(date: string): DayState {
 }
 
 export function upsertDay(date: string, sessionId: string, entry: DaySessionEntry): void {
-  const f = fileFor(date);
-  fs.mkdirSync(path.dirname(f), { recursive: true });
   const cur = readDay(date);
   cur[sessionId] = entry;
-  fs.writeFileSync(f, JSON.stringify(cur));
+  // atomic: a kill mid-write must never leave truncated JSON that readDay
+  // silently swallows as {} (losing the whole day's session entries).
+  atomicWrite(fileFor(date), JSON.stringify(cur));
 }
 
 export interface ChildEntry { sessionId: string; entry: DaySessionEntry; }

--- a/src/distillSweep.ts
+++ b/src/distillSweep.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { sessionsDir } from "./paths.js";
 import { writeFailure } from "./sentinel.js";
 import { readCursor } from "./cursor.js";
+import { atomicWrite } from "./atomicWrite.js";
 
 const FLAG_EXT = ".needs-distill";
 
@@ -42,7 +43,9 @@ export function readAttempts(sid: string): number {
 
 export function bumpAttempts(sid: string): number {
   const n = readAttempts(sid) + 1;
-  try { fs.writeFileSync(attemptsPath(sid), String(n)); } catch { /* best-effort */ }
+  // atomic so an interrupted bump never truncates the counter to 0, which would
+  // reset the retry budget and re-open the runaway it exists to bound.
+  try { atomicWrite(attemptsPath(sid), String(n)); } catch { /* best-effort */ }
   return n;
 }
 

--- a/src/lockfile.ts
+++ b/src/lockfile.ts
@@ -9,6 +9,24 @@ function readToken(dir: string): string | null {
   try { return fs.readFileSync(path.join(dir, "token"), "utf8"); } catch { return null; }
 }
 
+// A lock whose recorded holder is gone should be reclaimed at once rather than
+// waiting out the mtime TTL — a crashed distill otherwise wedges every acquirer
+// for 15 minutes. Returns true only when the pid is readable AND provably dead;
+// an unreadable pid or a PID-reuse ambiguity falls through to the mtime TTL.
+function holderIsDead(dir: string): boolean {
+  let pid: number;
+  try {
+    pid = Number(fs.readFileSync(path.join(dir, "pid"), "utf8").trim());
+  } catch { return false; }
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return false; // signal delivered (or EPERM) -> process exists
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "ESRCH";
+  }
+}
+
 export function acquireLock(name: string, opts: { maxAgeMs?: number } = {}): boolean {
   const dir = lockDir(name);
   fs.mkdirSync(path.dirname(dir), { recursive: true });
@@ -23,7 +41,7 @@ export function acquireLock(name: string, opts: { maxAgeMs?: number } = {}): boo
     const maxAgeMs = opts.maxAgeMs ?? 15 * 60 * 1000;
     try {
       const age = Date.now() - fs.statSync(dir).mtimeMs;
-      if (age > maxAgeMs) {
+      if (holderIsDead(dir) || age > maxAgeMs) {
         forceRelease(name);
         fs.mkdirSync(dir);
         fs.writeFileSync(path.join(dir, "pid"), String(process.pid));

--- a/src/searchIndex.ts
+++ b/src/searchIndex.ts
@@ -107,6 +107,11 @@ export function openIndex(): Index {
   const db = new Database(dbPath);
   sqliteVec.load(db);
   db.pragma("journal_mode = WAL");
+  // distill and reconcile hold different locks, so both can write index.db at
+  // once. WAL + an explicit busy_timeout makes the second writer wait for the
+  // first instead of throwing SQLITE_BUSY. Pinned rather than relying on
+  // better-sqlite3's 5000ms default.
+  db.pragma("busy_timeout = 10000");
 
   ensureVecTable(db);
 

--- a/src/spawnChild.ts
+++ b/src/spawnChild.ts
@@ -1,0 +1,54 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { writeFailure } from "./sentinel.js";
+
+export interface SpawnDetachedOpts {
+  cwd?: string;
+  onError?: (e: Error) => void;
+}
+
+// The single detached-spawn primitive. Every fire-and-forget child in
+// SuperBrain (distill, reconcile, discover, bootstrap, backfill) goes through
+// here so the spawn mechanics and — critically — the failure path are
+// identical: a spawn that throws synchronously or emits an async 'error' must
+// always reach the sentinel, never vanish silently. Singleton/debounce gating
+// stays at the call sites because it is genuinely site-specific (a lock for
+// distill, a time-stamp for reconcile, note-existence for discover, a deps
+// check for bootstrap) and a one-size gate here would be wrong for most of them.
+export function spawnDetachedCommand(
+  name: string,
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  opts: SpawnDetachedOpts = {},
+): ChildProcess | null {
+  const handleError = (e: Error) => {
+    writeFailure(`${name} spawn failed: ${e.message}`);
+    try { opts.onError?.(e); } catch { /* onError is best-effort */ }
+  };
+  try {
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: "ignore",
+      env,
+      cwd: opts.cwd,
+    });
+    child.on("error", handleError);
+    child.unref();
+    return child;
+  } catch (e: any) {
+    handleError(e instanceof Error ? e : new Error(String(e)));
+    return null;
+  }
+}
+
+// Convenience wrapper for the common case: a detached Node child running one
+// script (the four node-spawned daemons). Backfill, which shells out to
+// `npx tsx`, calls spawnDetachedCommand directly.
+export function spawnDetachedChild(
+  name: string,
+  scriptPath: string,
+  env: NodeJS.ProcessEnv,
+  opts: SpawnDetachedOpts = {},
+): ChildProcess | null {
+  return spawnDetachedCommand(name, process.execPath, [scriptPath], env, opts);
+}

--- a/tests/casWrite.test.ts
+++ b/tests/casWrite.test.ts
@@ -36,4 +36,21 @@ describe("casWrite", () => {
     expect(r.ok).toBe(true);
     expect(fs.readFileSync(FILE, "utf8")).toBe("ONLY\n");
   });
+
+  it("refuses to clobber under unrelenting contention; reports ok:false", () => {
+    fs.writeFileSync(FILE, "INIT\n");
+    let n = 0;
+    // Every attempt observes a fresh external write, so the CAS never stabilises.
+    // The old blind fallback overwrote the peer's data after maxAttempts; it must
+    // now decline to write and report failure instead.
+    const r = casWrite(FILE, () => {
+      fs.writeFileSync(FILE, `EXTERNAL-${++n}\n`);
+      return "MINE\n";
+    }, { maxAttempts: 3 });
+    expect(r.ok).toBe(false);
+    expect(r.attempts).toBe(3);
+    const final = fs.readFileSync(FILE, "utf8");
+    expect(final).toMatch(/^EXTERNAL-/);
+    expect(final).not.toContain("MINE");
+  });
 });

--- a/tests/claudeCli.test.ts
+++ b/tests/claudeCli.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
 import { buildClaudeSpawnOptions } from "../src/claudeCli.js";
 
 describe("claudeCli buildClaudeSpawnOptions", () => {
@@ -17,5 +18,45 @@ describe("claudeCli buildClaudeSpawnOptions", () => {
     expect(buildClaudeSpawnOptions("darwin").encoding).toBe("utf8");
     expect(buildClaudeSpawnOptions("win32").encoding).toBe("utf8");
     expect(buildClaudeSpawnOptions("linux").encoding).toBe("utf8");
+  });
+  it("sets a finite positive timeout so a hung claude -p cannot wedge forever", () => {
+    const opts = buildClaudeSpawnOptions("darwin");
+    expect(typeof opts.timeout).toBe("number");
+    expect(opts.timeout!).toBeGreaterThan(0);
+    expect(Number.isFinite(opts.timeout!)).toBe(true);
+  });
+  it("raises maxBuffer above the 1MB default for large distill output", () => {
+    const opts = buildClaudeSpawnOptions("darwin");
+    expect(typeof opts.maxBuffer).toBe("number");
+    expect(opts.maxBuffer!).toBeGreaterThan(1024 * 1024);
+  });
+  it("honours SUPERBRAIN_DISTILL_TIMEOUT_MS override", () => {
+    const prev = process.env.SUPERBRAIN_DISTILL_TIMEOUT_MS;
+    process.env.SUPERBRAIN_DISTILL_TIMEOUT_MS = "1234";
+    try {
+      expect(buildClaudeSpawnOptions("darwin").timeout).toBe(1234);
+    } finally {
+      if (prev === undefined) delete process.env.SUPERBRAIN_DISTILL_TIMEOUT_MS;
+      else process.env.SUPERBRAIN_DISTILL_TIMEOUT_MS = prev;
+    }
+  });
+});
+
+// Real-subprocess proof that the timeout mechanism buildClaudeSpawnOptions
+// relies on actually bounds a hang: execFileSync against a busy loop must throw
+// promptly rather than block forever.
+describe("execFileSync timeout bounds a hung child", () => {
+  it("kills a busy-loop child once the timeout elapses", () => {
+    const opts = { ...buildClaudeSpawnOptions("darwin"), timeout: 200 };
+    const start = Date.now();
+    let threw = false;
+    try {
+      execFileSync(process.execPath, ["-e", "while(true){}"], opts);
+    } catch (e: any) {
+      threw = true;
+      expect(e.killed === true || e.code === "ETIMEDOUT" || e.signal != null).toBe(true);
+    }
+    expect(threw).toBe(true);
+    expect(Date.now() - start).toBeLessThan(5000);
   });
 });

--- a/tests/cursor.test.ts
+++ b/tests/cursor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -25,5 +25,14 @@ describe("cursor", () => {
     writeCursor("s", 10);
     fs.writeFileSync(path.join(TMP, "sessions/s.cursor"), "garbage");
     expect(readCursor("s")).toBe(0);
+  });
+  it("preserves the prior cursor when a write is interrupted mid-flight", () => {
+    writeCursor("s", 4096);
+    // A truncated cursor reads back as 0, which reprocesses the whole session;
+    // an atomic write keeps the old offset intact when the new write fails.
+    const spy = vi.spyOn(fs, "writeSync").mockImplementationOnce(() => { throw new Error("ENOSPC"); });
+    expect(() => writeCursor("s", 8192)).toThrow();
+    spy.mockRestore();
+    expect(readCursor("s")).toBe(4096);
   });
 });

--- a/tests/dailyState.test.ts
+++ b/tests/dailyState.test.ts
@@ -1,4 +1,4 @@
-import { it, expect, beforeEach, afterEach } from "vitest";
+import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -36,4 +36,23 @@ it("re-upserting the same session overwrites (no duplication)", () => {
 
 it("readDay returns {} for an unknown date", () => {
   expect(readDay("2099-01-01")).toEqual({});
+});
+
+it("preserves the prior day file when a write is interrupted mid-flight", () => {
+  upsertDay("2026-05-19", "S1", entry());
+  const f = path.join(TMP, "daily", "2026-05-19.json");
+  const before = fs.readFileSync(f, "utf8");
+
+  // atomicWrite stages content into a temp file (fs.writeSync) then renames; a
+  // crash there must leave the original intact, never a truncated JSON that
+  // readDay would silently swallow as {}. A plain in-place writeFileSync cannot
+  // offer this — the target is truncated before the failing write.
+  const spy = vi.spyOn(fs, "writeSync").mockImplementationOnce(() => { throw new Error("ENOSPC"); });
+  expect(() => upsertDay("2026-05-19", "S2", entry({ digestLine: "s2" }))).toThrow();
+  spy.mockRestore();
+
+  const after = fs.readFileSync(f, "utf8");
+  expect(after).toBe(before);
+  expect(() => JSON.parse(after)).not.toThrow();
+  expect(Object.keys(readDay("2026-05-19"))).toEqual(["S1"]);
 });

--- a/tests/distillSweep.test.ts
+++ b/tests/distillSweep.test.ts
@@ -1,4 +1,4 @@
-import { it, expect, beforeEach, afterEach } from "vitest";
+import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -103,7 +103,20 @@ it("sweep clears the flag for an empty-delta flagged session", () => {
   expect(fs.existsSync(path.join(TMP_DATA, "sessions/B.needs-distill"))).toBe(false);
 });
 
-import { sweepPendingDistills, flagPath } from "../src/distillSweep.js";
+import { sweepPendingDistills, flagPath, bumpAttempts, readAttempts } from "../src/distillSweep.js";
+
+it("an interrupted bumpAttempts preserves the prior count, never resetting the retry budget", () => {
+  process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;
+  expect(bumpAttempts("S")).toBe(1);
+  expect(bumpAttempts("S")).toBe(2);
+  // The write is best-effort (swallowed), but atomicWrite must leave the prior
+  // count intact rather than truncate it to a 0 that re-opens the runaway.
+  const spy = vi.spyOn(fs, "writeSync").mockImplementationOnce(() => { throw new Error("ENOSPC"); });
+  bumpAttempts("S");
+  spy.mockRestore();
+  expect(readAttempts("S")).toBe(2);
+  delete process.env.SUPERBRAIN_DATA_DIR;
+});
 
 it("a throwing flagged session is isolated; host distill and siblings unaffected", async () => {
   process.env.SUPERBRAIN_DATA_DIR = TMP_DATA;

--- a/tests/helpers/subprocess.ts
+++ b/tests/helpers/subprocess.ts
@@ -1,0 +1,58 @@
+import { spawnSync, spawn, type ChildProcess } from "node:child_process";
+
+// spawnSync blocks until the child exits and reaps it, so the returned pid
+// belongs to a process that is no longer alive. PID reuse inside a single test
+// window is vanishingly unlikely, which makes this a deterministic dead pid.
+export function deadPid(): number {
+  const r = spawnSync(process.execPath, ["-e", "0"]);
+  if (typeof r.pid !== "number") throw new Error("spawnSync returned no pid");
+  return r.pid;
+}
+
+// Spawn a real detached Node child that runs `code` (an inline -e script) and
+// keeps running until the test kills it. The caller is responsible for killing
+// the returned child; it is detached so a parent crash never orphans the test.
+export function spawnChild(
+  code: string,
+  env: NodeJS.ProcessEnv = process.env,
+): ChildProcess {
+  return spawn(process.execPath, ["-e", code], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+// Resolve once the child has printed `marker` on stdout, or reject on timeout.
+// Lets a test wait for "the child has acquired the lock" before killing it.
+export function waitForMarker(
+  child: ChildProcess,
+  marker: string,
+  timeoutMs = 5000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const timer = setTimeout(() => {
+      reject(new Error(`marker "${marker}" not seen within ${timeoutMs}ms; saw: ${buf}`));
+    }, timeoutMs);
+    child.stdout?.on("data", (d) => {
+      buf += String(d);
+      if (buf.includes(marker)) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.on("exit", () => {
+      clearTimeout(timer);
+      reject(new Error(`child exited before printing "${marker}"; saw: ${buf}`));
+    });
+  });
+}
+
+// Wait for a child to exit and resolve with its exit code / signal.
+export function waitForExit(
+  child: ChildProcess,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve) => {
+    child.on("exit", (code, signal) => resolve({ code, signal }));
+  });
+}

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -288,7 +288,9 @@ describe("inject lock serialization", () => {
     process.env.SUPERBRAIN_EMBED_STUB = "1";
 
     fs.mkdirSync(path.join(dataDir, "locks/distill.lock"), { recursive: true });
-    fs.writeFileSync(path.join(dataDir, "locks/distill.lock/pid"), "99999");
+    // A live holder pid: the lock primitive reclaims locks held by a dead pid,
+    // so a genuine "held by another process" must point at a process that exists.
+    fs.writeFileSync(path.join(dataDir, "locks/distill.lock/pid"), String(process.pid));
 
     process.env.SUPERBRAIN_INJECT_LOCK_WAIT_MS = "300";
 

--- a/tests/lockfile.test.ts
+++ b/tests/lockfile.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { acquireLock, releaseLock } from "../src/lockfile";
+import { deadPid } from "./helpers/subprocess";
 
 let TMP: string;
 
@@ -36,5 +37,25 @@ describe("lockfile", () => {
     const token = fs.readFileSync(path.join(TMP, "locks", "distill.lock", "token"), "utf8");
     releaseLock("distill", token);
     expect(acquireLock("distill")).toBe(true);
+  });
+  it("reclaims a fresh lock whose holder pid is dead, without waiting for the TTL", () => {
+    expect(acquireLock("distill")).toBe(true);
+    const pidFile = path.join(TMP, "locks", "distill.lock", "pid");
+    fs.writeFileSync(pidFile, String(deadPid()));
+    // age is ~0, far under the 15-min mtime TTL; only liveness can free it
+    expect(acquireLock("distill")).toBe(true);
+  });
+  it("does NOT reclaim a fresh lock whose holder pid is alive", () => {
+    expect(acquireLock("distill")).toBe(true);
+    const pidFile = path.join(TMP, "locks", "distill.lock", "pid");
+    fs.writeFileSync(pidFile, String(process.pid)); // this process is alive
+    expect(acquireLock("distill")).toBe(false);
+  });
+  it("falls back to the mtime TTL when the pid is unreadable", () => {
+    expect(acquireLock("distill")).toBe(true);
+    const pidFile = path.join(TMP, "locks", "distill.lock", "pid");
+    fs.rmSync(pidFile, { force: true });
+    expect(acquireLock("distill")).toBe(false); // fresh, no pid -> hold
+    expect(acquireLock("distill", { maxAgeMs: -1 })).toBe(true); // stale -> break
   });
 });

--- a/tests/reconcileRunaway.test.ts
+++ b/tests/reconcileRunaway.test.ts
@@ -104,7 +104,9 @@ it("a second sb-reconcile is a no-op while the first holds the reconcile lock", 
 
   const lockDir = path.join(TMP_DATA, "locks", "reconcile.lock");
   fs.mkdirSync(lockDir, { recursive: true });
-  fs.writeFileSync(path.join(lockDir, "pid"), "99999");
+  // A live holder pid: the lock primitive reclaims locks held by a dead pid,
+  // so simulating "the first still holds it" requires a process that exists.
+  fs.writeFileSync(path.join(lockDir, "pid"), String(process.pid));
   fs.writeFileSync(path.join(lockDir, "token"), "held-elsewhere");
 
   execFileSync("npx", ["tsx", "bin/sb-reconcile.ts"], { env, encoding: "utf8" });

--- a/tests/searchIndex.test.ts
+++ b/tests/searchIndex.test.ts
@@ -18,6 +18,14 @@ afterEach(() => {
 const vec = (n: number) => Float32Array.from(Array(256).fill(n));
 
 describe("searchIndex", () => {
+  it("opens with WAL and a non-zero busy_timeout so cross-process writers wait, not throw", () => {
+    const ix = openIndex();
+    expect(String(ix.db.pragma("journal_mode", { simple: true })).toLowerCase()).toBe("wal");
+    // Pinned explicitly rather than relying on better-sqlite3's 5000ms default,
+    // so a library default change can't silently shorten the cross-writer wait.
+    expect(ix.db.pragma("busy_timeout", { simple: true })).toBeGreaterThanOrEqual(10000);
+    ix.db.close();
+  });
   it("upsert → bm25 + vectorKNN; re-upsert replaces; delete removes", () => {
     const ix = openIndex();
     ix.upsertNote("projects/x.md", 1, "h1", [

--- a/tests/spawnChild.test.ts
+++ b/tests/spawnChild.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnDetachedChild, spawnDetachedCommand } from "../src/spawnChild";
+
+let TMP: string;
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "sb-spawn-"));
+  process.env.SUPERBRAIN_DATA_DIR = TMP;
+});
+
+afterEach(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+async function waitFor(pred: () => boolean, ms = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("waitFor timed out");
+}
+
+describe("spawnDetachedChild", () => {
+  it("runs a detached node script to completion and returns the child", async () => {
+    const marker = path.join(TMP, "marker");
+    const script = path.join(TMP, "writer.js");
+    fs.writeFileSync(script, `require("fs").writeFileSync(${JSON.stringify(marker)}, "ok");`);
+
+    const child = spawnDetachedChild("test", script, process.env);
+    expect(child).not.toBeNull();
+    expect(typeof child!.pid).toBe("number");
+
+    await waitFor(() => fs.existsSync(marker));
+    expect(fs.readFileSync(marker, "utf8")).toBe("ok");
+  });
+
+  it("routes a spawn failure to the sentinel and invokes onError", async () => {
+    const { readAndClearFailure } = await import("../src/sentinel.js");
+    readAndClearFailure(); // clear any residue
+
+    let onErrorCalled = false;
+    // A non-existent cwd makes the spawn fail (sync throw or async 'error');
+    // either path must reach the sentinel and the onError hook.
+    spawnDetachedChild("badcwd", path.join(TMP, "noscript.js"), process.env, {
+      cwd: path.join(TMP, "does-not-exist"),
+      onError: () => { onErrorCalled = true; },
+    });
+
+    await waitFor(() => onErrorCalled);
+    const msg = readAndClearFailure();
+    expect(msg).toMatch(/badcwd spawn failed/);
+  });
+
+  it("spawnDetachedCommand runs an arbitrary command (not just node)", async () => {
+    const marker = path.join(TMP, "cmd-marker");
+    const script = path.join(TMP, "cmd.js");
+    fs.writeFileSync(script, `require("fs").writeFileSync(${JSON.stringify(marker)}, "cmd");`);
+    const child = spawnDetachedCommand("cmdtest", process.execPath, [script], process.env);
+    expect(child).not.toBeNull();
+    await waitFor(() => fs.existsSync(marker));
+    expect(fs.readFileSync(marker, "utf8")).toBe("cmd");
+  });
+
+  it("passes the supplied env through to the child", async () => {
+    const marker = path.join(TMP, "env-marker");
+    const script = path.join(TMP, "envwriter.js");
+    fs.writeFileSync(
+      script,
+      `require("fs").writeFileSync(${JSON.stringify(marker)}, process.env.SB_TEST_FLAG || "");`,
+    );
+
+    const child = spawnDetachedChild("envtest", script, { ...process.env, SB_TEST_FLAG: "xyz" });
+    expect(child).not.toBeNull();
+    await waitFor(() => fs.existsSync(marker));
+    expect(fs.readFileSync(marker, "utf8")).toBe("xyz");
+  });
+});


### PR DESCRIPTION
## Summary

Stabilisation remediation from the 2026-06-12 audit, executed test-first. Retires the recurring lock-wedge / hang / lifecycle-spawn class plus bounded data-path debt, in four phases.

**Phase 1 — the two missing primitives**
- `lockfile`: `acquireLock` reclaims a lock whose recorded holder pid is provably dead (`process.kill(pid,0)` → `ESRCH`) instead of waiting out the 15-min mtime TTL. The TTL stays as the PID-reuse backstop. **This is the fix for the distill.lock wedge that froze all memory writes.**
- `claudeCli`: `buildClaudeSpawnOptions` sets a 180s timeout (env-overridable via `SUPERBRAIN_DISTILL_TIMEOUT_MS`) + 64MB maxBuffer, so a hung `claude -p` throws instead of blocking forever. The existing distill catch routes the throw to the sentinel and releases the lock.

**Phase 2 — one safe-spawn primitive**
- New `src/spawnChild.ts` (`spawnDetachedCommand` + `spawnDetachedChild`). All five detached spawn sites (distill, reconcile, discover, bootstrap, backfill) route through it, so a spawn failure (sync throw or async `error`) always reaches the sentinel. Previously only distill did; the other four swallowed spawn failures silently.

**Phase 3 — data-path durability**
- `index.db`: explicit `busy_timeout = 10000` (pins intent over better-sqlite3's 5000ms default).
- `writeCursor` / `upsertDay` / `bumpAttempts` route through `atomicWrite` (temp + fsync + rename) — a kill mid-write no longer truncates them into silent data loss.
- `casWrite`: dropped the blind-overwrite fallback that clobbered a concurrent peer through a TOCTOU window; it now declines (`ok:false`) and preserves the peer's data.

**Phase 0 — harness + CI**
- Real-subprocess test helper (`tests/helpers/subprocess.ts`).
- Separate `compat` CI job adds {ubuntu, macOS} × {Node 20, 22} coverage.

### Deliberate deviations from the audit plan (flagged for review)
1. **Phase 2** — the helper does NOT bake in a uniform singleton/debounce. Three of the five gates aren't time-based (the distill lock is itself the singleton; discover gates on note-existence; bootstrap on a deps check), so a one-size debounce would be wrong — it would silently drop captures. Gating stays at the call sites; the helper owns only mechanics + error routing.
2. **Phase 3 #4** — did NOT add a shared app-level index lock. SQLite's WAL + busy_timeout already guarantees integrity under concurrent writers; an extra cross-entrypoint lock is deadlock risk for no gain.
3. **Phase 0 CI** — added a separate `compat` job rather than making the existing `typecheck • build • test` job a matrix, which would rename its status checks and stall `main` branch protection.

### Test Plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run build` — clean
- [x] `npm test` — 927 pass / 0 fail (16 new tests across lockfile, claudeCli, spawnChild, searchIndex, cursor, dailyState, distillSweep, casWrite)
- [x] `git diff --exit-code dist` — clean (`release:check`)
- [ ] CI green across the new compat matrix (ubuntu/macOS × Node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
